### PR TITLE
fix(#38,#44): propagate the real settlement failure reason; stop one bad outbox row stalling the batch

### DIFF
--- a/src/Order/Orders.Application/Orders.Application.csproj
+++ b/src/Order/Orders.Application/Orders.Application.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- OutboxProcessorService.ProcessDueMessagesAsync is internal so its batch-resilience
+         behaviour (issue #44) can be tested without driving the background loop's timing. -->
+    <InternalsVisibleTo Include="Wallet.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -65,7 +65,11 @@ public class OutboxProcessorService : BackgroundService
         _logger.LogInformation("OutboxProcessorService stopped.");
     }
 
-    private async Task ProcessDueMessagesAsync(CancellationToken ct)
+    /// <summary>
+    /// internal rather than private so the batch-resilience behaviour required by issue #44
+    /// can be tested directly, without driving the timing of the background loop.
+    /// </summary>
+    internal async Task ProcessDueMessagesAsync(CancellationToken ct)
     {
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
@@ -116,7 +120,34 @@ public class OutboxProcessorService : BackgroundService
             }
 
             // Persist per message so a crash mid-batch never loses progress or double-marks.
-            await db.SaveChangesAsync(ct);
+            //
+            // This save has its own guard on purpose. It used to sit outside any try/catch, so a
+            // persistence failure on one message threw out of the whole loop: the generic handler
+            // logged "Unexpected error in the outbox processing loop" without naming the row, the
+            // in-memory RetryCount was discarded so the message never advanced towards Failed, and
+            // every remaining message in the batch was skipped for that cycle — one bad row could
+            // stall settlement for all the others. See issue #44.
+            try
+            {
+                await db.SaveChangesAsync(ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception saveEx)
+            {
+                _logger.LogError(saveEx,
+                    "Could not persist the outcome of outbox message {Id} (trade {AggregateId}). " +
+                    "Its state is unchanged and it will be retried; continuing with the rest of the batch.",
+                    message.Id, message.AggregateId);
+
+                // Detach only THIS message, so the next message's save does not retry the write
+                // that just failed. Detaching everything would also drop the messages still to be
+                // processed in this batch, silently leaving them Pending — which is the very
+                // stall this guard exists to prevent.
+                db.Entry(message).State = EntityState.Detached;
+            }
         }
     }
 

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -519,10 +519,12 @@ public class WalletApiClient : IWalletApiClient
         }
     }
     /// <summary>
-    /// بعد از اینکه معامله‌ای انجام شد، باید تراکنش معامله ثبت و بالانس‌ها به‌روزرسانی شوند
+    /// بعد از اینکه معامله‌ای انجام شد، باید تراکنش معامله ثبت و بالانس‌ها به‌روزرسانی شوند.
+    ///
+    /// دلیل رد شدن تسویه باید عیناً به فراخوان برسد. پیش‌تر هر خطایی به یک پیام عمومی
+    /// تبدیل می‌شد، پس پردازشگر outbox هیچ‌وقت نمی‌فهمید مشکل واقعی چه بوده و همان
+    /// رشتهٔ بی‌فایده در LastError ذخیره می‌شد (issue #38).
     /// </summary>
-    /// <param name="trade"></param>
-    /// <returns></returns>
     public async Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade)
     {
         try
@@ -531,22 +533,59 @@ public class WalletApiClient : IWalletApiClient
             var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync("api/wallet/changeBalance", stringContent);
+            var body = await response.Content.ReadAsStringAsync();
+
+            // endpoint در هر دو حالت موفق و ناموفق یک ApiResponse برمی‌گرداند و پیام
+            // دقیق تسویه در Message آن است.
+            var parsed = TryParseMessage(body);
 
             if (response.IsSuccessStatusCode)
             {
-                _logger.LogInformation("Successfully TradeTransactionAndBalanceChangeAsnc {Amount} {Asset} for user {UserId}");
-                return (true, "موجودی با موفقیت آزاد شد");
+                // _logger عمداً با ?. صدا زده می‌شود: یکی از سازنده‌های این کلاس logger
+                // نمی‌گیرد و آن را null می‌گذارد.
+                _logger?.LogInformation(
+                    "Trade {TradeId} settled by the wallet service. Symbol: {Symbol}, quantity: {Quantity}, quote: {QuoteQuantity}.",
+                    trade.Id, trade.Symbol, trade.Quantity, trade.QuoteQuantity);
+
+                return (true, parsed ?? "تسویهٔ معامله با موفقیت انجام شد.");
             }
-            else
-            {
-                _logger.LogWarning("Failed to TradeTransactionAndBalanceChangeAsnc for user {UserId}, asset {Asset}, amount {Amount}. Status: {Status}");
-                return (false, "خطا در آزاد کردن موجودی");
-            }
+
+            var reason = parsed ?? $"سرویس کیف پول کد {(int)response.StatusCode} برگرداند.";
+
+            _logger?.LogWarning(
+                "Wallet service rejected settlement of trade {TradeId} with status {StatusCode}: {Reason}",
+                trade.Id, (int)response.StatusCode, reason);
+
+            return (false, reason);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error TradeTransactionAndBalanceChangeAsnc for user {UserId}, asset {Asset}, amount {Amount}");
+            _logger?.LogError(ex, "Error settling trade {TradeId} against the wallet service.", trade.Id);
             return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// پیام را از بدنهٔ ApiResponse بیرون می‌کشد. اگر بدنه خالی یا غیرقابل‌تجزیه بود
+    /// null برمی‌گرداند تا فراخوان خودش یک پیام جایگزین بسازد — خواندن پیام هرگز نباید
+    /// خودش باعث شکست تسویه شود.
+    /// </summary>
+    private string? TryParseMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        try
+        {
+            var apiResponse = JsonSerializer.Deserialize<TallaEgg.Core.DTOs.ApiResponse<string>>(
+                body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return string.IsNullOrWhiteSpace(apiResponse?.Message) ? null : apiResponse.Message;
+        }
+        catch (JsonException)
+        {
+            _logger?.LogDebug("Wallet settlement response was not a parsable ApiResponse: {Body}", body);
+            return null;
         }
     }
 

--- a/src/Wallet/Wallet.Tests/OutboxBatchResilienceTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxBatchResilienceTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Infrastructure.Clients;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// One outbox message that cannot be persisted must not stall the rest of the batch.
+///
+/// The per-message SaveChangesAsync used to sit outside any try/catch. A failure there threw
+/// out of the whole loop: the generic handler logged "Unexpected error in the outbox
+/// processing loop" without naming the row, the in-memory RetryCount was discarded so the
+/// message never advanced towards Failed (and so never surfaced to an operator), and every
+/// message after it in the batch was skipped for that cycle. See issue #44.
+/// </summary>
+public class OutboxBatchResilienceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+
+    public OutboxBatchResilienceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var setup = new OrdersDbContext(Options()))
+            setup.Database.EnsureCreated();
+
+        var services = new ServiceCollection();
+        services.AddScoped<OrdersDbContext>(_ => new FailFirstSaveDbContext(Options()));
+        services.AddScoped<IWalletApiClient, AlwaysSettlesWalletClient>();
+        _provider = services.BuildServiceProvider();
+    }
+
+    private DbContextOptions<OrdersDbContext> Options() =>
+        new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    /// <summary>Fails the first SaveChangesAsync, then behaves normally.</summary>
+    private sealed class FailFirstSaveDbContext : OrdersDbContext
+    {
+        private bool _hasFailed;
+
+        public FailFirstSaveDbContext(DbContextOptions<OrdersDbContext> options) : base(options) { }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (!_hasFailed)
+            {
+                _hasFailed = true;
+                throw new DbUpdateException("simulated persistence failure");
+            }
+
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private sealed class AlwaysSettlesWalletClient : IWalletApiClient
+    {
+        public Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade) =>
+            Task.FromResult((true, "settled"));
+
+        public Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset) =>
+            throw new NotSupportedException();
+        public Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(Guid userId, string asset, decimal amount) =>
+            throw new NotSupportedException();
+        public Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount) =>
+            throw new NotSupportedException();
+        public Task<(bool Success, string Message)> IncreaseBalanceAsync(Guid userId, string asset, decimal amount) =>
+            throw new NotSupportedException();
+        public Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(Guid userId, string asset, decimal amount) =>
+            throw new NotSupportedException();
+        public Task<(bool Success, string Message, bool HasSufficientCreditAndBalanceBase, bool HasSufficientCreditAndBalanceQuote)>
+            ValidateCreditAndBalanceAsync(Guid userId, string symbol, decimal amount, decimal price) =>
+            throw new NotSupportedException();
+    }
+
+    private static string PayloadFor(Guid tradeId) =>
+        System.Text.Json.JsonSerializer.Serialize(new TradeDto
+        {
+            Id = tradeId,
+            BuyerUserId = Guid.NewGuid(),
+            SellerUserId = Guid.NewGuid(),
+            Symbol = "MAUA/IRT",
+            Quantity = 10m,
+            QuoteQuantity = 184_680_733m
+        });
+
+    private Guid SeedPendingMessage()
+    {
+        using var db = new OrdersDbContext(Options());
+        var tradeId = Guid.NewGuid();
+        var message = OutboxMessage.Create("TradeSettlement", tradeId, PayloadFor(tradeId));
+        db.OutboxMessages.Add(message);
+        db.SaveChanges();
+        return message.Id;
+    }
+
+    [Fact]
+    public async Task AMessageThatCannotBePersisted_DoesNotStopTheRestOfTheBatch()
+    {
+        var firstId = SeedPendingMessage();
+        // Created second, so the processor's OrderBy(CreatedAt) reaches it after the failing one.
+        await Task.Delay(10);
+        var secondId = SeedPendingMessage();
+
+        var processor = new OutboxProcessorService(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<OutboxProcessorService>.Instance);
+
+        // Must not throw — the loop absorbs the persistence failure.
+        await processor.ProcessDueMessagesAsync(CancellationToken.None);
+
+        using var db = new OrdersDbContext(Options());
+
+        var first = await db.OutboxMessages.SingleAsync(m => m.Id == firstId);
+        var second = await db.OutboxMessages.SingleAsync(m => m.Id == secondId);
+
+        Assert.Equal(OutboxMessageStatus.Pending, first.Status);
+        Assert.Equal(OutboxMessageStatus.Completed, second.Status);
+    }
+}

--- a/src/Wallet/Wallet.Tests/SettlementFailureReasonTests.cs
+++ b/src/Wallet/Wallet.Tests/SettlementFailureReasonTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Infrastructure.Clients;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The wallet service's real rejection reason must reach the caller.
+///
+/// It used to be discarded: every non-success response was mapped to the fixed string
+/// "خطا در آزاد کردن موجودی" (which was itself copied from the unlock method and did not
+/// even describe settlement). During live testing the wallet logged
+/// "Fee exceeds the trade amount" while the outbox processor logged the generic string, so
+/// finding the cause meant cross-referencing two services' logs by hand — and
+/// OutboxMessage.LastError, which #39's reconciliation reads, stored the useless string.
+/// See issue #38.
+/// </summary>
+public class SettlementFailureReasonTests
+{
+    private const string WalletBaseUrl = "http://localhost:60933/api";
+
+    /// <summary>Returns a canned response so no wallet service is needed.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json")
+            });
+    }
+
+    private static WalletApiClient ClientReturning(HttpStatusCode status, string body)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["WalletApiUrl"] = WalletBaseUrl })
+            .Build();
+
+        return new WalletApiClient(
+            new HttpClient(new StubHandler(status, body)),
+            config,
+            NullLogger<WalletApiClient>.Instance);
+    }
+
+    private static string ApiResponseBody(bool success, string message) =>
+        JsonSerializer.Serialize(new ApiResponse<string>(success, message, null));
+
+    private static TradeDto AnyTrade() => new()
+    {
+        Id = Guid.NewGuid(),
+        BuyerUserId = Guid.NewGuid(),
+        SellerUserId = Guid.NewGuid(),
+        Symbol = "MAUA/IRT",
+        Quantity = 10m,
+        QuoteQuantity = 184_680_733m,
+        FeeBuyer = 0m,
+        FeeSeller = 0m
+    };
+
+    /// <summary>
+    /// The exact scenario from the issue: the wallet rejects with a specific reason and the
+    /// caller must see that reason, not a generic substitute.
+    /// </summary>
+    [Fact]
+    public async Task Rejection_PropagatesTheWalletsOwnReason()
+    {
+        const string walletReason = "Fee exceeds the trade amount.";
+        var client = ClientReturning(HttpStatusCode.BadRequest, ApiResponseBody(false, walletReason));
+
+        var (success, message) = await client.TradeTransactionAndBalanceChangeAsync(AnyTrade());
+
+        Assert.False(success);
+        Assert.Equal(walletReason, message);
+    }
+
+    /// <summary>A different reason must come through as itself — not one hardcoded string swapped for another.</summary>
+    [Fact]
+    public async Task Rejection_PropagatesADifferentReasonVerbatim()
+    {
+        const string walletReason = "Seller locked MAUA (4.00) is less than required (12.00).";
+        var client = ClientReturning(HttpStatusCode.BadRequest, ApiResponseBody(false, walletReason));
+
+        var (success, message) = await client.TradeTransactionAndBalanceChangeAsync(AnyTrade());
+
+        Assert.False(success);
+        Assert.Equal(walletReason, message);
+    }
+
+    /// <summary>
+    /// Reading the reason must never itself break settlement: an unparsable body still yields a
+    /// failure with something actionable (the status code) rather than an exception.
+    /// </summary>
+    [Fact]
+    public async Task Rejection_WithUnparsableBody_StillFailsWithAnInformativeMessage()
+    {
+        var client = ClientReturning(HttpStatusCode.InternalServerError, "<html>502 Bad Gateway</html>");
+
+        var (success, message) = await client.TradeTransactionAndBalanceChangeAsync(AnyTrade());
+
+        Assert.False(success);
+        Assert.Contains("500", message);
+    }
+
+    /// <summary>An empty body is the other shape a proxy or a crashed service can return.</summary>
+    [Fact]
+    public async Task Rejection_WithEmptyBody_StillFailsWithAnInformativeMessage()
+    {
+        var client = ClientReturning(HttpStatusCode.ServiceUnavailable, string.Empty);
+
+        var (success, message) = await client.TradeTransactionAndBalanceChangeAsync(AnyTrade());
+
+        Assert.False(success);
+        Assert.Contains("503", message);
+    }
+
+    [Fact]
+    public async Task Success_IsReportedAsSuccess()
+    {
+        var client = ClientReturning(HttpStatusCode.OK, ApiResponseBody(true, "Trade settled"));
+
+        var (success, _) = await client.TradeTransactionAndBalanceChangeAsync(AnyTrade());
+
+        Assert.True(success);
+    }
+}


### PR DESCRIPTION
Closes #38. Closes #44.

Both are about the same thing from opposite ends: when settlement fails, can anyone find out why, and does one bad row take the others down with it.

## Type
- [x] Bug fix (observability / outbox resilience — no money path change)

---

## #38 — the wallet's rejection reason never reached the caller

`TradeTransactionAndBalanceChangeAsync` never read the response body:

```csharp
if (response.IsSuccessStatusCode) return (true,  "موجودی با موفقیت آزاد شد");
else                              return (false, "خطا در آزاد کردن موجودی");
```

Both strings were copied from the *unlock* method, so the failure message did not even describe settlement. Observed live:

| Service | What it said |
|---|---|
| Wallet | `Trade settlement rejected: Fee exceeds the trade amount.` |
| Orders | `Wallet settlement rejected: خطا در آزاد کردن موجودی` |

Finding the cause meant cross-referencing two services' logs by hand — and `OutboxMessage.LastError`, which #39's reconciliation reads, stored the useless string.

**Fix:** parse the endpoint's `ApiResponse` and propagate its `Message`. An unparsable or empty body falls back to the status code instead of throwing, so *reading* the reason can never itself fail the settlement.

Two things fixed while in there:
- The method's three log statements had message-template placeholders but **no arguments**, producing structurally broken logs (an existing audit finding). They now log the trade id and the real reason.
- All logger calls in the method now use `?.`. `_logger` is `ILogger<WalletApiClient>?` and one of the class's two constructors leaves it null — the previous code would have thrown `NullReferenceException` on that path.

---

## #44 — the remaining half

The primary fix (truncating `LastError`) already landed in #50; the issue was never updated to say so. What remained was the per-message save:

```csharp
// Persist per message so a crash mid-batch never loses progress or double-marks.
await db.SaveChangesAsync(ct);        // <-- outside any try/catch
```

A failure here threw out of the whole loop:
1. the generic handler logged `Unexpected error in the outbox processing loop` — **without naming the row**,
2. the in-memory `RetryCount` was discarded, so the message never advanced towards `Failed` and never surfaced to an operator,
3. every remaining message in the batch was skipped for that cycle — **one bad row could stall settlement for all the others.**

**Fix:** the save has its own guard that logs the offending `message.Id` and continues with the batch.

Only the failed message is detached. Detaching the whole change tracker would also drop the messages still to be processed, silently leaving them `Pending` — which is the exact stall the guard exists to prevent. That mistake was made first and **caught by the new test**, which is the main argument for the test existing.

---

## Testing

`Wallet.Tests`: **34/34 pass** (was 28).

`SettlementFailureReasonTests` (5) — a stubbed `HttpMessageHandler`, no wallet service needed:
- the exact reason from the issue is propagated verbatim
- a second, different reason is propagated verbatim (so it isn't one hardcoded string swapped for another)
- an unparsable body still fails, with the status code in the message
- an empty body likewise
- success is still reported as success

`OutboxBatchResilienceTests` (1) — SQLite in-memory with a `DbContext` that fails its first `SaveChangesAsync`:
- the failing message stays `Pending`, the next message still reaches `Completed`

**Verified the tests catch the bugs:** reverting both fixes makes **5 of the 6 fail**, then restored.

```
SettlementFailureReasonTests.Rejection_PropagatesTheWalletsOwnReason [FAIL]
SettlementFailureReasonTests.Rejection_PropagatesADifferentReasonVerbatim [FAIL]
SettlementFailureReasonTests.Rejection_WithUnparsableBody_StillFailsWithAnInformativeMessage [FAIL]
SettlementFailureReasonTests.Rejection_WithEmptyBody_StillFailsWithAnInformativeMessage [FAIL]
OutboxBatchResilienceTests.AMessageThatCannotBePersisted_DoesNotStopTheRestOfTheBatch [FAIL]
Failed!  - Failed: 5, Passed: 29
```

(The success-path test passes either way, as expected — it pins behaviour that was already correct.)

Full solution builds clean, 0 errors. All six services restarted and healthy.

## Note

`ProcessDueMessagesAsync` is now `internal` with `InternalsVisibleTo("Wallet.Tests")`, so the batch behaviour is testable without driving the background loop's timing.