### PR TITLE
fix(#42): make settled-exactly-once a database guarantee, not a code convention

### DIFF
--- a/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.Designer.cs
+++ b/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wallet.Infrastructure;
 
@@ -11,9 +12,11 @@ using Wallet.Infrastructure;
 namespace Wallet.Api.Migrations
 {
     [DbContext(typeof(WalletDbContext))]
-    partial class WalletDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727104807_AddTradeSettlements")]
+    partial class AddTradeSettlements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.cs
+++ b/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wallet.Api.Migrations
+{
+    /// <summary>
+    /// جدول TradeSettlements را می‌سازد و سطرهای معاملاتی که از قبل تسویه شده‌اند را پر می‌کند.
+    ///
+    /// این جدول سد یکتایی تسویه است (issue #42): چون TradeId کلید اصلی است، دو تسویهٔ
+    /// همزمان از یک معامله دیگر نمی‌توانند هر دو اعمال شوند.
+    /// </summary>
+    public partial class AddTradeSettlements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TradeSettlements",
+                columns: table => new
+                {
+                    TradeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SettledAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Symbol = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    Quantity = table.Column<decimal>(type: "decimal(28,8)", precision: 28, scale: 8, nullable: false),
+                    QuoteQuantity = table.Column<decimal>(type: "decimal(28,8)", precision: 28, scale: 8, nullable: false),
+                    BuyerUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SellerUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TradeSettlements", x => x.TradeId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TradeSettlements_SettledAt",
+                table: "TradeSettlements",
+                column: "SettledAt");
+
+            // ── Backfill ──────────────────────────────────────────────────────────────
+            //
+            // چرا این بخش الزامی است و نمی‌تواند یک قدم جداگانه باشد:
+            // معاملاتی که پیش از این migration تسویه شده‌اند سطری در جدول جدید ندارند.
+            // چون مسیر جدید تسویه، «قبلاً تسویه شده؟» را از همین جدول می‌پرسد، بدون
+            // backfill یک re-drive روی آن معاملات دوباره تسویه‌شان می‌کرد — یعنی این
+            // migration دقیقاً همان تسویهٔ دوگانه‌ای را می‌ساخت که برای رفعش نوشته شده.
+            //
+            // منبع حقیقت برای «چه چیزی تسویه شده» جدول Transactions است: هر تسویه چهار
+            // سطر با Type = Trade (مقدار ۲) و ReferenceId برابر با شناسهٔ معامله می‌نویسد.
+            //
+            // نکات پیاده‌سازی:
+            // • TRY_CAST و نه CAST — اگر ReferenceId قدیمی‌ای وجود داشته باشد که Guid
+            //   معتبر نیست، CAST کل migration را می‌شکند؛ TRY_CAST آن را NULL می‌کند و
+            //   شرط WHERE کنارش می‌گذارد.
+            // • MIN(CreatedAt) به‌عنوان SettledAt — زمان واقعی تسویه، نه زمان اجرای migration.
+            // • MAX(...) برای Symbol/مقادیر: هر چهار سطر یک معامله متعلق به یک تسویه‌اند،
+            //   ولی چون GROUP BY لازم است از تجمیع استفاده می‌شود.
+            // • مقادیر و طرفین معامله در Transactions ذخیره نشده‌اند (فقط مبلغ هر پایه و
+            //   کیف پول). بازسازی دقیقشان نیازمند join با دیتابیس سرویس سفارش‌هاست که از
+            //   داخل این migration ممکن نیست. چون این ستون‌ها فقط برای حسابرسی‌اند و نه
+            //   برای تضمین یکتایی، برای سطرهای قدیمی صفر/خالی می‌مانند و با یک نشانهٔ
+            //   صریح در Symbol علامت‌گذاری می‌شوند تا با سطرهای واقعی اشتباه نشوند.
+            migrationBuilder.Sql(@"
+INSERT INTO TradeSettlements (TradeId, SettledAt, Symbol, Quantity, QuoteQuantity, BuyerUserId, SellerUserId)
+SELECT
+    TRY_CAST(t.ReferenceId AS uniqueidentifier)  AS TradeId,
+    MIN(t.CreatedAt)                             AS SettledAt,
+    'BACKFILLED'                                 AS Symbol,
+    0                                            AS Quantity,
+    0                                            AS QuoteQuantity,
+    '00000000-0000-0000-0000-000000000000'       AS BuyerUserId,
+    '00000000-0000-0000-0000-000000000000'       AS SellerUserId
+FROM Transactions t
+WHERE t.Type = 2                                        -- TransactionType.Trade
+  AND t.ReferenceId IS NOT NULL
+  AND TRY_CAST(t.ReferenceId AS uniqueidentifier) IS NOT NULL
+GROUP BY TRY_CAST(t.ReferenceId AS uniqueidentifier);
+");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TradeSettlements");
+        }
+    }
+}

--- a/src/Wallet/Wallet.Core/TradeSettlement.cs
+++ b/src/Wallet/Wallet.Core/TradeSettlement.cs
@@ -1,0 +1,62 @@
+namespace Wallet.Core;
+
+/// <summary>
+/// یک سطر به‌ازای هر معاملهٔ تسویه‌شده. کلید اصلی خودِ <see cref="TradeId"/> است.
+///
+/// چرا این جدول وجود دارد:
+/// تضمین «هر معامله دقیقاً یک بار تسویه می‌شود» پیش‌تر فقط با یک SELECT در کد برقرار
+/// می‌شد که بیرون از تراکنش اجرا می‌شد و هیچ پشتوانه‌ای در دیتابیس نداشت. دو تسویهٔ
+/// همزمان از یک معامله می‌توانستند هر دو آن بررسی را رد کنند و هر دو اعمال شوند،
+/// یعنی پول از هیچ ساخته می‌شد (issue #42).
+///
+/// با کلید اصلی بودن TradeId، این تضمین از یک «قاعدهٔ کد» به یک «حقیقت سطح schema»
+/// تبدیل می‌شود: حتی اگر روزی مسیر جدیدی بررسی کد را دور بزند، دیتابیس درج دوم را
+/// رد می‌کند. این همان درسی است که از #53 گرفتیم — محافظت ساختاری از محافظت رفتاری
+/// قابل اتکاتر است.
+///
+/// چرا جدول جدا و نه ایندکس یکتا روی Transactions:
+/// هر تسویه به‌درستی چهار سطر تراکنش با یک ReferenceId می‌نویسد (یک سطر برای هر پایه)،
+/// پس ایندکس یکتا باید روی (WalletId, ReferenceId) می‌بود — که کار می‌کند اما نیت را
+/// بیان نمی‌کند. اینجا «یک سطر = یک تسویه» مستقیماً خوانده می‌شود.
+/// </summary>
+public class TradeSettlement
+{
+    /// <summary>شناسهٔ معامله در سرویس سفارش‌ها. کلید اصلی — همین است که تسویهٔ تکراری را غیرممکن می‌کند.</summary>
+    public Guid TradeId { get; private set; }
+
+    /// <summary>زمان تسویه. برای مغایرت‌گیری و پاسخ به «این معامله کِی تسویه شد؟».</summary>
+    public DateTime SettledAt { get; private set; }
+
+    /// <summary>
+    /// نماد و مقادیر برای حسابرسی نگهداری می‌شوند. بدون این‌ها، فهمیدن اینکه یک سطر
+    /// تسویه به چه چیزی مربوط بوده نیازمند join با سرویس سفارش‌ها (دیتابیس دیگر) است.
+    /// </summary>
+    public string Symbol { get; private set; } = string.Empty;
+
+    public decimal Quantity { get; private set; }
+
+    public decimal QuoteQuantity { get; private set; }
+
+    public Guid BuyerUserId { get; private set; }
+
+    public Guid SellerUserId { get; private set; }
+
+    /// <summary>EF Core به سازندهٔ بدون پارامتر نیاز دارد.</summary>
+    private TradeSettlement() { }
+
+    public static TradeSettlement Create(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, decimal quantity, decimal quoteQuantity)
+    {
+        return new TradeSettlement
+        {
+            TradeId = tradeId,
+            BuyerUserId = buyerUserId,
+            SellerUserId = sellerUserId,
+            Symbol = symbol,
+            Quantity = quantity,
+            QuoteQuantity = quoteQuantity,
+            SettledAt = DateTime.UtcNow
+        };
+    }
+}

--- a/src/Wallet/Wallet.Infrastructure/WalletDbContext.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletDbContext.cs
@@ -11,6 +11,9 @@ public class WalletDbContext : DbContext
     public DbSet<WalletTransaction> WalletTransactions => Set<WalletTransaction>();
     public DbSet<Transaction> Transactions => Set<Transaction>();
 
+    /// <summary>یک سطر به‌ازای هر معاملهٔ تسویه‌شده. کلید اصلی آن، تسویهٔ تکراری را غیرممکن می‌کند (issue #42).</summary>
+    public DbSet<TradeSettlement> TradeSettlements => Set<TradeSettlement>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         // Wallet configuration
@@ -71,5 +74,28 @@ public class WalletDbContext : DbContext
         modelBuilder.Entity<Transaction>().HasIndex(t => new { t.WalletId, t.CreatedAt });
         modelBuilder.Entity<Transaction>().HasIndex(t => new { t.Currency, t.CreatedAt });
         modelBuilder.Entity<Transaction>().HasIndex(t => new { t.Type, t.Status });
+
+        // TradeSettlement configuration — سد یکتایی تسویه (issue #42)
+        //
+        // TradeId عمداً کلید اصلی است و نه یک ستون معمولی با ایندکس یکتا: کلید اصلی
+        // نیت را مستقیم بیان می‌کند («یک سطر = یک معاملهٔ تسویه‌شده») و امکان درج
+        // سطر دوم برای همان معامله را در سطح موتور دیتابیس از بین می‌برد، مستقل از
+        // اینکه کدام مسیر کد فراخوانی کرده باشد.
+        modelBuilder.Entity<TradeSettlement>().HasKey(s => s.TradeId);
+
+        // ValueGeneratedNever لازم است چون TradeId از سرویس سفارش‌ها می‌آید. بدون آن،
+        // EF کلید Guid را به‌صورت خودکار تولیدشده فرض می‌کند و مقدار ارسالی را نادیده
+        // می‌گیرد — که یعنی هر تسویه یک شناسهٔ تازه می‌گرفت و قید یکتایی هیچ‌وقت فعال نمی‌شد.
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.TradeId).ValueGeneratedNever();
+
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.SettledAt).IsRequired();
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.Symbol).IsRequired().HasMaxLength(32);
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.Quantity).IsRequired().HasPrecision(28, 8);
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.QuoteQuantity).IsRequired().HasPrecision(28, 8);
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.BuyerUserId).IsRequired();
+        modelBuilder.Entity<TradeSettlement>().Property(s => s.SellerUserId).IsRequired();
+
+        // برای پرس‌وجوی «تسویه‌های اخیر» در مغایرت‌گیری (#39).
+        modelBuilder.Entity<TradeSettlement>().HasIndex(s => s.SettledAt);
     }
-} 
+}

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -202,10 +202,16 @@ public class WalletRepository : IWalletRepository
     {
         var referenceId = tradeId.ToString();
 
-        // Idempotency: a retry or a duplicate outbox delivery must not settle twice.
-        // Check the NEW Transactions table (settlement writes here), not the legacy WalletTransactions.
-        var alreadySettled = await _context.Transactions.AnyAsync(t => t.ReferenceId == referenceId);
-        if (alreadySettled)
+        // مسیر سریع: اگر معامله از قبل تسویه شده، بدون باز کردن تراکنش برمی‌گردیم.
+        //
+        // این بررسی «تضمین» نیست — فقط بهینه‌سازی است. تحویل مجدد outbox حالت عادی است
+        // (طراحی صریحاً اجازه می‌دهد پیامی که موفق شده دوباره فرستاده شود)، پس ارزش دارد
+        // که مسیر پرتکرار بدون هزینهٔ تراکنش و بدون تولید استثنا رد شود.
+        //
+        // تضمین واقعی، کلید اصلی جدول TradeSettlements است که پایین‌تر اعمال می‌شود.
+        // پیش‌تر همین SELECT تنها محافظ بود و چون بیرون از تراکنش اجرا می‌شد، دو تسویهٔ
+        // همزمان می‌توانستند هر دو از آن رد شوند و پول دو برابر جابه‌جا شود (issue #42).
+        if (await _context.TradeSettlements.AnyAsync(s => s.TradeId == tradeId))
         {
             _logger.LogInformation("Trade {TradeId} already settled; skipping (idempotent).", tradeId);
             return (true, "Trade already settled.");
@@ -304,13 +310,40 @@ public class WalletRepository : IWalletRepository
             buyerQuote.UpdatedAt = now; buyerBase.UpdatedAt = now; sellerBase.UpdatedAt = now; sellerQuote.UpdatedAt = now;
             _context.Wallets.UpdateRange(buyerQuote, buyerBase, sellerBase, sellerQuote);
 
-            await _context.SaveChangesAsync(); // single save: 4 balance changes + 4 transaction records
+            // سد یکتایی: این سطر داخل همان تراکنشِ جابه‌جایی پول درج می‌شود.
+            //
+            // چون TradeId کلید اصلی است، اگر تسویهٔ همزمانِ دیگری زودتر commit کرده باشد،
+            // این درج با نقض کلید تکراری شکست می‌خورد و کل تراکنش — شامل هر چهار تغییر
+            // موجودی — برگردانده می‌شود. یعنی «دقیقاً یک بار» را دیتابیس تضمین می‌کند،
+            // نه ترتیب اجرای کد.
+            _context.TradeSettlements.Add(
+                TradeSettlement.Create(tradeId, buyerUserId, sellerUserId, symbol!, quantity, quoteQuantity));
+
+            await _context.SaveChangesAsync(); // یک save: ۴ تغییر موجودی + ۴ سطر تراکنش + ۱ سطر تسویه
             await tx.CommitAsync();
 
             _logger.LogInformation(
                 "Settled trade {TradeId}: buyer={Buyer} seller={Seller} {Qty} {Base} for {Quote} {QuoteAsset}",
                 tradeId, buyerUserId, sellerUserId, quantity, baseAsset, quoteQuantity, quoteAsset);
             return (true, "Trade settled.");
+        }
+        catch (DbUpdateException ex) when (IsDuplicateSettlement(ex))
+        {
+            // بازندهٔ رقابت. تسویهٔ همزمانِ دیگری زودتر commit کرده و کلید اصلی، درج دوم
+            // را رد کرده است. rollback همهٔ تغییرات موجودی این تلاش را برمی‌گرداند، پس
+            // نتیجهٔ نهایی دقیقاً یک تسویه است.
+            //
+            // این را به «موفقیت» ترجمه می‌کنیم و نه خطا، چون از دید فراخوان واقعاً موفق
+            // است: معامله تسویه شده. اگر خطا برمی‌گرداندیم، پردازشگر outbox پیام را
+            // شکست‌خورده تلقی می‌کرد، پنج بار retry می‌کرد و در نهایت به Failed می‌رسید —
+            // یعنی یک معاملهٔ کاملاً سالم به‌عنوان «گیرکرده» به اپراتور هشدار می‌داد.
+            await tx.RollbackAsync();
+
+            _logger.LogInformation(
+                "Trade {TradeId} was settled concurrently by another caller; this attempt was rolled back (idempotent).",
+                tradeId);
+
+            return (true, "Trade already settled.");
         }
         catch (Exception ex)
         {
@@ -319,6 +352,20 @@ public class WalletRepository : IWalletRepository
             return (false, $"Settlement error: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// تشخیص اینکه آیا شکست ذخیره‌سازی به‌خاطر درج تکراری در TradeSettlements بوده است.
+    ///
+    /// عمداً به کد خطای خاص SQL Server (۲۶۲۷ برای نقض قید، ۲۶۰۱ برای ایندکس یکتا) تکیه
+    /// نمی‌کنیم، چون تست‌ها روی SQLite اجرا می‌شوند و کد خطای دیگری تولید می‌کند. اگر
+    /// فقط کد SQL Server را می‌پذیرفتیم، این مسیر در تست‌ها هرگز اجرا نمی‌شد — یعنی
+    /// دقیقاً همان چیزی که باید تضمین شود، بی‌آزمون می‌ماند.
+    ///
+    /// در عوض از خودِ EF می‌پرسیم چه چیزی در حال درج بوده: اگر تنها موجودیتِ Added از
+    /// نوع TradeSettlement باشد، تنها دلیل ممکنِ نقض یکتایی همان کلید تکراری است.
+    /// </summary>
+    private static bool IsDuplicateSettlement(DbUpdateException ex) =>
+        ex.Entries.Count > 0 && ex.Entries.All(e => e.Entity is TradeSettlement);
 
     /// <summary>Adds (but does not save) a completed Trade transaction record to the current unit of work.</summary>
     private void AddTradeTransaction(WalletEntity wallet, decimal amount, string asset,

--- a/src/Wallet/Wallet.Tests/SettlementUniquenessTests.cs
+++ b/src/Wallet/Wallet.Tests/SettlementUniquenessTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wallet.Core;
+using Wallet.Infrastructure;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// «هر معامله دقیقاً یک بار تسویه می‌شود» باید توسط دیتابیس تضمین شود، نه توسط ترتیب اجرای کد.
+///
+/// پیش‌تر تنها محافظ، یک SELECT بود که ۴۶ خط پیش از باز شدن تراکنش اجرا می‌شد و هیچ قید
+/// یکتایی پشتش نبود. دو تسویهٔ همزمان از یک معامله می‌توانستند هر دو از آن بررسی رد شوند
+/// و هر دو اعمال شوند — یعنی هر دو طرف دو برابر اعتبار می‌گرفتند و پول از هیچ ساخته
+/// می‌شد (issue #42).
+///
+/// حالا TradeId کلید اصلی جدول TradeSettlements است و آن سطر داخل همان تراکنشِ جابه‌جایی
+/// پول درج می‌شود.
+/// </summary>
+public class SettlementUniquenessTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly HookedWalletDbContext _context;
+    private readonly WalletRepository _repository;
+
+    private readonly Guid _buyerId = Guid.NewGuid();
+    private readonly Guid _sellerId = Guid.NewGuid();
+
+    private const string Base = "MAUA";
+    private const string Quote = "IRT";
+    private const decimal Quantity = 2m;
+    private const decimal QuoteQuantity = 1000m;
+
+    /// <summary>
+    /// یک قلاب درست پیش از SaveChanges، برای بازسازی قطعی و بدون رقابتِ حالتی که رقیب
+    /// دقیقاً در بازهٔ بین «بررسی سریع» و «درج» ما commit کرده است.
+    ///
+    /// چرا این روش و نه اجرای واقعی دو Task موازی: SQLite در حافظه روی یک اتصال، دو
+    /// تراکنش نوشتنِ همزمان را پشتیبانی نمی‌کند، پس تست موازی یا قفل می‌شد یا وابسته به
+    /// زمان‌بندی و ناپایدار می‌شد. آنچه باید اثبات شود این نیست که «رقابت رخ می‌دهد»،
+    /// بلکه این است که «وقتی رخ داد، دیتابیس جلویش را می‌گیرد و کد آن را درست ترجمه
+    /// می‌کند» — و این تست دقیقاً همان را با قید واقعی دیتابیس می‌سنجد.
+    /// </summary>
+    private sealed class HookedWalletDbContext : WalletDbContext
+    {
+        public Action? BeforeSave;
+
+        public HookedWalletDbContext(DbContextOptions<WalletDbContext> options) : base(options) { }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            var hook = BeforeSave;
+            BeforeSave = null; // فقط یک بار اجرا شود، وگرنه rollback هم دوباره آن را صدا می‌زند
+            hook?.Invoke();
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public SettlementUniquenessTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options;
+        _context = new HookedWalletDbContext(options);
+        _context.Database.EnsureCreated();
+        _repository = new WalletRepository(NullLogger<WalletRepository>.Instance, _context);
+
+        SeedFullyLockedWallets();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private void SeedWallet(Guid userId, string asset, decimal balance, decimal locked)
+    {
+        var wallet = WalletEntity.Create(userId, asset);
+        wallet.Balance = balance;
+        wallet.LockedBalance = locked;
+        _context.Wallets.Add(wallet);
+    }
+
+    private void SeedFullyLockedWallets()
+    {
+        SeedWallet(_buyerId, Quote, balance: 0m, locked: QuoteQuantity);
+        SeedWallet(_buyerId, Base, balance: 0m, locked: 0m);
+        SeedWallet(_sellerId, Base, balance: 0m, locked: Quantity);
+        SeedWallet(_sellerId, Quote, balance: 0m, locked: 0m);
+        _context.SaveChanges();
+    }
+
+    private Task<(bool Success, string Message)> SettleAsync(Guid tradeId) =>
+        _repository.SettleTradeAsync(
+            tradeId, _buyerId, _sellerId, $"{Base}/{Quote}", Quantity, QuoteQuantity, 0m, 0m);
+
+    private async Task<WalletEntity> ReloadAsync(Guid userId, string asset)
+    {
+        _context.ChangeTracker.Clear();
+        return await _context.Wallets.SingleAsync(w => w.UserId == userId && w.Asset == asset);
+    }
+
+    /// <summary>یک تسویهٔ عادی باید سطر تسویه را ثبت کند — پایهٔ همهٔ تضمین‌های بعدی.</summary>
+    [Fact]
+    public async Task Settlement_RecordsExactlyOneTradeSettlementRow()
+    {
+        var tradeId = Guid.NewGuid();
+
+        var (success, _) = await SettleAsync(tradeId);
+
+        Assert.True(success);
+        Assert.Equal(1, await _context.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
+    }
+
+    /// <summary>
+    /// مورد اصلی #42: رقیب پس از رد شدن ما از بررسی سریع، commit می‌کند. درج ما باید با
+    /// نقض کلید اصلی شکست بخورد و کل تراکنش برگردد.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentSettlement_IsRefusedByTheDatabase_AndReportedAsAlreadySettled()
+    {
+        var tradeId = Guid.NewGuid();
+
+        // رقیب: سطر تسویه را مستقیماً درج می‌کند، درست پیش از SaveChanges ما — یعنی همان
+        // لحظه‌ای که بررسی سریع ما از قبل رد شده و دیگر کاری از آن برنمی‌آید.
+        _context.BeforeSave = () =>
+            _context.Database.ExecuteSqlRaw(
+                @"INSERT INTO TradeSettlements
+                      (TradeId, SettledAt, Symbol, Quantity, QuoteQuantity, BuyerUserId, SellerUserId)
+                  VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6})",
+                tradeId, DateTime.UtcNow, $"{Base}/{Quote}", Quantity, QuoteQuantity, _buyerId, _sellerId);
+
+        var (success, message) = await SettleAsync(tradeId);
+
+        // از دید فراخوان موفق است: معامله تسویه شده — فقط نه توسط ما.
+        // اگر خطا برمی‌گشت، پردازشگر outbox پنج بار retry می‌کرد و معاملهٔ سالم را
+        // به‌عنوان «گیرکرده» به اپراتور هشدار می‌داد.
+        Assert.True(success, message);
+        Assert.Contains("already settled", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// مهم‌ترین ادعا: بازندهٔ رقابت نباید هیچ پولی جابه‌جا کرده باشد. این همان چیزی است
+    /// که #42 دربارهٔ آن بود — نه پیام خطا، بلکه دو برابر شدن موجودی.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentSettlement_LeavesBalancesAndTransactionsUntouched()
+    {
+        var tradeId = Guid.NewGuid();
+
+        _context.BeforeSave = () =>
+            _context.Database.ExecuteSqlRaw(
+                @"INSERT INTO TradeSettlements
+                      (TradeId, SettledAt, Symbol, Quantity, QuoteQuantity, BuyerUserId, SellerUserId)
+                  VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6})",
+                tradeId, DateTime.UtcNow, $"{Base}/{Quote}", Quantity, QuoteQuantity, _buyerId, _sellerId);
+
+        await SettleAsync(tradeId);
+
+        // هیچ سطر تراکنشی نوشته نشده — نه اینکه نوشته و بعد جبران شده باشد.
+        Assert.Equal(0, await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
+
+        // و موجودی‌ها دقیقاً همان حالت پیش از تسویه‌اند: وثیقه هنوز قفل، هیچ دارایی‌ای منتقل نشده.
+        var buyerQuote = await ReloadAsync(_buyerId, Quote);
+        var buyerBase = await ReloadAsync(_buyerId, Base);
+        var sellerBase = await ReloadAsync(_sellerId, Base);
+        var sellerQuote = await ReloadAsync(_sellerId, Quote);
+
+        Assert.Equal(QuoteQuantity, buyerQuote.LockedBalance);
+        Assert.Equal(0m, buyerQuote.Balance);
+        Assert.Equal(0m, buyerBase.Balance);
+        Assert.Equal(Quantity, sellerBase.LockedBalance);
+        Assert.Equal(0m, sellerBase.Balance);
+        Assert.Equal(0m, sellerQuote.Balance);
+    }
+
+    /// <summary>
+    /// تحویل مجدد عادی outbox (رقابتی در کار نیست) باید از مسیر سریع رد شود: بدون استثنا،
+    /// بدون تراکنش، و بدون نوشتن سطر دوم.
+    /// </summary>
+    [Fact]
+    public async Task RedeliveryAfterSuccess_IsIdempotent_AndDoesNotDoubleApply()
+    {
+        var tradeId = Guid.NewGuid();
+
+        var first = await SettleAsync(tradeId);
+        var second = await SettleAsync(tradeId);
+
+        Assert.True(first.Success);
+        Assert.True(second.Success);
+
+        Assert.Equal(1, await _context.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
+        Assert.Equal(4, await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
+
+        // موجودی‌ها فقط یک بار جابه‌جا شده‌اند.
+        Assert.Equal(Quantity, (await ReloadAsync(_buyerId, Base)).Balance);
+        Assert.Equal(QuoteQuantity, (await ReloadAsync(_sellerId, Quote)).Balance);
+    }
+
+    /// <summary>
+    /// دو معاملهٔ متفاوت نباید همدیگر را مسدود کنند — قید یکتایی باید روی شناسهٔ معامله
+    /// باشد و نه چیزی که به‌طور اتفاقی بین معاملات مشترک است (مثل طرفین یا نماد).
+    /// </summary>
+    [Fact]
+    public async Task DifferentTrades_BetweenTheSameParties_BothSettle()
+    {
+        var firstTrade = Guid.NewGuid();
+        var secondTrade = Guid.NewGuid();
+
+        // وثیقهٔ لازم برای معاملهٔ دوم را هم قفل می‌کنیم.
+        //
+        // هر دو کیف پول در یک واحد کاری بارگذاری می‌شوند و بین آن‌ها ChangeTracker پاک
+        // نمی‌شود؛ در غیر این صورت موجودیت اول detach می‌شد و تغییرش هرگز ذخیره نمی‌شد.
+        _context.ChangeTracker.Clear();
+        var buyerQuote = await _context.Wallets.SingleAsync(w => w.UserId == _buyerId && w.Asset == Quote);
+        var sellerBase = await _context.Wallets.SingleAsync(w => w.UserId == _sellerId && w.Asset == Base);
+        buyerQuote.LockedBalance += QuoteQuantity;
+        sellerBase.LockedBalance += Quantity;
+        await _context.SaveChangesAsync();
+
+        var a = await SettleAsync(firstTrade);
+        var b = await SettleAsync(secondTrade);
+
+        Assert.True(a.Success, a.Message);
+        Assert.True(b.Success, b.Message);
+        Assert.Equal(2, await _context.TradeSettlements.CountAsync());
+        Assert.Equal(8, await _context.Transactions.CountAsync());
+    }
+}


### PR DESCRIPTION
Closes #42.

## Description

Settlement idempotency was enforced by a `SELECT` that ran **46 lines before** the transaction opened, with **no unique constraint** behind it:

```csharp
var alreadySettled = await _context.Transactions.AnyAsync(t => t.ReferenceId == referenceId);   // line 207
...
await using var tx = await _context.Database.BeginTransactionAsync();                           // line 253
```

Two concurrent settlements of the same trade could both pass that check and both apply — each party credited twice, money created from nothing.

## Type
- [x] Bug fix (money path — duplicated balances)

## Changes

**A dedicated `TradeSettlements` table, `TradeId` as the PRIMARY KEY**, inserted inside the same transaction that moves the money. A concurrent second settlement fails on the duplicate key, and that rolls back all four balance changes with it. The guarantee moves from "a rule the code follows" to "a fact the schema enforces" — the same lesson as #53.

**Why not a unique index on `Transactions`:** one settlement legitimately writes four rows sharing a `ReferenceId` (one per leg), so the index would have to be `(WalletId, ReferenceId)`. That works, but it does not state the intent. One row per settlement reads directly, and gives #39's reconciliation a table to query.

**The duplicate-key catch returns the existing "already settled" *success* path**, not an error. From the caller's side the trade genuinely is settled. Returning an error would make the outbox processor retry five times and finally alert an operator about a perfectly healthy trade.

**`IsDuplicateSettlement` inspects `DbUpdateException.Entries`, not SQL Server error numbers 2627/2601.** The tests run on SQLite, which raises a different code — keying on the SQL Server number would mean this path never executes under test, leaving the guarantee itself unverified.

## The migration backfills, and that is not optional

Previously settled trades have no row in the new table. Since the fast path now asks *that* table whether a trade is settled, a re-drive of an old trade would settle it a second time — **the migration would have created the very bug it exists to fix.**

The backfill derives from `Transactions` (`Type = Trade`, grouped by `ReferenceId`), using `MIN(CreatedAt)` so rows carry the real settlement time rather than the migration time, and `TRY_CAST` so a malformed legacy `ReferenceId` cannot break the migration.

Verified on the dev database:

```
Settlements | DistinctSettledTrades
          7 |                     7
```

Backfilled rows are marked `Symbol = 'BACKFILLED'` with zeroed amounts: the audit columns cannot be reconstructed without joining the Orders database, and they play no part in the uniqueness guarantee. Marking them explicitly keeps them from being mistaken for real records.

## Testing

`Wallet.Tests`: **39/39 pass** (was 34). Five new tests in `SettlementUniquenessTests`:

- a normal settlement records exactly one settlement row
- a concurrent settlement is refused by the database and reported as already settled
- **the loser moves no money** — 0 transaction rows, all four balances untouched, collateral still locked
- ordinary outbox redelivery still takes the fast path and does not double-apply
- two *different* trades between the same parties both settle (the constraint is on the trade, not on something incidentally shared)

**Verified the tests catch the bug:** removing the uniqueness row makes **all 5 fail**, then restored.

The concurrency test uses a `SaveChanges` hook to reproduce the interleaving deterministically. SQLite in-memory cannot run two concurrent write transactions, so a thread-based test would either deadlock or be timing-dependent — and what needs proving is not that the race occurs, but that the database stops it and the code translates that correctly.

## Live verification

Migration applied to the dev database, services restarted, then re-settled an already-settled (backfilled) trade through the real endpoint:

```
success = True
data    = Trade already settled.
```

```
legs for that trade: 4     (not 8)
total settlements:   7     (unchanged)
total trade legs:    28    (unchanged)
```

That trade came from the backfill, so this also confirms the backfill actually protects historical trades — without it, this exact call would have doubled the money.

## Note

Not addressed here: the check-then-act window between `ValidateCreditAndBalanceAsync` and the lock, which is the same family of problem one layer up. That is tracked in #36.