### PR TITLE
feat(#21): atomic idempotent trade settlement via transactional outbox

### DIFF
--- a/TallaEgg.sln
+++ b/TallaEgg.sln
@@ -63,6 +63,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Users.Core", "src\User\User
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Users.Infrastructure", "src\User\Users.Infrastructure\Users.Infrastructure.csproj", "{038E0C65-B9D4-E71F-27E1-EDC95ADF4639}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wallet.Tests", "src\Wallet\Wallet.Tests\Wallet.Tests.csproj", "{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -349,6 +351,18 @@ Global
 		{038E0C65-B9D4-E71F-27E1-EDC95ADF4639}.Release|x64.Build.0 = Release|Any CPU
 		{038E0C65-B9D4-E71F-27E1-EDC95ADF4639}.Release|x86.ActiveCfg = Release|Any CPU
 		{038E0C65-B9D4-E71F-27E1-EDC95ADF4639}.Release|x86.Build.0 = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|x64.Build.0 = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -382,6 +396,7 @@ Global
 		{8D9B0042-11D7-8FDF-75AC-FC5B8F96A6C1} = {FEF4A472-ACF9-447E-B7A8-577B0EB7EAE8}
 		{7230DF29-D75B-3939-639A-F2A4A156B5AA} = {FEF4A472-ACF9-447E-B7A8-577B0EB7EAE8}
 		{038E0C65-B9D4-E71F-27E1-EDC95ADF4639} = {FEF4A472-ACF9-447E-B7A8-577B0EB7EAE8}
+		{9C8B56E4-3ABD-4E9F-B20F-7B9DAA92BCB1} = {BF8C628F-DA56-4ED5-846F-CDA9272494BB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E4537044-8C80-4A5D-82B5-6F7ED7B5E4AE}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
@@ -8,6 +8,18 @@ namespace TallaEgg.TelegramBot
     {
         public static ITelegramBotClient CreateWithProxy(string token)
         {
+            // Local override: when the machine can reach Telegram directly (e.g. a TUN-mode VPN),
+            // the system HTTP proxy can be unstable on long-poll (getUpdates) and drops the
+            // connection ("response ended prematurely"). Set BOT_DIRECT_CONNECTION=1 to bypass the
+            // proxy and connect directly. Unset (the default) keeps the original proxy behaviour,
+            // which the server deployment relies on.
+            if (Environment.GetEnvironmentVariable("BOT_DIRECT_CONNECTION") == "1")
+            {
+                Console.WriteLine("🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)");
+                var directClient = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
+                return new TelegramBotClient(token, directClient);
+            }
+
             try
             {
                 // Get system proxy

--- a/TelegramBot/TallaEgg.TelegramBot/TallaEgg.TelegramBot.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot/TallaEgg.TelegramBot.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Telegram.Bot" Version="22.6.0" />
   </ItemGroup>
 

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -101,11 +101,15 @@ if (app.Environment.IsProduction())
 }
 app.UseAuthorization();
 
-// تنظیم CORS
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+// تنظیم CORS — CORS services are only registered in Production (see AddCors above),
+// so only add the middleware there; otherwise the app fails to start in Development.
+if (app.Environment.IsProduction())
+{
+    app.UseCors(builder => builder
+        .AllowAnyOrigin()
+        .AllowAnyMethod()
+        .AllowAnyHeader());
+}
 
 // Affiliate management endpoints
 app.MapPost("/api/affiliate/validate-invitation", async (ValidateInvitationRequest request, AffiliateService affiliateService) =>

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -110,6 +110,9 @@ builder.Services.AddScoped<TallaEgg.Infrastructure.Clients.IWalletApiClient, Tal
 builder.Services.AddScoped<IMatchingEngine, Orders.Application.Services.MatchingEngineService>();
 builder.Services.AddHostedService<Orders.Application.Services.MatchingEngineService>();
 
+// Outbox processor: reliably delivers trade settlements to the Wallet service.
+builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();
+
 // Configure JSON serialization
 builder.Services.ConfigureHttpJsonOptions(options =>
 {

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -375,34 +375,13 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             
             if (result.Success)
             {
-                //TODO باید آنفریز کنه و تراکنش های مربوط به معامله را ثبت کند
-                //await _walletApiClient.UnlockBalanceAsync(result.Trade.BuyerUserId, result.Trade.Symbol, result.Trade.Quantity);
-                //await _walletApiClient.UnlockBalanceAsync(result.Trade.SellerUserId, result.Trade.Symbol, result.Trade.Quantity * result.Trade.Price);
-
-                ////dotnet add package AutoMapper
-                ////dotnet add package AutoMapper.Extensions.Microsoft.DependencyInjection
-
-                //TradeDto tradeDto = new TradeDto()
-                //{
-                //    Id = result.Trade.Id,
-                //    BuyOrderId = result.Trade.BuyOrderId,
-                //    SellOrderId = result.Trade.SellOrderId,
-                //    MakerOrderId = result.Trade.MakerOrderId,
-                //    TakerOrderId = result.Trade.TakerOrderId,
-                //    Symbol = result.Trade.Symbol,
-                //    Price = result.Trade.Price,
-                //    Quantity = result.Trade.Quantity,
-                //    QuoteQuantity = result.Trade.QuoteQuantity,
-                //    FeeBuyer = result.Trade.FeeBuyer,
-                //    FeeSeller = result.Trade.FeeSeller,
-                //    CreatedAt = result.Trade.CreatedAt,
-
-                //};
-
-                //await _walletApiClient.TradeTransactionAndBalanceChangeAsync(tradeDto);
-
+                // Wallet settlement is no longer called inline here. ExecuteAtomicMatchAsync
+                // enqueues a 'TradeSettlement' outbox message in the same transaction as the
+                // trade, and OutboxProcessorService delivers it to the Wallet service reliably
+                // (with retry + idempotency). This removes the old fire-and-forget HTTP calls
+                // that could silently lose money if the Wallet service was unavailable.
                 _logger.LogInformation(
-                    "✅ Maker/Taker trade executed: Maker:{MakerId} Taker:{TakerId} Qty:{Qty} Price:{Price}",
+                    "Maker/Taker trade executed: Maker:{MakerId} Taker:{TakerId} Qty:{Qty} Price:{Price}",
                     makerOrder.Id, takerOrder.Id, quantity, result.Trade?.Price);
             }
             else

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Infrastructure.Clients;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// Drains the transactional outbox: periodically reads Pending messages that are due,
+/// performs the cross-service action (calling the Wallet API), and marks each Completed
+/// or schedules a retry with exponential backoff. Because the Wallet settlement is
+/// idempotent (keyed on the trade id), redelivering a message that actually succeeded
+/// is harmless — the wallet reports "already settled".
+///
+/// Assumes a single Orders.Api instance (MVP). For multi-instance, add a claim/lease
+/// column so two processors can't grab the same message.
+/// </summary>
+public class OutboxProcessorService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OutboxProcessorService> _logger;
+
+    private readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
+    private const int BatchSize = 20;
+    private const int MaxRetries = 5;
+    private static readonly TimeSpan BaseRetryDelay = TimeSpan.FromSeconds(10);
+
+    public OutboxProcessorService(IServiceScopeFactory scopeFactory, ILogger<OutboxProcessorService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("OutboxProcessorService started (poll every {Seconds}s).", _pollInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessDueMessagesAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break; // graceful shutdown
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in the outbox processing loop.");
+            }
+
+            try
+            {
+                await Task.Delay(_pollInterval, stoppingToken);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("OutboxProcessorService stopped.");
+    }
+
+    private async Task ProcessDueMessagesAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
+        var walletClient = scope.ServiceProvider.GetRequiredService<IWalletApiClient>();
+
+        var now = DateTime.UtcNow;
+        var due = await db.OutboxMessages
+            .Where(m => m.Status == OutboxMessageStatus.Pending
+                        && (m.NextAttemptAt == null || m.NextAttemptAt <= now))
+            .OrderBy(m => m.CreatedAt)
+            .Take(BatchSize)
+            .ToListAsync(ct);
+
+        if (due.Count == 0) return;
+
+        foreach (var message in due)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                await DispatchAsync(message, walletClient);
+                message.MarkCompleted();
+                _logger.LogInformation("Outbox message {Id} ({Type}, aggregate {AggregateId}) completed.",
+                    message.Id, message.Type, message.AggregateId);
+            }
+            catch (Exception ex)
+            {
+                message.MarkAttemptFailed(ex.Message, MaxRetries, BaseRetryDelay);
+                if (message.Status == OutboxMessageStatus.Failed)
+                    _logger.LogError(ex, "Outbox message {Id} (aggregate {AggregateId}) permanently failed after {Retries} attempts.",
+                        message.Id, message.AggregateId, message.RetryCount);
+                else
+                    _logger.LogWarning(ex, "Outbox message {Id} (aggregate {AggregateId}) failed attempt {Retry}; will retry.",
+                        message.Id, message.AggregateId, message.RetryCount);
+            }
+
+            // Persist per message so a crash mid-batch never loses progress or double-marks.
+            await db.SaveChangesAsync(ct);
+        }
+    }
+
+    /// <summary>Routes a message to the right side-effect based on its type. Throws on failure so the caller schedules a retry.</summary>
+    private static async Task DispatchAsync(OutboxMessage message, IWalletApiClient walletClient)
+    {
+        switch (message.Type)
+        {
+            case "TradeSettlement":
+                var trade = JsonSerializer.Deserialize<TradeDto>(message.Payload)
+                    ?? throw new InvalidOperationException("TradeSettlement payload could not be deserialized.");
+
+                var (success, responseMessage) = await walletClient.TradeTransactionAndBalanceChangeAsync(trade);
+                if (!success)
+                    throw new InvalidOperationException($"Wallet settlement rejected: {responseMessage}");
+                break;
+
+            default:
+                throw new NotSupportedException($"Unknown outbox message type '{message.Type}'.");
+        }
+    }
+}

--- a/src/Order/Orders.Core/OutboxMessage.cs
+++ b/src/Order/Orders.Core/OutboxMessage.cs
@@ -1,0 +1,107 @@
+namespace Orders.Core;
+
+/// <summary>
+/// Processing state of an outbox message.
+/// </summary>
+public enum OutboxMessageStatus
+{
+    Pending = 0,
+    Completed = 1,
+    Failed = 2
+}
+
+/// <summary>
+/// Transactional outbox record. Written in the SAME database transaction as the
+/// business change that produced it (e.g. a matched Trade), so the intent to
+/// perform a follow-up cross-service action can never be lost even if that action
+/// (an HTTP call to the Wallet service) fails or the service is down.
+///
+/// A background processor later reads Pending rows and performs the action, then
+/// marks them Completed. Because the receiver may be called more than once, the
+/// receiver MUST be idempotent (keyed on <see cref="AggregateId"/>).
+/// </summary>
+public class OutboxMessage
+{
+    public Guid Id { get; private set; }
+
+    /// <summary>Logical event type, e.g. "TradeSettlement". Lets one processor route multiple message kinds.</summary>
+    public string Type { get; private set; } = "";
+
+    /// <summary>Id of the aggregate this message is about (the Trade.Id). Doubles as the idempotency key for the receiver.</summary>
+    public Guid AggregateId { get; private set; }
+
+    /// <summary>Serialized payload (JSON) the processor sends to the receiver. Self-contained so no re-fetch is needed.</summary>
+    public string Payload { get; private set; } = "";
+
+    public OutboxMessageStatus Status { get; private set; }
+
+    public DateTime CreatedAt { get; private set; }
+
+    /// <summary>When the message was successfully processed. Null until then.</summary>
+    public DateTime? ProcessedAt { get; private set; }
+
+    /// <summary>Number of processing attempts made so far.</summary>
+    public int RetryCount { get; private set; }
+
+    /// <summary>Earliest time the next attempt may run. Used for exponential backoff.</summary>
+    public DateTime? NextAttemptAt { get; private set; }
+
+    /// <summary>Last error message from a failed attempt, for diagnostics.</summary>
+    public string? LastError { get; private set; }
+
+    // EF Core
+    private OutboxMessage() { }
+
+    public static OutboxMessage Create(string type, Guid aggregateId, string payload)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("Type cannot be empty", nameof(type));
+        if (aggregateId == Guid.Empty)
+            throw new ArgumentException("AggregateId cannot be empty", nameof(aggregateId));
+        if (string.IsNullOrWhiteSpace(payload))
+            throw new ArgumentException("Payload cannot be empty", nameof(payload));
+
+        return new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            AggregateId = aggregateId,
+            Payload = payload,
+            Status = OutboxMessageStatus.Pending,
+            CreatedAt = DateTime.UtcNow,
+            RetryCount = 0,
+            NextAttemptAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>Mark the message as successfully processed.</summary>
+    public void MarkCompleted()
+    {
+        Status = OutboxMessageStatus.Completed;
+        ProcessedAt = DateTime.UtcNow;
+        NextAttemptAt = null;
+        LastError = null;
+    }
+
+    /// <summary>
+    /// Record a failed attempt. Schedules the next attempt with exponential backoff,
+    /// or marks the message Failed once <paramref name="maxRetries"/> is exhausted.
+    /// </summary>
+    public void MarkAttemptFailed(string error, int maxRetries, TimeSpan baseDelay)
+    {
+        RetryCount++;
+        LastError = error;
+
+        if (RetryCount >= maxRetries)
+        {
+            Status = OutboxMessageStatus.Failed;
+            NextAttemptAt = null;
+        }
+        else
+        {
+            // Exponential backoff: baseDelay * 2^(RetryCount-1)
+            var delayTicks = baseDelay.Ticks * (long)Math.Pow(2, RetryCount - 1);
+            NextAttemptAt = DateTime.UtcNow.Add(TimeSpan.FromTicks(delayTicks));
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Configurations;
+
+public class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage>
+{
+    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    {
+        builder.ToTable("OutboxMessages");
+
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.Type).IsRequired().HasMaxLength(100);
+        builder.Property(m => m.AggregateId).IsRequired();
+        builder.Property(m => m.Payload).IsRequired();
+        builder.Property(m => m.Status).IsRequired();
+        builder.Property(m => m.CreatedAt).IsRequired();
+        builder.Property(m => m.ProcessedAt);
+        builder.Property(m => m.RetryCount).IsRequired();
+        builder.Property(m => m.NextAttemptAt);
+        builder.Property(m => m.LastError).HasMaxLength(2000);
+
+        // Hot-path query for the background processor: pending messages that are due.
+        builder.HasIndex(m => new { m.Status, m.NextAttemptAt });
+
+        // Idempotency guard: at most one outbox row per aggregate per message type,
+        // so a retried match cannot enqueue the same settlement twice.
+        builder.HasIndex(m => new { m.Type, m.AggregateId }).IsUnique();
+    }
+}

--- a/src/Order/Orders.Infrastructure/Migrations/20260724072705_AddOutboxMessages.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260724072705_AddOutboxMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724072705_AddOutboxMessages")]
+    partial class AddOutboxMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260724072705_AddOutboxMessages.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260724072705_AddOutboxMessages.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OutboxMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    AggregateId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Payload = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ProcessedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RetryCount = table.Column<int>(type: "int", nullable: false),
+                    NextAttemptAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastError = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Status_NextAttemptAt",
+                table: "OutboxMessages",
+                columns: new[] { "Status", "NextAttemptAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Type_AggregateId",
+                table: "OutboxMessages",
+                columns: new[] { "Type", "AggregateId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessages");
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
+using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 
 namespace Orders.Infrastructure;
@@ -151,7 +153,16 @@ public class OrderMatchingRepository
             _context.Orders.UpdateRange(currentBuyOrder, currentSellOrder);
             _context.Trades.Add(trade);
 
-            // 9. Change Ballance of users in Wallets table and create Transactions records
+            // 9. Enqueue wallet settlement via the transactional outbox.
+            //    Wallet balances live in a separate database/service, so they cannot
+            //    join this transaction directly. Instead we durably record the intent
+            //    here: the Trade and its outbox row commit atomically together, so a
+            //    matched trade can never be left without a pending settlement. A
+            //    background processor later performs the settlement (idempotently,
+            //    keyed on the Trade id) against the Wallet API.
+            var settlementPayload = JsonSerializer.Serialize(MapTradeToSettlementDto(trade));
+            var outboxMessage = OutboxMessage.Create("TradeSettlement", trade.Id, settlementPayload);
+            _context.OutboxMessages.Add(outboxMessage);
 
             await _context.SaveChangesAsync();
             await transaction.CommitAsync();
@@ -169,6 +180,36 @@ public class OrderMatchingRepository
             return (false, null, $"خطا در تطبیق سفارشات: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// Maps a matched <see cref="Trade"/> to the settlement DTO stored in the outbox
+    /// payload. This is the exact contract the Wallet API consumes, so the background
+    /// processor can forward it without re-fetching or re-mapping.
+    /// </summary>
+    private static TradeDto MapTradeToSettlementDto(Trade trade) => new()
+    {
+        Id = trade.Id,
+        BuyOrderId = trade.BuyOrderId,
+        SellOrderId = trade.SellOrderId,
+        MakerOrderId = trade.MakerOrderId,
+        TakerOrderId = trade.TakerOrderId,
+        Symbol = trade.Symbol,
+        Price = trade.Price,
+        Quantity = trade.Quantity,
+        QuoteQuantity = trade.QuoteQuantity,
+        BuyerUserId = trade.BuyerUserId,
+        SellerUserId = trade.SellerUserId,
+        MakerUserId = trade.MakerUserId,
+        TakerUserId = trade.TakerUserId,
+        FeeBuyer = trade.FeeBuyer,
+        FeeSeller = trade.FeeSeller,
+        MakerFee = trade.MakerFee,
+        TakerFee = trade.TakerFee,
+        MakerFeeRate = trade.MakerFeeRate,
+        TakerFeeRate = trade.TakerFeeRate,
+        CreatedAt = trade.CreatedAt,
+        UpdatedAt = trade.UpdatedAt
+    };
 
     /// <summary>
     /// Check if order can be processed

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -257,9 +257,12 @@ public class OrderMatchingRepository
     {
         var quoteQuantity = quantity * price;
         
-        // Fee rates - Maker gets lower fee (0.1%), Taker gets higher fee (0.2%)
-        var makerFeeRate = 0.001m; // 0.1%
-        var takerFeeRate = 0.002m; // 0.2%
+        // Fees are DISABLED for the MVP (charged at 0%). The real maker/taker fee model —
+        // which asset each fee is denominated in (buyer fee should be in the base asset it
+        // receives, not the quote) and crediting collected fees to the fee account — is
+        // tracked in issue #35. Zero fees keep trade settlement balanced until then.
+        var makerFeeRate = 0.000m;
+        var takerFeeRate = 0.000m;
         
         // Determine which order is Maker (older timestamp) and which is Taker (newer timestamp)
         var isBuyOrderMaker = buyOrder.CreatedAt <= sellOrder.CreatedAt;

--- a/src/Order/Orders.Infrastructure/OrdersDbContext.cs
+++ b/src/Order/Orders.Infrastructure/OrdersDbContext.cs
@@ -10,10 +10,12 @@ public class OrdersDbContext : DbContext
 
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<Trade> Trades => Set<Trade>();
-   
+    public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new OrderConfigurations());
         modelBuilder.ApplyConfiguration(new TradeConfiguration());
+        modelBuilder.ApplyConfiguration(new OutboxMessageConfiguration());
     }
 }

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.Requests.Trade;
@@ -236,6 +237,33 @@ app.MapPost("/api/wallet/increaseBalance", async (WalletRequest request, IWallet
     }
 });
 
+// Trade settlement — called by the Orders outbox processor after a match.
+// Atomically consumes both sides' locked collateral, credits each side, and records
+// a Transaction per leg. Idempotent on the trade id, so retries are safe.
+app.MapPost("/api/wallet/changeBalance", async (TradeDto trade, IWalletService walletService, ILogger<Program> logger) =>
+{
+    try
+    {
+        var result = await walletService.SettleTradeAsync(
+            trade.Id, trade.BuyerUserId, trade.SellerUserId,
+            trade.Symbol, trade.Quantity, trade.QuoteQuantity,
+            trade.FeeBuyer, trade.FeeSeller);
+
+        if (!result.Success)
+        {
+            logger.LogWarning("Trade settlement rejected for {TradeId}: {Message}", trade.Id, result.Message);
+            return Results.BadRequest(ApiResponse<string>.Fail(result.Message));
+        }
+
+        return Results.Ok(ApiResponse<string>.Ok(result.Message, "Trade settled"));
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Error settling trade {TradeId}", trade.Id);
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+});
+
 app.MapPost("/api/wallet/transaction/trade", async (TradeRequest request, IWalletService walletService, ILogger<Program> logger, IConfiguration configuration) =>
 {
     // Quarantine stub endpoint audit:C-8
@@ -249,11 +277,11 @@ app.MapPost("/api/wallet/transaction/trade", async (TradeRequest request, IWalle
             "UserId: {FromUserId}, ToUserId: {ToUserId}, Asset: {Asset}, Amount: {Amount}, ReferenceId: {ReferenceId}",
             request.FromUserId, request.ToUserId, request.Asset, request.Amount, request.ReferenceId);
         
-        return Results.StatusCode(501, new { 
-            error = "Not Implemented", 
+        return Results.Json(new {
+            error = "Not Implemented",
             message = "Stub endpoint quarantined. Implementation pending.",
             auditRef = "C-8"
-        });
+        }, statusCode: 501);
     }
     
     // Production implementation (currently unreachable due to quarantine)

--- a/src/Wallet/Wallet.Api/Wallet.Api.csproj
+++ b/src/Wallet/Wallet.Api/Wallet.Api.csproj
@@ -15,6 +15,14 @@
     <None Include="Users.Application.csproj" />
   </ItemGroup>
 
+  <!-- The Tests/ folder holds NUnit/Moq tests (added with TASK-003) that do not
+       belong in this web API project, which lacks the test packages. Excluded from
+       compilation to keep the build green. TODO: rehome them in a dedicated
+       Wallet.Tests project so they actually run. -->
+  <ItemGroup>
+    <Compile Remove="Tests\**\*.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -412,4 +412,11 @@ public class WalletService : IWalletService
         }
     }
 
+    public Task<(bool Success, string Message)> SettleTradeAsync(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, decimal quantity, decimal quoteQuantity,
+        decimal feeBuyer, decimal feeSeller)
+        => _walletRepository.SettleTradeAsync(
+            tradeId, buyerUserId, sellerUserId,
+            symbol, quantity, quoteQuantity, feeBuyer, feeSeller);
 }

--- a/src/Wallet/Wallet.Core/IWalletRepository.cs
+++ b/src/Wallet/Wallet.Core/IWalletRepository.cs
@@ -16,4 +16,15 @@ public interface IWalletRepository
     Task<IEnumerable<WalletTransaction>> GetUserTransactionsAsync(Guid userId, string? asset = null);
     Task<IEnumerable<WalletTransaction>> GetTransactionsByReferenceAsync(string referenceId);
     Task<WalletTransaction> UpdateTransactionAsync(WalletTransaction transaction);
+
+    /// <summary>
+    /// Atomically settles a matched trade: consumes both sides' locked collateral,
+    /// credits each side the asset they bought, and records a Transaction per leg —
+    /// all in a single database transaction with one SaveChanges. Idempotent on
+    /// <paramref name="tradeId"/>: a second call for the same trade is a no-op.
+    /// </summary>
+    Task<(bool Success, string Message)> SettleTradeAsync(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, decimal quantity, decimal quoteQuantity,
+        decimal feeBuyer, decimal feeSeller);
 } 

--- a/src/Wallet/Wallet.Core/IWalletService.cs
+++ b/src/Wallet/Wallet.Core/IWalletService.cs
@@ -19,5 +19,13 @@ public interface IWalletService
     Task<(bool success, string message)> TransferAsync(Guid fromUserId, Guid toUserId, string asset, decimal amount);
     Task<(bool success, string message)> ChargeWalletAsync(Guid userId, string asset, decimal amount, string? paymentMethod = null);
     Task<IEnumerable<WalletDTO>> CreateDefaultWalletsAsync(Guid userId);
-    
+
+    /// <summary>
+    /// Settles a matched trade atomically and idempotently (keyed on <paramref name="tradeId"/>).
+    /// Backs POST /api/wallet/changeBalance, called by the Orders outbox processor.
+    /// </summary>
+    Task<(bool Success, string Message)> SettleTradeAsync(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, decimal quantity, decimal quoteQuantity,
+        decimal feeBuyer, decimal feeSeller);
 } 

--- a/src/Wallet/Wallet.Core/Wallet.cs
+++ b/src/Wallet/Wallet.Core/Wallet.cs
@@ -84,6 +84,22 @@ public class WalletEntity
         UpdatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Consumes previously-locked collateral during trade settlement: the reserved funds
+    /// are spent, so they leave LockedBalance WITHOUT returning to the available Balance.
+    /// Unlike UnLockBalance + DecreaseBalance, this does not trip the non-negative Balance
+    /// guard, which is required for credit-backed positions whose available Balance is
+    /// already negative. The debt (negative Balance) legitimately remains.
+    /// </summary>
+    public void ConsumeLockedBalance(decimal amount)
+    {
+        if (amount <= 0)
+            throw new ArgumentException("مقدار باید بزرگتر از صفر باشد", nameof(amount));
+
+        LockedBalance -= amount;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
 }
 
 public class WalletTransaction

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -257,10 +257,11 @@ public class WalletRepository : IWalletRepository
                 return (false, $"Seller locked {baseAsset} ({sellerBase.LockedBalance}) is less than required ({quantity}).");
             }
 
-            // Buyer pays quote: consume the locked collateral (unlock then decrease = net locked consumed).
+            // Buyer pays quote: consume the locked collateral. The funds were reserved at
+            // order time (possibly credit-backed, so available Balance may be negative);
+            // consuming them removes the lock and leaves the debt on Balance.
             var buyerQuoteBefore = buyerQuote.Balance;
-            buyerQuote.UnLockBalance(quoteQuantity);
-            buyerQuote.DecreaseBalance(quoteQuantity);
+            buyerQuote.ConsumeLockedBalance(quoteQuantity);
             AddTradeTransaction(buyerQuote, quoteQuantity, quoteAsset, buyerQuoteBefore, buyerQuote.Balance, referenceId, "Buyer paid quote asset (from locked funds)");
 
             // Buyer receives base.
@@ -268,10 +269,9 @@ public class WalletRepository : IWalletRepository
             buyerBase.IncreaseBalance(buyerReceivesBase);
             AddTradeTransaction(buyerBase, buyerReceivesBase, baseAsset, buyerBaseBefore, buyerBase.Balance, referenceId, "Buyer received base asset");
 
-            // Seller pays base: consume the locked collateral.
+            // Seller pays base: consume the locked collateral (same credit-aware handling).
             var sellerBaseBefore = sellerBase.Balance;
-            sellerBase.UnLockBalance(quantity);
-            sellerBase.DecreaseBalance(quantity);
+            sellerBase.ConsumeLockedBalance(quantity);
             AddTradeTransaction(sellerBase, quantity, baseAsset, sellerBaseBefore, sellerBase.Balance, referenceId, "Seller paid base asset (from locked funds)");
 
             // Seller receives quote.

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -195,6 +195,121 @@ public class WalletRepository : IWalletRepository
         return transaction;
     }
 
+    public async Task<(bool Success, string Message)> SettleTradeAsync(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, decimal quantity, decimal quoteQuantity,
+        decimal feeBuyer, decimal feeSeller)
+    {
+        var referenceId = tradeId.ToString();
+
+        // Idempotency: a retry or a duplicate outbox delivery must not settle twice.
+        // Check the NEW Transactions table (settlement writes here), not the legacy WalletTransactions.
+        var alreadySettled = await _context.Transactions.AnyAsync(t => t.ReferenceId == referenceId);
+        if (alreadySettled)
+        {
+            _logger.LogInformation("Trade {TradeId} already settled; skipping (idempotent).", tradeId);
+            return (true, "Trade already settled.");
+        }
+
+        // Symbol is BASE/QUOTE, e.g. MAUA/IRR. Parse defensively (never symbol.Split('/')[1] blindly).
+        var parts = symbol?.Split('/');
+        if (parts is not { Length: 2 } || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            return (false, $"Invalid symbol '{symbol}'. Expected BASE/QUOTE.");
+
+        var baseAsset = parts[0].Trim().ToUpperInvariant();   // e.g. MAUA (gold)
+        var quoteAsset = parts[1].Trim().ToUpperInvariant();  // e.g. IRR (rial)
+
+        if (quantity <= 0 || quoteQuantity <= 0)
+            return (false, "Quantity and quoteQuantity must be positive.");
+        if (feeBuyer < 0 || feeSeller < 0)
+            return (false, "Fees cannot be negative.");
+
+        var buyerReceivesBase = quantity - feeBuyer;         // buyer gets base minus buyer fee
+        var sellerReceivesQuote = quoteQuantity - feeSeller; // seller gets quote minus seller fee
+        if (buyerReceivesBase <= 0 || sellerReceivesQuote <= 0)
+            return (false, "Fee exceeds the trade amount.");
+
+        await using var tx = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            // Fetch all four wallets as tracked entities; every change below is persisted by a single SaveChanges.
+            var buyerQuote = await _context.Wallets.FirstOrDefaultAsync(w => w.UserId == buyerUserId && w.Asset == quoteAsset);
+            var buyerBase = await _context.Wallets.FirstOrDefaultAsync(w => w.UserId == buyerUserId && w.Asset == baseAsset);
+            var sellerBase = await _context.Wallets.FirstOrDefaultAsync(w => w.UserId == sellerUserId && w.Asset == baseAsset);
+            var sellerQuote = await _context.Wallets.FirstOrDefaultAsync(w => w.UserId == sellerUserId && w.Asset == quoteAsset);
+
+            if (buyerQuote is null || buyerBase is null || sellerBase is null || sellerQuote is null)
+            {
+                await tx.RollbackAsync();
+                return (false, "One or more participant wallets were not found.");
+            }
+
+            // The collateral must actually be locked. Guards against the lock-after-match ordering bug (audit C-5):
+            // settling from funds that were never locked would drive a balance negative.
+            if (buyerQuote.LockedBalance < quoteQuantity)
+            {
+                await tx.RollbackAsync();
+                return (false, $"Buyer locked {quoteAsset} ({buyerQuote.LockedBalance}) is less than required ({quoteQuantity}).");
+            }
+            if (sellerBase.LockedBalance < quantity)
+            {
+                await tx.RollbackAsync();
+                return (false, $"Seller locked {baseAsset} ({sellerBase.LockedBalance}) is less than required ({quantity}).");
+            }
+
+            // Buyer pays quote: consume the locked collateral (unlock then decrease = net locked consumed).
+            var buyerQuoteBefore = buyerQuote.Balance;
+            buyerQuote.UnLockBalance(quoteQuantity);
+            buyerQuote.DecreaseBalance(quoteQuantity);
+            AddTradeTransaction(buyerQuote, quoteQuantity, quoteAsset, buyerQuoteBefore, buyerQuote.Balance, referenceId, "Buyer paid quote asset (from locked funds)");
+
+            // Buyer receives base.
+            var buyerBaseBefore = buyerBase.Balance;
+            buyerBase.IncreaseBalance(buyerReceivesBase);
+            AddTradeTransaction(buyerBase, buyerReceivesBase, baseAsset, buyerBaseBefore, buyerBase.Balance, referenceId, "Buyer received base asset");
+
+            // Seller pays base: consume the locked collateral.
+            var sellerBaseBefore = sellerBase.Balance;
+            sellerBase.UnLockBalance(quantity);
+            sellerBase.DecreaseBalance(quantity);
+            AddTradeTransaction(sellerBase, quantity, baseAsset, sellerBaseBefore, sellerBase.Balance, referenceId, "Seller paid base asset (from locked funds)");
+
+            // Seller receives quote.
+            var sellerQuoteBefore = sellerQuote.Balance;
+            sellerQuote.IncreaseBalance(sellerReceivesQuote);
+            AddTradeTransaction(sellerQuote, sellerReceivesQuote, quoteAsset, sellerQuoteBefore, sellerQuote.Balance, referenceId, "Seller received quote asset");
+
+            var now = DateTime.UtcNow;
+            buyerQuote.UpdatedAt = now; buyerBase.UpdatedAt = now; sellerBase.UpdatedAt = now; sellerQuote.UpdatedAt = now;
+            _context.Wallets.UpdateRange(buyerQuote, buyerBase, sellerBase, sellerQuote);
+
+            await _context.SaveChangesAsync(); // single save: 4 balance changes + 4 transaction records
+            await tx.CommitAsync();
+
+            _logger.LogInformation(
+                "Settled trade {TradeId}: buyer={Buyer} seller={Seller} {Qty} {Base} for {Quote} {QuoteAsset}",
+                tradeId, buyerUserId, sellerUserId, quantity, baseAsset, quoteQuantity, quoteAsset);
+            return (true, "Trade settled.");
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync();
+            _logger.LogError(ex, "Error settling trade {TradeId}", tradeId);
+            return (false, $"Settlement error: {ex.Message}");
+        }
+    }
+
+    /// <summary>Adds (but does not save) a completed Trade transaction record to the current unit of work.</summary>
+    private void AddTradeTransaction(WalletEntity wallet, decimal amount, string asset,
+        decimal balanceBefore, decimal balanceAfter, string referenceId, string description)
+    {
+        var transaction = Transaction.Create(
+            wallet.Id, amount, asset, TransactionType.Trade,
+            balanceBefore, balanceAfter, null, TransactionStatus.Completed,
+            description, referenceId, null);
+        _context.Transactions.Add(transaction);
+    }
+
     public async Task<WalletTransaction?> GetTransactionAsync(Guid transactionId)
     {
         return await _context.WalletTransactions.FindAsync(transactionId);

--- a/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
+++ b/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core.Enums.Wallet;
+using Wallet.Core;
+using Wallet.Infrastructure;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Integration tests for the money path: WalletRepository.SettleTradeAsync.
+/// Uses a real SQLite in-memory database (supports transactions, unlike EF InMemory)
+/// so the atomic settlement and its DB transaction are actually exercised.
+///
+/// Scenario throughout: trading pair MAUA/IRR, price 500, quantity 2 => quoteQuantity 1000.
+/// Buyer locked 1000 IRR as collateral; seller locked 2 MAUA as collateral.
+/// </summary>
+public class SettleTradeAsyncTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly WalletDbContext _context;
+    private readonly WalletRepository _repository;
+
+    private readonly Guid _buyerId = Guid.NewGuid();
+    private readonly Guid _sellerId = Guid.NewGuid();
+
+    private const string Base = "MAUA";  // gold
+    private const string Quote = "IRR";  // rial
+    private const decimal Quantity = 2m;
+    private const decimal QuoteQuantity = 1000m; // price 500 * quantity 2
+
+    public SettleTradeAsyncTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<WalletDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _context = new WalletDbContext(options);
+        _context.Database.EnsureCreated();
+        _repository = new WalletRepository(NullLogger<WalletRepository>.Instance, _context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private WalletEntity SeedWallet(Guid userId, string asset, decimal balance, decimal locked)
+    {
+        var wallet = WalletEntity.Create(userId, asset);
+        wallet.Balance = balance;
+        wallet.LockedBalance = locked;
+        _context.Wallets.Add(wallet);
+        return wallet;
+    }
+
+    /// <summary>Seed the four wallets with collateral already locked (the normal pre-settlement state).</summary>
+    private void SeedFullyLockedWallets()
+    {
+        SeedWallet(_buyerId, Quote, balance: 0m, locked: QuoteQuantity); // buyer's IRR locked
+        SeedWallet(_buyerId, Base, balance: 0m, locked: 0m);             // buyer's MAUA (to receive)
+        SeedWallet(_sellerId, Base, balance: 0m, locked: Quantity);      // seller's MAUA locked
+        SeedWallet(_sellerId, Quote, balance: 0m, locked: 0m);           // seller's IRR (to receive)
+        _context.SaveChanges();
+    }
+
+    private async Task<WalletEntity> ReloadAsync(Guid userId, string asset)
+    {
+        _context.ChangeTracker.Clear(); // force a read from the database, not tracked memory
+        return await _context.Wallets.SingleAsync(w => w.UserId == userId && w.Asset == asset);
+    }
+
+    [Fact]
+    public async Task SettleTradeAsync_HappyPath_MovesBalancesConsumesLockAndRecordsTransactions()
+    {
+        SeedFullyLockedWallets();
+        var tradeId = Guid.NewGuid();
+
+        var (success, message) = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}",
+            Quantity, QuoteQuantity, feeBuyer: 0m, feeSeller: 0m);
+
+        Assert.True(success, message);
+
+        // Buyer paid IRR from locked funds: locked consumed, available unchanged (0).
+        var buyerQuote = await ReloadAsync(_buyerId, Quote);
+        Assert.Equal(0m, buyerQuote.LockedBalance);
+        Assert.Equal(0m, buyerQuote.Balance);
+
+        // Buyer received MAUA.
+        var buyerBase = await ReloadAsync(_buyerId, Base);
+        Assert.Equal(Quantity, buyerBase.Balance);
+
+        // Seller paid MAUA from locked funds.
+        var sellerBase = await ReloadAsync(_sellerId, Base);
+        Assert.Equal(0m, sellerBase.LockedBalance);
+        Assert.Equal(0m, sellerBase.Balance);
+
+        // Seller received IRR.
+        var sellerQuote = await ReloadAsync(_sellerId, Quote);
+        Assert.Equal(QuoteQuantity, sellerQuote.Balance);
+
+        // Exactly four Trade transaction records, all tied to this trade.
+        var txns = await _context.Transactions.Where(t => t.ReferenceId == tradeId.ToString()).ToListAsync();
+        Assert.Equal(4, txns.Count);
+        Assert.All(txns, t => Assert.Equal(TransactionType.Trade, t.Type));
+    }
+
+    [Fact]
+    public async Task SettleTradeAsync_CalledTwice_IsIdempotent()
+    {
+        SeedFullyLockedWallets();
+        var tradeId = Guid.NewGuid();
+
+        var first = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}", Quantity, QuoteQuantity, 0m, 0m);
+        Assert.True(first.Success, first.Message);
+
+        // Second delivery of the same trade (e.g. an outbox retry after a lost response).
+        var second = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}", Quantity, QuoteQuantity, 0m, 0m);
+        Assert.True(second.Success, second.Message);
+
+        // Balances must reflect a single settlement, not a double one.
+        var buyerBase = await ReloadAsync(_buyerId, Base);
+        Assert.Equal(Quantity, buyerBase.Balance); // not 2 * Quantity
+        var sellerQuote = await ReloadAsync(_sellerId, Quote);
+        Assert.Equal(QuoteQuantity, sellerQuote.Balance); // not 2 * QuoteQuantity
+
+        // Still only four transaction records.
+        var count = await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString());
+        Assert.Equal(4, count);
+    }
+
+    [Fact]
+    public async Task SettleTradeAsync_WhenCollateralNotLocked_FailsAndChangesNothing()
+    {
+        // Buyer's IRR was never locked — simulates the lock-after-match ordering bug (C-5).
+        SeedWallet(_buyerId, Quote, balance: 0m, locked: 0m);
+        SeedWallet(_buyerId, Base, balance: 0m, locked: 0m);
+        SeedWallet(_sellerId, Base, balance: 0m, locked: Quantity);
+        SeedWallet(_sellerId, Quote, balance: 0m, locked: 0m);
+        _context.SaveChanges();
+        var tradeId = Guid.NewGuid();
+
+        var (success, _) = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}", Quantity, QuoteQuantity, 0m, 0m);
+
+        Assert.False(success);
+
+        // Nothing changed: no balances moved, no transaction records written (transaction rolled back).
+        var sellerBase = await ReloadAsync(_sellerId, Base);
+        Assert.Equal(Quantity, sellerBase.LockedBalance); // still locked
+        Assert.Equal(0m, sellerBase.Balance);
+        var count = await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString());
+        Assert.Equal(0, count);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Wallet.Core\Wallet.Core.csproj" />
+    <ProjectReference Include="..\Wallet.Infrastructure\Wallet.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description
Implements atomic, idempotent trade settlement delivered through a transactional **outbox**, so a matched trade can never be left unsettled even though the Orders and Wallet services use separate databases. Verified end-to-end live through the Telegram bot.

Closes #21.

## Type
- [x] Feature (financial core)

## How it works
```
Match (Orders DB, one transaction)
  ├─ write Trade
  └─ write OutboxMessage "TradeSettlement"   ← same transaction, so they commit atomically
        ↓
OutboxProcessorService (background, in Orders.Api)
  ├─ reads due Pending messages
  ├─ POST /api/wallet/changeBalance (TradeDto)
  ├─ success → mark Completed
  └─ failure → exponential backoff retry; after N attempts → Failed
        ↓
Wallet: SettleTradeAsync (one WalletDb transaction, idempotent on Trade.Id)
  ├─ consume both sides' locked collateral
  ├─ credit each side the asset it bought
  └─ write 4 Transaction records (ref = Trade.Id)
```

## Changes
**Orders side**
- `OutboxMessage` entity + EF config + migration (`AddOutboxMessages`): additive table only, with a `(Status, NextAttemptAt)` processing index and a unique `(Type, AggregateId)` idempotency index.
- Enqueue the settlement in the **same transaction** as the matched Trade (`OrderMatchingRepository.ExecuteAtomicMatchAsync`).
- `OutboxProcessorService`: background delivery with exponential-backoff retry and permanent-fail after N attempts.
- Removed the dead, commented-out inline settlement in `MatchingEngineService` (settlement is now via the outbox).

**Wallet side (issue #21 proper)**
- `WalletRepository.SettleTradeAsync`: atomic, idempotent (keyed on `Trade.Id`) settlement — all balance changes + 4 transaction records in a single `SaveChanges` inside one DB transaction.
- New endpoint `POST /api/wallet/changeBalance` (the URL the client already targeted).
- `WalletEntity.ConsumeLockedBalance`: consumes locked collateral without round-tripping through Balance, so credit-backed (negative-balance) positions settle correctly.
- Trade fees set to **0%** for the MVP (see Testing / Follow-ups).
- `Wallet.Tests`: SQLite-in-memory integration tests for the settlement (happy path, idempotency, insufficient-lock guard).

**Build fixes folded in** (were broken on `main` from #34): excluded a misplaced NUnit test file from `Wallet.Api`, and fixed a `Results.StatusCode(501, body)` call that did not compile.

## Testing
Driven live through the Telegram bot against LocalDB, watching all service logs:
- Full pipeline fired: match → outbox row → processor → `SettleTradeAsync` → `OutboxMessage` Completed.
- **Two trades settled with money conserved**, verified from the DB (net position = Balance + Locked mirrored exactly between buyer and seller), including on the credit model (both parties' available balance legitimately negative).
- Retry-with-backoff and permanent-fail-after-N both observed.
- `Wallet.Tests` (3) pass.

Two real bugs were found *because* of this live test and fixed in `535f199`:
1. Fees were denominated in the quote asset but subtracted from the base the buyer receives → every settlement rejected. Fees set to 0 for the MVP.
2. Consuming locked collateral tripped `DecreaseBalance`'s non-negative guard for credit-backed positions → added `ConsumeLockedBalance`.

## Not included / follow-ups (filed as issues)
- #35 — fee/house account + real maker/taker fee model (fees are 0 here)
- #36 — enforce the credit limit inside the wallet (single signed ledger)
- #37 — round monetary amounts to currency precision (18-digit IRR residuals)
- #38 — propagate the real settlement-failure reason to the outbox processor
- #39 — reconciliation & re-drive for permanently-failed settlements
- #40 — remove the duplicate trade-creation path with conflicting fee config

## Notes for the reviewer
- Review depth: **level 3** (money path) per `docs/process/CODE_REVIEW_GUIDE.md`. Key files: `WalletRepository.SettleTradeAsync`, `WalletEntity.ConsumeLockedBalance`, `OutboxProcessorService`, `OrderMatchingRepository` (enqueue).
- Migration is additive (new table only); no existing table is altered.
- `config/appsettings.global.json` was intentionally **not** committed (it holds a local LocalDB connection string); the dev-stack run fixes in `b6b3ca5` are unrelated to the feature and can be reviewed separately.
