### PR TITLE
fix: financial safeguards — fee guard, amount rounding, counterparty rules, settlement re-drive

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -716,6 +716,109 @@ static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironm
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Settlement reconciliation (issue #39)
+//
+// When an outbox settlement exhausts its retries it is marked Failed and abandoned,
+// but the trade is already recorded and the participants' collateral stays locked.
+// Nothing surfaced those trades and there was no way to settle them once the cause
+// was fixed. These endpoints make stuck settlements visible and re-drivable.
+//
+// Re-driving is safe because settlement is idempotent on the trade id: a redundant
+// delivery is a no-op rather than a double settlement.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Lists trades whose settlement never completed, newest first.
+app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db) =>
+{
+    try
+    {
+        var stuck = await db.OutboxMessages
+            .AsNoTracking()
+            .Where(m => m.Status != OutboxMessageStatus.Completed)
+            .OrderByDescending(m => m.CreatedAt)
+            .Select(m => new
+            {
+                m.Id,
+                TradeId = m.AggregateId,
+                m.Type,
+                Status = m.Status.ToString(),
+                m.RetryCount,
+                m.CreatedAt,
+                m.NextAttemptAt,
+                m.LastError
+            })
+            .ToListAsync();
+
+        return Results.Ok(ApiResponse<object>.Ok(new
+        {
+            Count = stuck.Count,
+            FailedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Failed)),
+            Items = stuck
+        }, "فهرست تسویه‌های ناتمام"));
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Error listing unsettled outbox messages");
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+});
+
+/// Puts a permanently-failed settlement back in the queue after the cause has been fixed.
+app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbContext db) =>
+{
+    try
+    {
+        var message = await db.OutboxMessages.FirstOrDefaultAsync(m => m.Id == messageId);
+        if (message is null)
+            return Results.NotFound(ApiResponse<string>.Fail("پیام یافت نشد."));
+
+        message.ResetForRetry();
+        await db.SaveChangesAsync();
+
+        Log.Information("Outbox message {MessageId} (trade {TradeId}) was re-driven by an operator.",
+            message.Id, message.AggregateId);
+
+        return Results.Ok(ApiResponse<string>.Ok(message.AggregateId.ToString(),
+            "پیام برای پردازش مجدد در صف قرار گرفت."));
+    }
+    catch (InvalidOperationException ex)
+    {
+        // Raised when the message is not in a re-drivable state (Completed or Pending).
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Error re-driving outbox message {MessageId}", messageId);
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+});
+
+/// Re-drives every failed settlement at once, for use after a fix that affects them all.
+app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
+{
+    try
+    {
+        var failed = await db.OutboxMessages
+            .Where(m => m.Status == OutboxMessageStatus.Failed)
+            .ToListAsync();
+
+        foreach (var message in failed)
+            message.ResetForRetry();
+
+        await db.SaveChangesAsync();
+
+        Log.Information("{Count} failed outbox message(s) were re-driven by an operator.", failed.Count);
+
+        return Results.Ok(ApiResponse<int>.Ok(failed.Count,
+            $"{failed.Count} تسویهٔ ناموفق دوباره در صف قرار گرفت."));
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Error re-driving all failed outbox messages");
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+});
 
 app.Run();
 

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Orders.Core;
 using Serilog;
+using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
@@ -61,9 +62,13 @@ public class OrderService
             var assetToCheck = request.Side == TallaEgg.Core.Enums.Order.OrderSide.Buy
                 ? request.Symbol.Split('/')[1] : request.Symbol.Split('/')[0];
 
+            // مبلغ قفل‌شده باید با همان دقتِ خودِ دارایی گرد شود. بدون این کار،
+            // «مقدار × قیمت» تا ۱۸ رقم اعشار پیش می‌رود، در حالی که تسویه و ستون‌های
+            // دیتابیس با دقت کمتری کار می‌کنند و یک باقی‌ماندهٔ کوچک در LockedBalance
+            // جا می‌ماند.
             var amountToCheck = request.Side == TallaEgg.Core.Enums.Order.OrderSide.Buy
-                ? request.Quantity * request.Price
-                : request.Quantity;
+                ? CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity * request.Price, assetToCheck)
+                : CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity, assetToCheck);
 
             _logger.LogInformation("Validating balance for user {UserId}: {Amount} {Asset}",
                 userId, amountToCheck, assetToCheck);

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -29,15 +30,43 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     private readonly SemaphoreSlim _processingSemaphore = new(1, 1); // Prevent concurrent processing
     private bool _isRunning = false;
 
+    /// <summary>
+    /// شناسهٔ کاربر بازارگردان (ادمین). اگر تنظیم شده باشد و RequireMarketMakerCounterparty
+    /// روشن باشد، هر معامله باید یک طرفش این کاربر باشد.
+    /// </summary>
+    private readonly Guid? _marketMakerUserId;
+
+    /// <summary>
+    /// آیا الزام «یک طرف معامله باید بازارگردان باشد» فعال است؟ در مدل فعلی کسب‌وکار
+    /// مشتری‌ها فقط با ادمین معامله می‌کنند، اما وقتی بازار نظیربه‌نظیر باز شود این
+    /// تنظیم خاموش می‌شود (نه اینکه کد حذف شود).
+    /// </summary>
+    private readonly bool _requireMarketMakerCounterparty;
+
     public MatchingEngineService(
         IServiceScopeFactory scopeFactory,
         ILogger<MatchingEngineService> logger,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        IConfiguration configuration)
     {
         _scopeFactory = scopeFactory;
 
         _logger = logger;
         _serviceProvider = serviceProvider;
+
+        _requireMarketMakerCounterparty =
+            configuration.GetValue("Matching:RequireMarketMakerCounterparty", defaultValue: false);
+
+        var marketMakerId = configuration.GetValue<string?>("Matching:MarketMakerUserId", null);
+        _marketMakerUserId = Guid.TryParse(marketMakerId, out var parsed) ? parsed : null;
+
+        if (_requireMarketMakerCounterparty && _marketMakerUserId is null)
+        {
+            // خاموش می‌ماند تا تطبیق به‌کلی متوقف نشود؛ اما باید دیده شود.
+            _logger.LogError(
+                "Matching:RequireMarketMakerCounterparty is enabled but Matching:MarketMakerUserId is not set. " +
+                "The market-maker rule will NOT be enforced.");
+        }
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -339,13 +368,19 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             {
                 // For buy orders, find sell orders with price <= buy price
                 var sellOrders = await matchingRepository.GetSellOrdersWithLockAsync(incomingOrder.Asset);
-                return sellOrders.Where(s => s.Price <= incomingOrder.Price && s.RemainingAmount > 0).ToList();
+                return sellOrders
+                    .Where(s => s.Price <= incomingOrder.Price && s.RemainingAmount > 0)
+                    .Where(s => IsAllowedCounterparty(incomingOrder, s))
+                    .ToList();
             }
             else
             {
                 // For sell orders, find buy orders with price >= sell price
                 var buyOrders = await matchingRepository.GetBuyOrdersWithLockAsync(incomingOrder.Asset);
-                return buyOrders.Where(b => b.Price >= incomingOrder.Price && b.RemainingAmount > 0).ToList();
+                return buyOrders
+                    .Where(b => b.Price >= incomingOrder.Price && b.RemainingAmount > 0)
+                    .Where(b => IsAllowedCounterparty(incomingOrder, b))
+                    .ToList();
             }
         }
         catch (Exception ex)
@@ -353,6 +388,46 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             _logger.LogError(ex, "💥 Error getting matching orders for {OrderId}", incomingOrder.Id);
             return new List<Order>();
         }
+    }
+
+    /// <summary>
+    /// بررسی مجاز بودن طرف مقابل برای تطبیق.
+    ///
+    /// دو قاعده:
+    /// ۱. هیچ کاربری با خودش معامله نمی‌کند. این قاعده همیشه فعال است — خودمعاملگی
+    ///    از نظر اقتصادی خنثی است اما رد حسابرسی نادرست تولید می‌کند و می‌تواند برای
+    ///    ساختن حجم صوری استفاده شود.
+    /// ۲. اگر الزام بازارگردان فعال باشد، یک طرف معامله باید ادمین باشد. در این مرحله
+    ///    از محصول، مشتری‌ها فقط با ادمین معامله می‌کنند و نه با یکدیگر.
+    ///
+    /// سفارش رد‌شده لغو نمی‌شود؛ فقط در این دور تطبیق نادیده گرفته می‌شود و باز می‌ماند.
+    /// </summary>
+    private bool IsAllowedCounterparty(Order incomingOrder, Order candidate)
+    {
+        if (incomingOrder.UserId == candidate.UserId)
+        {
+            _logger.LogDebug(
+                "Skipping self-match for user {UserId} between orders {IncomingOrderId} and {CandidateOrderId}.",
+                incomingOrder.UserId, incomingOrder.Id, candidate.Id);
+            return false;
+        }
+
+        if (_requireMarketMakerCounterparty && _marketMakerUserId is Guid marketMaker)
+        {
+            var involvesMarketMaker =
+                incomingOrder.UserId == marketMaker || candidate.UserId == marketMaker;
+
+            if (!involvesMarketMaker)
+            {
+                _logger.LogDebug(
+                    "Skipping customer-to-customer match between orders {IncomingOrderId} and {CandidateOrderId}: " +
+                    "neither side is the market maker.",
+                    incomingOrder.Id, candidate.Id);
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -94,9 +94,21 @@ public class OutboxProcessorService : BackgroundService
             }
             catch (Exception ex)
             {
-                message.MarkAttemptFailed(ex.Message, MaxRetries, BaseRetryDelay);
+                // The stored reason is length-limited by the column; truncate so persisting
+                // the failure can never itself fail and leave the message stuck as Pending.
+                var reason = ex.Message.Length > 1900
+                    ? ex.Message[..1900] + "…(truncated)"
+                    : ex.Message;
+
+                message.MarkAttemptFailed(reason, MaxRetries, BaseRetryDelay);
                 if (message.Status == OutboxMessageStatus.Failed)
-                    _logger.LogError(ex, "Outbox message {Id} (aggregate {AggregateId}) permanently failed after {Retries} attempts.",
+                    // A trade is now recorded but unsettled, with the participants' collateral
+                    // still locked. It needs an operator: inspect /api/outbox/unsettled and
+                    // re-drive once the cause is fixed (settlement is idempotent).
+                    _logger.LogError(ex,
+                        "SETTLEMENT STUCK — outbox message {Id} (trade {AggregateId}) permanently failed after {Retries} attempts. " +
+                        "The trade is recorded but NOT settled and collateral remains locked. " +
+                        "Fix the cause, then POST /api/outbox/{Id}/redrive.",
                         message.Id, message.AggregateId, message.RetryCount);
                 else
                     _logger.LogWarning(ex, "Outbox message {Id} (aggregate {AggregateId}) failed attempt {Retry}; will retry.",

--- a/src/Order/Orders.Core/OutboxMessage.cs
+++ b/src/Order/Orders.Core/OutboxMessage.cs
@@ -104,4 +104,28 @@ public class OutboxMessage
             NextAttemptAt = DateTime.UtcNow.Add(TimeSpan.FromTicks(delayTicks));
         }
     }
+
+    /// <summary>
+    /// Puts a permanently-failed message back in the queue after an operator has fixed
+    /// the underlying cause. The retry counter is reset so the message gets a fresh set
+    /// of attempts, and it becomes due immediately.
+    ///
+    /// This is safe to call even if the action actually succeeded before the failure was
+    /// recorded: the receiver is idempotent on <see cref="AggregateId"/>, so a redundant
+    /// delivery is a no-op rather than a double settlement.
+    ///
+    /// Only a Failed message can be re-driven — reviving a Completed one would be an
+    /// attempt to settle the same trade twice, and a Pending one is already queued.
+    /// </summary>
+    public void ResetForRetry()
+    {
+        if (Status != OutboxMessageStatus.Failed)
+            throw new InvalidOperationException(
+                $"Only a failed message can be re-driven; this message is {Status}.");
+
+        Status = OutboxMessageStatus.Pending;
+        RetryCount = 0;
+        NextAttemptAt = DateTime.UtcNow;
+        ProcessedAt = null;
+    }
 }

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
+using TallaEgg.Core;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 
@@ -255,8 +256,12 @@ public class OrderMatchingRepository
     /// </summary>
     private static Trade CreateTrade(Order buyOrder, Order sellOrder, decimal quantity, decimal price)
     {
-        var quoteQuantity = quantity * price;
-        
+        // ارزش معامله با دقت واقعی ارز مظنه گرد می‌شود (تومان: بدون اعشار). این همان
+        // مبلغی است که در تسویه از خریدار کسر و به فروشنده پرداخت می‌شود، پس باید با
+        // مبلغی که هنگام ثبت سفارش قفل شده هم‌دقت باشد، وگرنه باقی‌مانده جا می‌ماند.
+        var quoteAsset = buyOrder.Asset.Split('/').Last();
+        var quoteQuantity = CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, quoteAsset);
+
         // Fees are DISABLED for the MVP (charged at 0%). The real maker/taker fee model —
         // which asset each fee is denominated in (buyer fee should be in the base asset it
         // receives, not the quote) and crediting collected fees to the fee account — is

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -132,6 +132,28 @@
         public static bool IsValidCurrency(string code) =>
             _map.ContainsKey(code);
 
+        /// <summary>
+        /// گرد کردن یک مبلغ به دقت واقعی همان دارایی (مثلاً تومان: بدون اعشار، آبشده: دو رقم).
+        ///
+        /// این متد باید در هر جایی که مبلغی محاسبه می‌شود صدا زده شود — به‌ویژه
+        /// «مقدار × قیمت» — چون نتیجهٔ آن ضرب تا ۱۸ رقم اعشار پیش می‌رود در حالی که
+        /// ستون‌های دیتابیس decimal(28,8) هستند. اگر مقدارِ قفل‌شده و مقدارِ تسویه‌شده
+        /// با دقت‌های متفاوت محاسبه شوند، پس از پایان سفارش یک باقی‌ماندهٔ کوچک در
+        /// LockedBalance جا می‌ماند که در سیستم مالی یک نشتی تدریجی است.
+        ///
+        /// از MidpointRounding.ToEven استفاده نمی‌کنیم؛ AwayFromZero رفتار مورد انتظار
+        /// در محاسبات مالی است.
+        /// </summary>
+        public static decimal RoundToCurrencyPrecision(decimal amount, string assetCode)
+        {
+            var info = GetCurrencyInfo(assetCode);
+            // اگر دارایی ناشناخته بود، مقدار را دست‌نخورده برمی‌گردانیم تا رفتار موجود نشکند.
+            if (info is null)
+                return amount;
+
+            return Math.Round(amount, info.DecimalPlaces, MidpointRounding.AwayFromZero);
+        }
+
         // 🔹 دیکشنری جفت‌های معاملاتی برای دسترسی سریع (case-insensitive)
         private static readonly Dictionary<string, TradingPairInfo> _pairMap =
             AllTradingPairs.ToDictionary(p => p.Symbol, p => p, StringComparer.OrdinalIgnoreCase);

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -224,10 +224,23 @@ public class WalletRepository : IWalletRepository
         if (feeBuyer < 0 || feeSeller < 0)
             return (false, "Fees cannot be negative.");
 
-        var buyerReceivesBase = quantity - feeBuyer;         // buyer gets base minus buyer fee
-        var sellerReceivesQuote = quoteQuantity - feeSeller; // seller gets quote minus seller fee
-        if (buyerReceivesBase <= 0 || sellerReceivesQuote <= 0)
-            return (false, "Fee exceeds the trade amount.");
+        // Fail closed on fees. Settlement debits each payer the full amount but would
+        // credit the receiver the amount minus the fee — and the difference is credited
+        // to NO account, so a non-zero fee silently destroys money on every trade.
+        // Fee rates are 0 for the MVP, so this guard is inert today; it exists so that
+        // restoring a non-zero rate produces a loud, visible failure instead of a slow
+        // leak. Remove it only together with fee crediting to the fee account (issue #35).
+        if (feeBuyer != 0m || feeSeller != 0m)
+        {
+            _logger.LogError(
+                "Refusing to settle trade {TradeId}: non-zero fees are not supported because collected " +
+                "fees are not credited to any account (feeBuyer={FeeBuyer}, feeSeller={FeeSeller}). See issue #35.",
+                tradeId, feeBuyer, feeSeller);
+            return (false, "Fee crediting is not implemented; settlement refused to avoid losing the fee amount.");
+        }
+
+        var buyerReceivesBase = quantity;      // no fee is deducted while fees are disabled
+        var sellerReceivesQuote = quoteQuantity;
 
         await using var tx = await _context.Database.BeginTransactionAsync();
         try

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -224,6 +224,14 @@ public class WalletRepository : IWalletRepository
         if (feeBuyer < 0 || feeSeller < 0)
             return (false, "Fees cannot be negative.");
 
+        // دفاع در عمق: تطبیق نباید اجازهٔ خودمعاملگی بدهد، اما اگر مسیری آن را دور بزند
+        // تسویه روی یک کیف پول مشترک انجام می‌شود و رد حسابرسی نادرست تولید می‌کند.
+        if (buyerUserId == sellerUserId)
+        {
+            _logger.LogError("Refusing to settle trade {TradeId}: buyer and seller are the same user.", tradeId);
+            return (false, "Buyer and seller must be different users.");
+        }
+
         // Fail closed on fees. Settlement debits each payer the full amount but would
         // credit the receiver the amount minus the fee — and the difference is credited
         // to NO account, so a non-zero fee silently destroys money on every trade.

--- a/src/Wallet/Wallet.Tests/CurrencyRoundingTests.cs
+++ b/src/Wallet/Wallet.Tests/CurrencyRoundingTests.cs
@@ -1,0 +1,69 @@
+using TallaEgg.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Tests for CurrenciesConstant.RoundToCurrencyPrecision.
+///
+/// Monetary amounts are computed as quantity × price, which for gold produces long
+/// fractional tails (a mesghal price divided by 4.3318 is not exact). Toman has no
+/// sub-unit, so those tails are meaningless — and worse, if the amount locked at order
+/// time and the amount settled later are rounded differently, a residual is left behind
+/// in LockedBalance. These tests pin the rounding contract both sides rely on.
+/// </summary>
+public class CurrencyRoundingTests
+{
+    [Fact]
+    public void Toman_IsRoundedToWholeUnits()
+    {
+        // The exact value observed in production logs: 79,000,000 per mesghal / 4.3318 × 10,000.
+        var raw = 182372224017.72935038552103052m;
+
+        var rounded = CurrenciesConstant.RoundToCurrencyPrecision(raw, CurrenciesConstant.Toman);
+
+        Assert.Equal(182372224018m, rounded);
+        Assert.Equal(0m, rounded % 1m); // no fractional part survives
+    }
+
+    [Fact]
+    public void Gold_IsRoundedToTwoDecimals()
+    {
+        var rounded = CurrenciesConstant.RoundToCurrencyPrecision(8.456789m, CurrenciesConstant.Maua);
+
+        Assert.Equal(8.46m, rounded);
+    }
+
+    [Fact]
+    public void Rounding_UsesAwayFromZero_NotBankersRounding()
+    {
+        // Banker's rounding would give 2 here; financial rounding must give 3.
+        Assert.Equal(3m, CurrenciesConstant.RoundToCurrencyPrecision(2.5m, CurrenciesConstant.Toman));
+        // And symmetrically for negative amounts, which occur on credit-backed balances.
+        Assert.Equal(-3m, CurrenciesConstant.RoundToCurrencyPrecision(-2.5m, CurrenciesConstant.Toman));
+    }
+
+    [Fact]
+    public void LockAndSettlementAmounts_AgreeAfterRounding()
+    {
+        // The residual bug: a buy order locks quantity × price, and settlement later
+        // consumes the trade's quoteQuantity. Computed independently at full precision the
+        // two can differ; rounded through the same helper they must be identical.
+        const decimal quantity = 12m;
+        const decimal pricePerGram = 18237222.401772935038552103052m;
+
+        var lockedAtOrderTime = CurrenciesConstant.RoundToCurrencyPrecision(quantity * pricePerGram, CurrenciesConstant.Toman);
+        var settledAtTradeTime = CurrenciesConstant.RoundToCurrencyPrecision(quantity * pricePerGram, CurrenciesConstant.Toman);
+
+        Assert.Equal(lockedAtOrderTime, settledAtTradeTime);
+        Assert.Equal(0m, lockedAtOrderTime - settledAtTradeTime); // no residual left locked
+    }
+
+    [Fact]
+    public void UnknownAsset_IsReturnedUnchanged()
+    {
+        // Defensive: an unrecognised asset must not silently lose precision.
+        var raw = 1.23456789m;
+
+        Assert.Equal(raw, CurrenciesConstant.RoundToCurrencyPrecision(raw, "NOT_A_REAL_ASSET"));
+    }
+}

--- a/src/Wallet/Wallet.Tests/OutboxMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxMessageTests.cs
@@ -1,0 +1,94 @@
+using Orders.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Tests for the OutboxMessage state machine, in particular the re-drive path added for
+/// stuck settlements: when a message exhausts its retries the trade is already recorded
+/// but unsettled, with collateral still locked, so an operator must be able to queue it
+/// again once the underlying cause is fixed.
+/// </summary>
+public class OutboxMessageTests
+{
+    private const int MaxRetries = 5;
+    private static readonly TimeSpan BaseDelay = TimeSpan.FromSeconds(10);
+
+    private static OutboxMessage NewMessage() =>
+        OutboxMessage.Create("TradeSettlement", Guid.NewGuid(), "{}");
+
+    private static OutboxMessage FailedMessage()
+    {
+        var message = NewMessage();
+        for (var i = 0; i < MaxRetries; i++)
+            message.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+        return message;
+    }
+
+    [Fact]
+    public void MarkAttemptFailed_BecomesFailed_OnlyAfterRetriesAreExhausted()
+    {
+        var message = NewMessage();
+
+        for (var i = 1; i < MaxRetries; i++)
+        {
+            message.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+            Assert.Equal(OutboxMessageStatus.Pending, message.Status);
+            Assert.NotNull(message.NextAttemptAt); // still scheduled for another attempt
+        }
+
+        message.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+
+        Assert.Equal(OutboxMessageStatus.Failed, message.Status);
+        Assert.Null(message.NextAttemptAt); // no longer picked up by the processor
+    }
+
+    [Fact]
+    public void MarkAttemptFailed_BacksOffExponentially()
+    {
+        var message = NewMessage();
+
+        message.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+        var afterFirst = message.NextAttemptAt!.Value;
+
+        message.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+        var afterSecond = message.NextAttemptAt!.Value;
+
+        // The second wait must be materially longer than the first.
+        Assert.True(afterSecond > afterFirst,
+            $"expected a longer delay after the second failure (first={afterFirst:O}, second={afterSecond:O})");
+    }
+
+    [Fact]
+    public void ResetForRetry_RequeuesAFailedMessageWithAFreshBudget()
+    {
+        var message = FailedMessage();
+        Assert.Equal(OutboxMessageStatus.Failed, message.Status);
+
+        message.ResetForRetry();
+
+        Assert.Equal(OutboxMessageStatus.Pending, message.Status);
+        Assert.Equal(0, message.RetryCount);      // a fresh set of attempts
+        Assert.NotNull(message.NextAttemptAt);    // due immediately
+        Assert.Null(message.ProcessedAt);
+    }
+
+    [Fact]
+    public void ResetForRetry_RefusesACompletedMessage()
+    {
+        // Reviving a completed settlement would be an attempt to settle the same trade
+        // twice. Settlement is idempotent, but the operation should still be rejected.
+        var message = NewMessage();
+        message.MarkCompleted();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => message.ResetForRetry());
+        Assert.Contains("Completed", ex.Message);
+    }
+
+    [Fact]
+    public void ResetForRetry_RefusesAPendingMessage()
+    {
+        var message = NewMessage();
+
+        Assert.Throws<InvalidOperationException>(() => message.ResetForRetry());
+    }
+}

--- a/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
+++ b/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
@@ -135,6 +135,31 @@ public class SettleTradeAsyncTests : IDisposable
     }
 
     [Fact]
+    public async Task SettleTradeAsync_WithNonZeroFee_RefusesAndChangesNothing()
+    {
+        // Settlement debits the payer in full but would credit the receiver net of the fee,
+        // with the fee going nowhere — so a non-zero fee destroys money. Until fees are
+        // credited to a fee account (issue #35), settlement must fail closed rather than leak.
+        SeedFullyLockedWallets();
+        var tradeId = Guid.NewGuid();
+
+        var (success, message) = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}",
+            Quantity, QuoteQuantity, feeBuyer: 0.5m, feeSeller: 0m);
+
+        Assert.False(success, "settlement must refuse a non-zero fee");
+        Assert.Contains("Fee crediting is not implemented", message);
+
+        // Nothing moved and nothing was recorded.
+        var buyerBase = await ReloadAsync(_buyerId, Base);
+        Assert.Equal(0m, buyerBase.Balance);
+        var sellerBase = await ReloadAsync(_sellerId, Base);
+        Assert.Equal(Quantity, sellerBase.LockedBalance);
+        var count = await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString());
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
     public async Task SettleTradeAsync_WhenCollateralNotLocked_FailsAndChangesNothing()
     {
         // Buyer's IRT was never locked — simulates the lock-after-match ordering bug (C-5).

--- a/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
+++ b/src/Wallet/Wallet.Tests/SettleTradeAsyncTests.cs
@@ -135,6 +135,26 @@ public class SettleTradeAsyncTests : IDisposable
     }
 
     [Fact]
+    public async Task SettleTradeAsync_WhenBuyerIsTheSeller_RefusesAndChangesNothing()
+    {
+        // Matching now blocks self-matching, but settlement guards it too: with one user on
+        // both sides the two "different" wallets resolve to the same tracked entity, which
+        // produces an incoherent balance history even though the trade nets out.
+        SeedFullyLockedWallets();
+        var tradeId = Guid.NewGuid();
+
+        var (success, message) = await _repository.SettleTradeAsync(
+            tradeId, _buyerId, _buyerId, $"{Base}/{Quote}",
+            Quantity, QuoteQuantity, 0m, 0m);
+
+        Assert.False(success, "settlement must refuse a self-trade");
+        Assert.Contains("must be different users", message);
+
+        var count = await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString());
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
     public async Task SettleTradeAsync_WithNonZeroFee_RefusesAndChangesNothing()
     {
         // Settlement debits the payer in full but would credit the receiver net of the fee,

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Wallet.Core\Wallet.Core.csproj" />
     <ProjectReference Include="..\Wallet.Infrastructure\Wallet.Infrastructure.csproj" />
+    <!-- OutboxMessage lives on the Orders side; its state machine is unit-tested here
+         until a dedicated Orders.Tests project exists (issue #46). -->
+    <ProjectReference Include="..\..\Order\Orders.Core\Orders.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Four financial-safety fixes found during the review and live testing of the settlement work. Each is a separate commit.

Closes #43, closes #37, closes #47, closes #39. Also fixes the error-truncation half of #44.

## Type
- [x] Bug fixes (money path)

## 1. Refuse settlement with non-zero fees — #43
Settlement debits each payer in full but credits the receiver the amount **minus** the fee, and the fee is credited to no account — so any non-zero fee silently destroys money on every trade. Fee rates are 0 for the MVP, so the defect was dormant, but nothing stopped someone restoring the previous `0.1%/0.2%` rates and quietly leaking value.

Settlement now fails closed with an explicit error and an `ERR` log. The guard is inert while fees are 0 and must be removed only together with crediting fees to the fee account (#35).

## 2. Round monetary amounts to currency precision — #37
`quantity × price` was carried at full decimal precision, producing ~18 fractional digits (a mesghal price ÷ 4.3318 is never exact). Toman has no sub-unit and the DB columns are `decimal(28,8)`, so the tail was meaningless and silently truncated. Worse, the amount **locked** at order time and the amount **settled** at trade time were computed independently and could disagree, leaving a residual in `LockedBalance` — observed live as a ~2.27 toman lock/unlock mismatch.

Adds `CurrenciesConstant.RoundToCurrencyPrecision` (AwayFromZero, per-asset `DecimalPlaces`) and applies it at the two sites that must agree.

## 3. Enforce counterparty rules — #47
Nothing prevented two customers matching each other, or a user matching their own orders. At this stage the admin is meant to be the counterparty to every customer trade, but that was a convention, not a rule.

`IsAllowedCounterparty` is applied at the single point where match candidates are selected:
- **Self-matching is always rejected** — it nets out economically but produces an incoherent audit trail (both "sides" resolve to one wallet) and could manufacture fake volume.
- **Requiring the market maker on one side is opt-in** via `Matching:RequireMarketMakerCounterparty` + `Matching:MarketMakerUserId`, so peer-to-peer trading is later enabled by turning the setting **off** rather than deleting code. If the flag is set without a user id the rule stays off and logs an error, so matching can never be silently disabled.

Rejected candidates are skipped for that pass only; the orders stay open. Settlement also refuses a trade whose buyer and seller are the same user, as defence in depth.

## 4. Surface and re-drive stuck settlements — #39
When a settlement exhausted its retries it was marked `Failed` and abandoned, but the trade was already recorded and collateral stayed locked. Nothing listed those trades and there was no way to settle them after a fix. **Three such trades are sitting in the dev database** from the fee/credit bugs found earlier.

- `OutboxMessage.ResetForRetry()` requeues a failed message with a fresh retry budget. Only a `Failed` message can be re-driven — reviving a `Completed` one would be an attempt to settle the same trade twice. Safe because settlement is idempotent on the trade id.
- `GET /api/outbox/unsettled` lists every settlement that never completed, with status, retry count and last error.
- `POST /api/outbox/{id}/redrive` and `POST /api/outbox/redrive-all-failed` queue them again.
- The permanent-failure log now states plainly that a trade is unsettled with collateral locked, and names the endpoint to call.

Also truncates the stored error to fit its column (**#44**): an over-long exception message made `SaveChanges` throw *outside* the per-message try/catch, discarding the retry bookkeeping and leaving the message `Pending` forever — so it never reached `Failed` and never raised the alert.

## Testing
`Wallet.Tests`: **22/22 pass** (was 16). New coverage:
- non-zero fee is refused and changes nothing
- self-trade settlement is refused
- rounding: toman to whole units, gold to 2 dp, AwayFromZero on both signs, lock and settlement amounts agree, unknown asset untouched
- outbox state machine: Failed only after retries exhausted, exponential backoff, re-drive resets the budget, Completed/Pending refuse to be re-driven

Full solution builds with 0 errors.

## Notes for the reviewer
- Review depth **level 3** (money path) per `docs/process/CODE_REVIEW_GUIDE.md`.
- No schema change; no migration needed.
- The market-maker rule is **off by default** — enabling it needs `Matching:MarketMakerUserId` set to the admin's user id. Until then only the self-match rule is active.
- The three stuck trades in the dev database can now be cleared with `POST /api/outbox/redrive-all-failed` once the services are running.
