### PR TITLE
fix(#53): register the matching engine once so its concurrency guard works

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -106,9 +106,9 @@ builder.Services.AddCors();
 
 builder.Services.AddScoped<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>();
 
-// Add Matching Engine
-builder.Services.AddScoped<IMatchingEngine, Orders.Application.Services.MatchingEngineService>();
-builder.Services.AddHostedService<Orders.Application.Services.MatchingEngineService>();
+// Add Matching Engine — یک نمونهٔ واحد (issue #53). جزئیات و دلیلش در
+// MatchingEngineRegistration نوشته شده، که تست‌ها هم از همان استفاده می‌کنند.
+builder.Services.AddMatchingEngine();
 
 // Outbox processor: reliably delivers trade settlements to the Wallet service.
 builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();

--- a/src/Order/Orders.Application/IMatchingEngine.cs
+++ b/src/Order/Orders.Application/IMatchingEngine.cs
@@ -7,6 +7,9 @@ public interface IMatchingEngine
     Task ProcessOrderAsync(Order order, CancellationToken cancellationToken = default);
     Task ProcessOrderAsync(Guid orderId, CancellationToken cancellationToken = default);
     Task ProcessAllPendingOrdersAsync(CancellationToken cancellationToken = default);
-    Task StartAsync(CancellationToken cancellationToken);
-    Task StopAsync(CancellationToken cancellationToken);
+
+    // StartAsync/StopAsync عمداً اینجا نیستند. چرخهٔ حیات موتور تطبیق را میزبان
+    // (IHostedService) مدیریت می‌کند. حالا که فقط یک نمونه از موتور وجود دارد
+    // (issue #53)، در معرض گذاشتن StopAsync یعنی هر مصرف‌کننده‌ای می‌توانست تطبیق
+    // را برای کل پروسه خاموش کند.
 }

--- a/src/Order/Orders.Application/MatchingEngineRegistration.cs
+++ b/src/Order/Orders.Application/MatchingEngineRegistration.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orders.Application.Services;
+
+namespace Orders.Application;
+
+/// <summary>
+/// ثبت موتور تطبیق در DI.
+///
+/// این کار عمداً در یک متد مشترک قرار گرفته تا هم <c>Orders.Api</c> و هم تست‌ها
+/// دقیقاً از یک مسیر استفاده کنند. اگر ثبت مستقیماً در <c>Program.cs</c> نوشته شود،
+/// تست فقط یک کپی از آن را می‌سنجد و اگر روزی <c>Program.cs</c> تغییر کند تست همچنان
+/// سبز می‌ماند — یعنی دقیقاً همان چیزی را که باید محافظت کند از دست می‌دهد.
+/// </summary>
+public static class MatchingEngineRegistration
+{
+    /// <summary>
+    /// موتور تطبیق را به‌صورت <b>یک نمونهٔ واحد</b> ثبت می‌کند و همان نمونه را هم
+    /// به‌عنوان <see cref="IMatchingEngine"/> (برای تزریق) و هم به‌عنوان
+    /// <c>IHostedService</c> (برای حلقهٔ پس‌زمینه) در دسترس می‌گذارد.
+    ///
+    /// پیش‌تر این سرویس دو بار جداگانه ثبت شده بود؛ نتیجه دو موتور مستقل با دو
+    /// <see cref="SemaphoreSlim"/> جدا بود، و سمافوری که برای جلوگیری از پردازش
+    /// همزمان نوشته شده بود عملاً هیچ چیزی را محافظت نمی‌کرد (issue #53).
+    ///
+    /// Singleton بودن امن است چون <see cref="MatchingEngineService"/> برای هر دسترسی
+    /// به دیتابیس با <c>IServiceScopeFactory</c> اسکوپ خودش را می‌سازد. وابستگی یک
+    /// سرویس Scoped مثل <c>OrderService</c> به یک Singleton مجاز است؛ عکسش نه.
+    /// </summary>
+    public static IServiceCollection AddMatchingEngine(this IServiceCollection services)
+    {
+        services.AddSingleton<MatchingEngineService>();
+        services.AddSingleton<IMatchingEngine>(sp => sp.GetRequiredService<MatchingEngineService>());
+        services.AddHostedService(sp => sp.GetRequiredService<MatchingEngineService>());
+
+        return services;
+    }
+}

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -109,23 +109,20 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         finally
         {
             _isRunning = false;
-            _processingSemaphore.Dispose();
             _logger.LogInformation("🛑 Matching Engine Service has stopped");
         }
     }
 
-    public new Task StartAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// سمافور اینجا آزاد می‌شود، نه در انتهای ExecuteAsync. این نمونه بین حلقهٔ
+    /// پس‌زمینه و مسیر درخواست‌ها مشترک است (issue #53)، پس اگر همزمان با توقف
+    /// حلقه Dispose می‌شد، درخواستی که در همان لحظه در حال پردازش بود
+    /// ObjectDisposedException می‌گرفت.
+    /// </summary>
+    public override void Dispose()
     {
-        _isRunning = true;
-        _logger.LogInformation("▶️ Matching Engine started manually");
-        return Task.CompletedTask;
-    }
-
-    public new Task StopAsync(CancellationToken cancellationToken)
-    {
-        _isRunning = false;
-        _logger.LogInformation("⏸️ Matching Engine stopped manually");
-        return Task.CompletedTask;
+        _processingSemaphore.Dispose();
+        base.Dispose();
     }
 
     /// <summary>

--- a/src/Wallet/Wallet.Tests/MatchingEngineRegistrationTests.cs
+++ b/src/Wallet/Wallet.Tests/MatchingEngineRegistrationTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The matching engine must exist exactly once per process.
+///
+/// It used to be registered twice — <c>AddScoped&lt;IMatchingEngine&gt;</c> for injection into
+/// OrderService, and <c>AddHostedService</c> for the background loop — which produced two
+/// independent engines. Its <c>SemaphoreSlim</c> guard is an instance field, so each engine
+/// held its own and the two never excluded each other: the background loop and the
+/// order-placement path could match the same orders concurrently. Nothing underneath caught
+/// it either (no row lock, no concurrency token), so a single order could fill twice, once
+/// per engine, producing two Trades with different ids that both settle. See issue #53.
+///
+/// This is a wiring test rather than a timing test on purpose. The defect is in the
+/// registration, and a test that tried to provoke the race would be slow, flaky, and would
+/// still not pin down what must stay true.
+/// </summary>
+public class MatchingEngineRegistrationTests
+{
+    /// <summary>
+    /// Calls the very same <c>AddMatchingEngine</c> that <c>Orders.Api/Program.cs</c> calls, so
+    /// this test covers the production wiring rather than a copy of it that could drift.
+    /// </summary>
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder().AddInMemoryCollection().Build());
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+
+        services.AddMatchingEngine();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void HostedInstanceAndInjectedInstance_AreTheSameObject()
+    {
+        using var provider = BuildProvider();
+
+        var hosted = provider.GetServices<IHostedService>().OfType<MatchingEngineService>().Single();
+
+        using var scope = provider.CreateScope();
+        var injected = scope.ServiceProvider.GetRequiredService<IMatchingEngine>();
+
+        Assert.Same(hosted, injected);
+    }
+
+    /// <summary>
+    /// Two separate request scopes must not each get their own engine — that was the shape of
+    /// the original bug, where N concurrent requests meant N semaphores.
+    /// </summary>
+    [Fact]
+    public void SeparateScopes_ResolveTheSameEngine()
+    {
+        using var provider = BuildProvider();
+
+        using var scopeA = provider.CreateScope();
+        using var scopeB = provider.CreateScope();
+
+        var a = scopeA.ServiceProvider.GetRequiredService<IMatchingEngine>();
+        var b = scopeB.ServiceProvider.GetRequiredService<IMatchingEngine>();
+
+        Assert.Same(a, b);
+    }
+
+    /// <summary>
+    /// The engine's lifetime belongs to the host. Exposing StopAsync on IMatchingEngine would
+    /// let any consumer disable matching for the whole process now that the instance is shared.
+    /// </summary>
+    [Fact]
+    public void IMatchingEngine_DoesNotExposeLifecycleControl()
+    {
+        var methods = typeof(IMatchingEngine).GetMethods().Select(m => m.Name).ToArray();
+
+        Assert.DoesNotContain("StartAsync", methods);
+        Assert.DoesNotContain("StopAsync", methods);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -24,6 +24,7 @@
          until a dedicated Orders.Tests project exists (issue #46). -->
     <ProjectReference Include="..\..\Order\Orders.Core\Orders.Core.csproj" />
     <ProjectReference Include="..\..\Order\Orders.Infrastructure\Orders.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Order\Orders.Application\Orders.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #53.

## Description

The process ran **two independent matching engines**, so the `SemaphoreSlim` written to "prevent concurrent processing" prevented nothing.

```csharp
// before — Orders.Api/Program.cs
builder.Services.AddScoped<IMatchingEngine, MatchingEngineService>();   // new instance per HTTP request
builder.Services.AddHostedService<MatchingEngineService>();             // one long-lived instance
```

The background loop (every 1 s) and the order-placement path each held their **own** semaphore, so both acquired immediately and could match the same orders concurrently. Because the registration was *scoped*, N concurrent placements meant N engines and N semaphores.

## Type
- [x] Bug fix (money path — a double-match settles twice)

## Why it mattered

Nothing underneath the semaphore caught the race:

- `GetBuyOrdersWithLockAsync` / `GetSellOrdersWithLockAsync` are named and documented as pessimistic locks but are plain LINQ queries — **no lock of any kind**.
- No `RowVersion` / concurrency token anywhere in the Orders model.
- `ExecuteAtomicMatchAsync` uses the default isolation level, and its re-fetch plus `Math.Min(..., RemainingAmount)` is a read-then-write. EF writes the row back as a full-row UPDATE, not a relative decrement.

So two engines could both read `RemainingAmount = 10`, both write `0`, and both create a Trade. Settlement idempotency is keyed on `Trade.Id`, and a double-match produces **two different ids** — so both would settle. This is a different failure from #42 and is not mitigated by it.

## Changes

**Single instance.** One `MatchingEngineService`, exposed both as `IMatchingEngine` and as the hosted service. Singleton is safe here: the service already creates its own scope via `IServiceScopeFactory` for every database access, which the constructor comment says was the intent. A scoped consumer (`OrderService`) depending on a singleton is valid.

**Registration moved into `MatchingEngineRegistration.AddMatchingEngine()`.** This is the part that makes the test meaningful: if the registration stayed inline in `Program.cs`, the test could only assert against a *copy* of it, and would stay green if `Program.cs` ever drifted back. Now the API and the tests call the same method.

**Semaphore disposal moved to `Dispose()`.** It was disposed at the end of `ExecuteAsync`. With one shared instance, that would break a request being processed at the moment the background loop stops.

**`StartAsync`/`StopAsync` removed from `IMatchingEngine`.** They were `new` methods (not overrides) that only flipped a bool. `IHostedService` dispatch always reached `BackgroundService`'s real implementations, so the loop did start — but with a shared instance, exposing `StopAsync` would let any consumer disable matching **process-wide**. Nothing called them.

## Testing

`Wallet.Tests`: **28/28 pass** (was 25). Three new tests in `MatchingEngineRegistrationTests`:

- the hosted instance and the injected instance are the same object
- two separate request scopes resolve the same engine
- `IMatchingEngine` exposes no lifecycle control

**Verified the tests catch the bug:** reverting `AddMatchingEngine` to the previous registration makes the first two fail, then restored.

```
Wallet.Tests.MatchingEngineRegistrationTests.SeparateScopes_ResolveTheSameEngine [FAIL]
Wallet.Tests.MatchingEngineRegistrationTests.HostedInstanceAndInjectedInstance_AreTheSameObject [FAIL]
Failed!  - Failed: 2, Passed: 1
```

These are wiring tests, not timing tests, on purpose: the defect is in the registration, and a test trying to provoke the race would be slow, flaky, and would pin down less.

**Runtime check:** full solution builds clean (0 errors), all six services restarted, and `Orders.Api` logs `🚀 Matching Engine Service is starting...` exactly **once** (it would have been ambiguous before), with 0 errors. Bot reconnected with 0 polling errors.

## Deliberately out of scope

Real row-level locking or a concurrency token in `ExecuteAtomicMatchAsync`, and renaming the misleading `...WithLockAsync` methods. Single-instancing closes the reachable race; database-level hardening is a larger change that belongs with #42. Recorded in #53 so the gap is not assumed fixed.

## Note

`src/Order/Orders.Tests/` contains test files but **no `.csproj`** and is not in the solution, so those tests have never run. The new tests therefore live in `Wallet.Tests`, following the precedent already documented in its csproj. Noted on #46.