### PR TITLE
fix(matching): buyer and seller were inverted, settling trades in the wrong direction

### DIFF
--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -442,11 +442,14 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     {
         try
         {
-            // Create trade with enhanced Maker/Taker logic
-            var trade = CreateMakerTakerTrade(makerOrder, takerOrder, quantity);
-            
-            // Execute atomic match (the method will create its own trade)
-            var result = await matchingRepository.ExecuteAtomicMatchAsync(makerOrder, takerOrder, quantity);
+            // ExecuteAtomicMatchAsync takes (buyOrder, sellOrder) — NOT (maker, taker).
+            // Passing maker/taker positionally compiles (both are Order) but silently swaps
+            // the roles whenever the resting order is a sell, which recorded the trade with
+            // buyer and seller inverted and settled it in the wrong direction.
+            var buyOrder = makerOrder.Side == OrderSide.Buy ? makerOrder : takerOrder;
+            var sellOrder = makerOrder.Side == OrderSide.Buy ? takerOrder : makerOrder;
+
+            var result = await matchingRepository.ExecuteAtomicMatchAsync(buyOrder, sellOrder, quantity);
             
             if (result.Success)
             {
@@ -482,13 +485,11 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     {
         try
         {
-            // Determine Maker/Taker based on timestamp
-            var isBuyOrderMaker = buyOrder.CreatedAt <= sellOrder.CreatedAt;
-            var makerOrder = isBuyOrderMaker ? buyOrder : sellOrder;
-            var takerOrder = isBuyOrderMaker ? sellOrder : buyOrder;
-
-            // Execute with standard method (it will create trade internally)
-            return await matchingRepository.ExecuteAtomicMatchAsync(makerOrder, takerOrder, quantity);
+            // ExecuteAtomicMatchAsync takes (buyOrder, sellOrder). Maker/taker is derived
+            // inside it from the order timestamps, so the orders must be passed by SIDE,
+            // never by maker/taker role — doing the latter inverts buyer and seller
+            // whenever the resting order is a sell.
+            return await matchingRepository.ExecuteAtomicMatchAsync(buyOrder, sellOrder, quantity);
         }
         catch (Exception ex)
         {

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -91,11 +91,29 @@ public class OrderMatchingRepository
     /// </summary>
     public async Task<(bool Success, Trade? Trade, string ErrorMessage)> ExecuteAtomicMatchAsync(
         Order buyOrder, 
-        Order sellOrder, 
+        Order sellOrder,
         decimal matchQuantity)
     {
+        // Both parameters are Order, so passing them in the wrong order compiles silently.
+        // That happened: callers passed (maker, taker) instead of (buy, sell), which inverted
+        // buyer and seller whenever the resting order was a sell — the trade was then settled
+        // in the wrong direction, giving the gold to the seller and the money to the buyer.
+        // Fail loudly rather than record an inverted trade.
+        if (buyOrder.Side != OrderSide.Buy)
+        {
+            _logger.LogError("ExecuteAtomicMatchAsync received order {OrderId} with side {Side} as the BUY order.",
+                buyOrder.Id, buyOrder.Side);
+            return (false, null, $"سفارش خرید نامعتبر است: سمت سفارش {buyOrder.Side} است.");
+        }
+        if (sellOrder.Side != OrderSide.Sell)
+        {
+            _logger.LogError("ExecuteAtomicMatchAsync received order {OrderId} with side {Side} as the SELL order.",
+                sellOrder.Id, sellOrder.Side);
+            return (false, null, $"سفارش فروش نامعتبر است: سمت سفارش {sellOrder.Side} است.");
+        }
+
         using var transaction = await _context.Database.BeginTransactionAsync();
-        
+
         try
         {
             // 1. Re-fetch orders with lock to ensure they haven't changed

--- a/src/Wallet/Wallet.Tests/AtomicMatchRoleTests.cs
+++ b/src/Wallet/Wallet.Tests/AtomicMatchRoleTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core.Enums.Order;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Tests that a matched trade records the buyer and the seller the right way round.
+///
+/// This covers a bug that reached production data: ExecuteAtomicMatchAsync takes
+/// (buyOrder, sellOrder), but callers passed (makerOrder, takerOrder). Both parameters
+/// are <see cref="Order"/>, so the mistake compiled silently and only inverted the roles
+/// when the resting order happened to be a sell. The trade was then settled in the wrong
+/// direction — the seller received the gold and the buyer received the money.
+///
+/// The existing settlement tests could not catch this because they pass buyerUserId and
+/// sellerUserId directly, i.e. below the layer where the inversion happened.
+/// </summary>
+public class AtomicMatchRoleTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly OrdersDbContext _context;
+    private readonly OrderMatchingRepository _repository;
+
+    private readonly Guid _buyerId = Guid.NewGuid();
+    private readonly Guid _sellerId = Guid.NewGuid();
+
+    private const string Symbol = "MAUA/IRT";
+    private const decimal Price = 20_000_000m;
+    private const decimal Quantity = 10m;
+
+    public AtomicMatchRoleTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<OrdersDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _context = new OrdersDbContext(options);
+        _context.Database.EnsureCreated();
+        _repository = new OrderMatchingRepository(_context, NullLogger<OrderMatchingRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private Order AddOrder(Guid userId, OrderSide side, DateTime createdAt)
+    {
+        var order = Order.CreateMakerOrder(Symbol, Quantity, Price, userId, side, TradingType.Spot);
+        // Force the timestamp so which side is the resting (maker) order is deterministic.
+        typeof(Order).GetProperty(nameof(Order.CreatedAt))!
+            .SetValue(order, createdAt);
+        order.Confirm();
+        _context.Orders.Add(order);
+        _context.SaveChanges();
+        return order;
+    }
+
+    /// <summary>
+    /// The resting order is the SELL — the exact case that used to invert the roles.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAtomicMatch_WhenSellOrderIsResting_RecordsRolesCorrectly()
+    {
+        var sell = AddOrder(_sellerId, OrderSide.Sell, DateTime.UtcNow.AddMinutes(-5)); // resting
+        var buy = AddOrder(_buyerId, OrderSide.Buy, DateTime.UtcNow);                   // incoming
+
+        var (success, trade, error) = await _repository.ExecuteAtomicMatchAsync(buy, sell, Quantity);
+
+        Assert.True(success, error);
+        Assert.NotNull(trade);
+        Assert.Equal(_buyerId, trade!.BuyerUserId);
+        Assert.Equal(_sellerId, trade.SellerUserId);
+        Assert.Equal(buy.Id, trade.BuyOrderId);
+        Assert.Equal(sell.Id, trade.SellOrderId);
+    }
+
+    /// <summary>The mirror case: the resting order is the BUY.</summary>
+    [Fact]
+    public async Task ExecuteAtomicMatch_WhenBuyOrderIsResting_RecordsRolesCorrectly()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, DateTime.UtcNow.AddMinutes(-5));  // resting
+        var sell = AddOrder(_sellerId, OrderSide.Sell, DateTime.UtcNow);              // incoming
+
+        var (success, trade, error) = await _repository.ExecuteAtomicMatchAsync(buy, sell, Quantity);
+
+        Assert.True(success, error);
+        Assert.Equal(_buyerId, trade!.BuyerUserId);
+        Assert.Equal(_sellerId, trade.SellerUserId);
+    }
+
+    /// <summary>
+    /// The structural guard: passing the orders the wrong way round must fail loudly
+    /// instead of recording an inverted trade.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAtomicMatch_WhenOrdersArePassedSwapped_IsRejected()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, DateTime.UtcNow.AddMinutes(-5));
+        var sell = AddOrder(_sellerId, OrderSide.Sell, DateTime.UtcNow);
+
+        // Deliberately swapped — this is what the buggy callers were doing.
+        var (success, trade, error) = await _repository.ExecuteAtomicMatchAsync(sell, buy, Quantity);
+
+        Assert.False(success, "a swapped call must be rejected, not recorded");
+        Assert.Null(trade);
+        Assert.Contains("سفارش خرید نامعتبر است", error);
+        Assert.Empty(_context.Trades);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -23,6 +23,7 @@
     <!-- OutboxMessage lives on the Orders side; its state machine is unit-tested here
          until a dedicated Orders.Tests project exists (issue #46). -->
     <ProjectReference Include="..\..\Order\Orders.Core\Orders.Core.csproj" />
+    <ProjectReference Include="..\..\Order\Orders.Infrastructure\Orders.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
A matched trade could be recorded with the buyer and the seller swapped, and was then settled in the wrong direction: **the seller received the gold and the buyer received the money.**

Found by driving a controlled trade through the running services and snapshotting the databases at each step, after the "insufficient locked collateral" rejections did not add up.

## Type
- [x] Bug fix (money path — wrong-direction settlement)

## Root cause
`ExecuteAtomicMatchAsync` takes `(buyOrder, sellOrder)`, but both call sites passed `(makerOrder, takerOrder)`:

```csharp
var makerOrder = isBuyOrderMaker ? buyOrder : sellOrder;
var takerOrder = isBuyOrderMaker ? sellOrder : buyOrder;
await matchingRepository.ExecuteAtomicMatchAsync(makerOrder, takerOrder, quantity);   // wrong
```

Both parameters are `Order`, so the mistake compiled silently. It only inverted the roles when the **resting (maker) order was a sell** — when the resting order was a buy, maker/taker happened to coincide with buy/sell and the trade was correct. So roughly half of all trades were inverted, depending on which side rested first.

## Evidence from real data
Trade `db27d38d`, verified against the underlying orders:

| Party | Order they actually placed | Should have | **What happened** |
|---|---|---|---|
| `ACE3A6E8` | **Sell** 8g | give gold, receive toman | received 8 MAUA, paid 146,821,182.88 IRT |
| `594F5182` | **Buy** 8g | pay toman, receive gold | received 146,821,182.88 IRT, paid 8 MAUA |

The stored `Trade` had `BuyOrderId` pointing at a **sell** order and `SellOrderId` at a **buy** order.

This also explains the `"Seller locked MAUA (4.00) is less than required (12.00)"` rejections that started the investigation: settlement was checking the collateral of the wrong side, so a buyer holding no gold looked like a seller short of gold. The lock guard was working correctly — it was being handed inverted roles, and it prevented several wrong-direction settlements from completing.

## Changes
- Both call sites now select the orders by `Side` instead of by maker/taker role. Maker/taker is still derived inside `ExecuteAtomicMatchAsync` from the timestamps, which is where it belongs.
- `ExecuteAtomicMatchAsync` validates that the orders it received actually have the sides its parameters claim, and refuses the match otherwise. A future positional mistake now fails loudly instead of silently recording an inverted trade.

## Testing
`Wallet.Tests`: **25/25 pass** (was 22). Three new tests in `AtomicMatchRoleTests`:
- resting **sell** order — the case that used to invert
- resting **buy** order — the mirror case
- a deliberately swapped call is rejected and records nothing

Verified the tests actually catch the bug: temporarily disabling the guard made the swapped test fail (1 failed / 3), then restored.

## Why existing tests missed it
`SettleTradeAsyncTests` passes `buyerUserId` and `sellerUserId` directly — below the layer where the inversion occurred. The matching layer had no tests at all, which is the gap tracked in #46.

## Note on data
All trading data in the dev databases was created by the buggy code and has been cleared (orders, trades, outbox, wallet transactions; balances zeroed). Users were kept. Testing restarts from a clean state.
