### PR TITLE
fix(bot): show buy/sell in trade history, and fix the Persian date

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -465,7 +465,9 @@ namespace TallaEgg.TelegramBot
                         {
                             var page = await _orderApi.GetUserTradesAsync(uid, pageNum, pageSize: 5);
 
-                            var text = await TradeListHandler.BuildTradesListAsync(page.Data!, pageNum);
+                            // uid همان کاربری است که فهرست را می‌بیند؛ برای تعیین اینکه هر
+                            // معامله از دید او خرید بوده یا فروش لازم است.
+                            var text = await TradeListHandler.BuildTradesListAsync(page.Data!, pageNum, uid);
 
                             // ویرایش پیام قبلی
                             await _botClient.EditMessageText(
@@ -616,7 +618,7 @@ namespace TallaEgg.TelegramBot
             var page = await _orderApi.GetUserTradesAsync(userId, pageNumber: 1, pageSize: 5);
             if (page.Success)
             {
-                var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1);
+                var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1, userId);
 
                 await _botClient.SendMessage(
                     chatId: chatId,

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
@@ -23,7 +23,16 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
             return navButtons.Any() ? new InlineKeyboardMarkup(navButtons) : null;
         }
 
-        public static async Task<string> BuildTradesListAsync(PagedResult<TradeHistoryDto> page, int currentPage)
+        /// <summary>
+        /// فهرست معاملات کاربر.
+        /// </summary>
+        /// <param name="viewerUserId">
+        /// کاربری که فهرست را می‌بیند. لازم است چون «خرید یا فروش» یک ویژگی خودِ معامله
+        /// نیست، بلکه به این بستگی دارد که بیننده کدام طرف معامله بوده: یک معاملهٔ واحد
+        /// برای یک طرف خرید است و برای طرف دیگر فروش.
+        /// </param>
+        public static async Task<string> BuildTradesListAsync(
+            PagedResult<TradeHistoryDto> page, int currentPage, Guid viewerUserId)
         {
             if (page == null || !page.Items.Any())
             {
@@ -44,11 +53,23 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
                 var displayPrice = isGold ? t.Price * CurrenciesConstant.GramsPerMesghal : t.Price;
                 var priceLabel = isGold ? "قیمت هر مثقال" : "قیمت هر واحد";
 
+                var isBuyer = t.BuyerUserId == viewerUserId;
+
+                // دو نشانهٔ مستقل برای یک واقعیت: برچسب صریح در بالا، و جهت پول در پایین.
+                // فقط رنگ ایموجی کافی نیست — کاربری که رنگ‌ها را تفکیک نمی‌کند یا پیام را
+                // سریع مرور می‌کند باید از روی خود کلمه‌ها بفهمد.
+                var sideLabel = isBuyer ? "🟢 خرید" : "🔴 فروش";
+
+                // «ارزش کل» نمی‌گفت این پول از حساب کاربر رفته یا به آن آمده. برای خریدار
+                // این مبلغ پرداختی است و برای فروشنده دریافتی.
+                var amountLabel = isBuyer ? "پرداختی" : "دریافتی";
+
                 sb.AppendLine($"📌 معاملهٔ {PersianFormat.Ltr(t.Id.ToString()[..8])}");
+                sb.AppendLine(sideLabel);
                 sb.AppendLine($"🏷️ دارایی: {PersianFormat.Symbol(t.Symbol)}");
                 sb.AppendLine($"📊 مقدار: {PersianFormat.Amount(t.Quantity, baseAsset)} {unit}");
                 sb.AppendLine($"💰 {priceLabel}: {PersianFormat.Number(displayPrice)} تومان");
-                sb.AppendLine($"💵 ارزش کل: {PersianFormat.Number(t.QuoteQuantity)} تومان");
+                sb.AppendLine($"💵 {amountLabel}: {PersianFormat.Number(t.QuoteQuantity)} تومان");
                 sb.AppendLine($"🕓 زمان: {PersianFormat.ToPersianDigits(TallaEgg.Core.Utilties.Utils.ConvertToPersianDate(t.CreatedAt))}");
                 sb.AppendLine("➖➖➖➖➖➖➖➖➖");
                 sb.AppendLine();

--- a/src/TallaEgg/TallaEgg.Core/Utilties/Utils.cs
+++ b/src/TallaEgg/TallaEgg.Core/Utilties/Utils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;   // PersianCalendar — بخشی از دات‌نت، بدون وابستگی خارجی
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -89,26 +90,64 @@ namespace TallaEgg.Core.Utilties
         /// </summary>
         /// <param name="dateTime">تاریخ میلادی</param>
         /// <returns>تاریخ شمسی به فرمت yyyy/MM/dd HH:mm</returns>
+        /// <summary>
+        /// تبدیل زمان UTC به تاریخ و ساعت شمسیِ تهران، با قالب yyyy/MM/dd HH:mm.
+        ///
+        /// نسخهٔ قبلی «تقریبی» بود و در عمل غلط: سال را ۶۲۱ واحد کم می‌کرد، ماه را جابه‌جا
+        /// می‌کرد، اما **روزِ میلادی را دست‌نخورده** برمی‌گرداند. مثلاً ۲۷ ژوئیهٔ ۲۰۲۶ که
+        /// معادل ۵ مرداد ۱۴۰۵ است، ۱۴۰۵/۰۵/۲۷ نمایش داده می‌شد — یعنی کاربر تاریخ معاملهٔ
+        /// خودش را ۲۲ روز اشتباه می‌دید.
+        ///
+        /// کامنت قبلی می‌گفت «برای پیاده‌سازی کامل نیاز به کتابخانه PersianCalendar است»؛
+        /// این درست نبود — PersianCalendar بخشی از خود دات‌نت است و هیچ وابستگی جدیدی
+        /// لازم ندارد.
+        /// </summary>
         public static string ConvertToPersianDate(DateTime dateTime)
         {
-            // تبدیل ساده به تاریخ شمسی - برای پیاده‌سازی کامل نیاز به کتابخانه PersianCalendar است
-            var persianMonths = new[] { "فروردین", "اردیبهشت", "خرداد", "تیر", "مرداد", "شهریور", 
-                                       "مهر", "آبان", "آذر", "دی", "بهمن", "اسفند" };
-            
-            // محاسبه تقریبی تاریخ شمسی
-            var year = dateTime.Year - 621;
-            var month = dateTime.Month;
-            var day = dateTime.Day;
-            
-            // تنظیم ماه شمسی (تقریبی)
-            if (month >= 3 && month <= 5) month = month - 2;
-            else if (month >= 6 && month <= 8) month = month - 2;
-            else if (month >= 9 && month <= 11) month = month - 2;
-            else if (month == 12) month = 10;
-            else if (month == 1) month = 11;
-            else if (month == 2) month = 12;
-            
-            return $"{year:0000}/{month:00}/{day:00} {dateTime:HH:mm}";
+            var local = ToTehranTime(dateTime);
+            var pc = new PersianCalendar();
+
+            // PersianCalendar در محدودهٔ تاریخ‌های خیلی قدیمی استثنا می‌دهد. تاریخ نمایشی
+            // هرگز نباید باعث شکست یک پیام شود، پس در آن حالت به قالب میلادی برمی‌گردیم.
+            try
+            {
+                return $"{pc.GetYear(local):0000}/{pc.GetMonth(local):00}/{pc.GetDayOfMonth(local):00} {local:HH:mm}";
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return local.ToString("yyyy/MM/dd HH:mm");
+            }
+        }
+
+        /// <summary>
+        /// زمان‌ها در دیتابیس UTC ذخیره می‌شوند (DateTime.UtcNow)، ولی کاربر ایرانی انتظار
+        /// ساعت تهران را دارد. بدون این تبدیل، معامله‌ای که ساعت ۱۳:۲۲ به وقت تهران انجام
+        /// شده، ۰۹:۵۲ نمایش داده می‌شد.
+        ///
+        /// شناسهٔ منطقهٔ زمانی روی ویندوز و لینوکس متفاوت است، پس هر دو امتحان می‌شوند.
+        /// اگر هیچ‌کدام موجود نبود، افست ثابت +۳:۳۰ استفاده می‌شود؛ ایران از سال ۱۴۰۱
+        /// ساعت تابستانی ندارد، پس این افست ثابت امروز درست است.
+        /// </summary>
+        private static DateTime ToTehranTime(DateTime dateTime)
+        {
+            // فقط زمان‌های UTC تبدیل می‌شوند. اگر فراخوانی مقدار Local یا Unspecified بدهد،
+            // تبدیل دوباره باعث جابه‌جایی اشتباه می‌شد.
+            if (dateTime.Kind == DateTimeKind.Local)
+                return dateTime;
+
+            var utc = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+            foreach (var id in new[] { "Iran Standard Time", "Asia/Tehran" })
+            {
+                try
+                {
+                    return TimeZoneInfo.ConvertTimeFromUtc(utc, TimeZoneInfo.FindSystemTimeZoneById(id));
+                }
+                catch (TimeZoneNotFoundException) { }
+                catch (InvalidTimeZoneException) { }
+            }
+
+            return utc.AddHours(3).AddMinutes(30);
         }
     }
     /// <summary>

--- a/src/Wallet/Wallet.Tests/PersianDateTests.cs
+++ b/src/Wallet/Wallet.Tests/PersianDateTests.cs
@@ -1,0 +1,81 @@
+using TallaEgg.Core.Utilties;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// تبدیل تاریخ میلادی به شمسی.
+///
+/// نسخهٔ قبلی سال را ۶۲۱ واحد کم می‌کرد و ماه را جابه‌جا می‌کرد، اما روزِ میلادی را
+/// دست‌نخورده برمی‌گرداند. نتیجه‌اش این بود که کاربر تاریخ معاملهٔ خودش را تا ۲۲ روز
+/// اشتباه می‌دید — مثلاً ۲۷ ژوئیهٔ ۲۰۲۶ به‌جای «۵ مرداد» به‌صورت «۲۷ مرداد» نمایش
+/// داده می‌شد.
+///
+/// همچنین زمان‌ها در دیتابیس UTC ذخیره می‌شوند و بدون تبدیل، ساعت اشتباه نمایش داده
+/// می‌شد.
+/// </summary>
+public class PersianDateTests
+{
+    /// <summary>
+    /// همان تاریخی که باگ روی آن دیده شد. ۲۷ ژوئیهٔ ۲۰۲۶ = ۵ مرداد ۱۴۰۵.
+    /// </summary>
+    [Fact]
+    public void TheDateThatExposedTheBug_ConvertsCorrectly()
+    {
+        var utc = new DateTime(2026, 7, 27, 6, 0, 0, DateTimeKind.Utc);
+
+        var result = Utils.ConvertToPersianDate(utc);
+
+        Assert.StartsWith("1405/05/05", result);
+    }
+
+    /// <summary>
+    /// چند تاریخ مرزی. مرز ماه‌ها و مرز سال جایی است که محاسبهٔ «تقریبی» قبلی بیشترین
+    /// خطا را داشت.
+    /// </summary>
+    [Theory]
+    [InlineData(2026, 3, 21, "1405/01/01")] // نوروز ۱۴۰۵
+    [InlineData(2026, 3, 20, "1404/12/29")] // یک روز پیش از نوروز
+    [InlineData(2026, 7, 22, "1405/04/31")] // آخرین روز تیر
+    [InlineData(2026, 7, 23, "1405/05/01")] // اولین روز مرداد
+    [InlineData(2026, 12, 31, "1405/10/10")]
+    public void KnownDates_ConvertCorrectly(int year, int month, int day, string expected)
+    {
+        // ساعت ۱۲ ظهر UTC انتخاب شده تا افست +۳:۳۰ تهران روز را جابه‌جا نکند و تست
+        // دربارهٔ خودِ تبدیل تقویم باشد، نه دربارهٔ مرز نیمه‌شب.
+        var utc = new DateTime(year, month, day, 12, 0, 0, DateTimeKind.Utc);
+
+        var result = Utils.ConvertToPersianDate(utc);
+
+        Assert.StartsWith(expected, result);
+    }
+
+    /// <summary>
+    /// ساعت باید به وقت تهران باشد. معامله‌ای که ۰۹:۵۲ به وقت UTC ثبت شده، برای کاربر
+    /// ایرانی ۱۳:۲۲ اتفاق افتاده است.
+    /// </summary>
+    [Fact]
+    public void TimeIsShownInTehranTime_NotUtc()
+    {
+        var utc = new DateTime(2026, 7, 27, 9, 52, 0, DateTimeKind.Utc);
+
+        var result = Utils.ConvertToPersianDate(utc);
+
+        Assert.EndsWith("13:22", result);
+    }
+
+    /// <summary>
+    /// تبدیل منطقهٔ زمانی می‌تواند تاریخ را هم عوض کند: ۲۲:۰۰ به وقت UTC یعنی ۰۱:۳۰
+    /// روز بعد در تهران. اگر فقط ساعت تبدیل می‌شد و تاریخ از UTC می‌آمد، این حالت
+    /// یک روز عقب نمایش داده می‌شد.
+    /// </summary>
+    [Fact]
+    public void LateUtcEvening_RollsOverToTheNextPersianDay()
+    {
+        var utc = new DateTime(2026, 7, 27, 22, 0, 0, DateTimeKind.Utc);
+
+        var result = Utils.ConvertToPersianDate(utc);
+
+        Assert.StartsWith("1405/05/06", result);
+        Assert.EndsWith("01:30", result);
+    }
+}

--- a/src/Wallet/Wallet.Tests/TradeListSideTests.cs
+++ b/src/Wallet/Wallet.Tests/TradeListSideTests.cs
@@ -1,0 +1,104 @@
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.TelegramBot.Infrastructure.Handlers;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// فهرست معاملات باید بگوید هر معامله از دید بیننده خرید بوده یا فروش.
+///
+/// پیش‌تر نمی‌گفت: کاربر فقط مقدار و مبلغ را می‌دید و هیچ راهی نداشت بفهمد طلا خریده
+/// یا فروخته. این یک ویژگی خودِ معامله نیست — یک معاملهٔ واحد برای یک طرف خرید است و
+/// برای طرف مقابل فروش — پس شناسهٔ بیننده باید به تابع ساخت متن داده شود.
+/// </summary>
+public class TradeListSideTests
+{
+    private static readonly Guid Customer = Guid.NewGuid();
+    private static readonly Guid MarketMaker = Guid.NewGuid();
+
+    private static PagedResult<TradeHistoryDto> PageWith(TradeHistoryDto trade) => new()
+    {
+        Items = new List<TradeHistoryDto> { trade },
+        TotalCount = 1,
+        PageNumber = 1,
+        PageSize = 5
+    };
+
+    private static TradeHistoryDto Trade(Guid buyer, Guid seller) => new()
+    {
+        Id = Guid.NewGuid(),
+        Symbol = "MAUA/IRT",
+        Price = 18_468_073.32m,
+        Quantity = 55m,
+        QuoteQuantity = 1_015_744_033m,
+        BuyerUserId = buyer,
+        SellerUserId = seller,
+        CreatedAt = new DateTime(2026, 7, 27, 9, 52, 0, DateTimeKind.Utc)
+    };
+
+    [Fact]
+    public async Task WhenViewerIsTheBuyer_ItIsShownAsABuy()
+    {
+        var page = PageWith(Trade(buyer: Customer, seller: MarketMaker));
+
+        var text = await TradeListHandler.BuildTradesListAsync(page, 1, Customer);
+
+        Assert.Contains("خرید", text);
+        Assert.DoesNotContain("فروش", text);
+    }
+
+    [Fact]
+    public async Task WhenViewerIsTheSeller_ItIsShownAsASell()
+    {
+        var page = PageWith(Trade(buyer: MarketMaker, seller: Customer));
+
+        var text = await TradeListHandler.BuildTradesListAsync(page, 1, Customer);
+
+        Assert.Contains("فروش", text);
+        Assert.DoesNotContain("خرید", text);
+    }
+
+    /// <summary>
+    /// همان معاملهٔ واحد باید برای دو طرف برعکس هم نمایش داده شود. این تستی است که یک
+    /// برچسب هاردکدشده را می‌گیرد — دو تست بالا به‌تنهایی با یک مقدار ثابت هم سبز
+    /// می‌شدند اگر داده‌هایشان متفاوت نبود.
+    /// </summary>
+    [Fact]
+    public async Task TheSameTrade_AppearsAsBuyToOnePartyAndSellToTheOther()
+    {
+        var trade = Trade(buyer: Customer, seller: MarketMaker);
+
+        var asBuyer = await TradeListHandler.BuildTradesListAsync(PageWith(trade), 1, Customer);
+        var asSeller = await TradeListHandler.BuildTradesListAsync(PageWith(trade), 1, MarketMaker);
+
+        Assert.Contains("خرید", asBuyer);
+        Assert.Contains("فروش", asSeller);
+    }
+
+    /// <summary>
+    /// جهت پول هم باید صریح باشد: «ارزش کل» نمی‌گفت این مبلغ پرداخت شده یا دریافت.
+    /// </summary>
+    [Fact]
+    public async Task TheMoneyDirectionIsLabelled()
+    {
+        var buyerView = await TradeListHandler.BuildTradesListAsync(
+            PageWith(Trade(buyer: Customer, seller: MarketMaker)), 1, Customer);
+        var sellerView = await TradeListHandler.BuildTradesListAsync(
+            PageWith(Trade(buyer: MarketMaker, seller: Customer)), 1, Customer);
+
+        Assert.Contains("پرداختی", buyerView);
+        Assert.Contains("دریافتی", sellerView);
+    }
+
+    /// <summary>تاریخ نمایش‌داده‌شده باید شمسیِ درست باشد و نه روزِ میلادی.</summary>
+    [Fact]
+    public async Task TheDateIsCorrectPersianDate()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            PageWith(Trade(buyer: Customer, seller: MarketMaker)), 1, Customer);
+
+        // ۲۷ ژوئیهٔ ۲۰۲۶ ساعت ۰۹:۵۲ UTC  =  ۵ مرداد ۱۴۰۵ ساعت ۱۳:۲۲ به وقت تهران
+        Assert.Contains("۱۴۰۵/۰۵/۰۵", text);
+        Assert.Contains("۱۳:۲۲", text);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -25,6 +25,8 @@
     <ProjectReference Include="..\..\Order\Orders.Core\Orders.Core.csproj" />
     <ProjectReference Include="..\..\Order\Orders.Infrastructure\Orders.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Order\Orders.Application\Orders.Application.csproj" />
+    <!-- برای تست ساخت متن فهرست معاملات (خرید/فروش و تاریخ شمسی). -->
+    <ProjectReference Include="..\..\..\TelegramBot\TallaEgg.TelegramBot.Infrastructure\TallaEgg.TelegramBot.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

The trade history gave no way to tell whether a trade was a **buy** or a **sell**. Reported from the running bot.

## Type
- [x] Bug fix (user-facing correctness)

## Buy / sell

Buy-or-sell is **not a property of the trade** — the same trade is a buy for one party and a sell for the other. So the viewer's user id is now passed into `BuildTradesListAsync` and the side derived from `BuyerUserId == viewerUserId`.

Each row carries the side **twice, in two independent forms**:

- an explicit label: `🟢 خرید` / `🔴 فروش`
- the money direction: `پرداختی` / `دریافتی`, replacing the neutral `ارزش کل`

Colour alone is not enough for someone skimming, or not distinguishing the emoji. The second label also answers a question the old text left open: whether that number left the account or entered it.

**Before**
```
📌 معاملهٔ e9c4bd7f
🏷️ دارایی: آبشده/تومان
📊 مقدار: ۵۵ گرم
💰 قیمت هر مثقال: ۸۰٬۰۰۰٬۰۰۰ تومان
💵 ارزش کل: ۱٬۰۱۵٬۷۴۴٬۰۳۳ تومان
🕓 زمان: ۱۴۰۵/۰۵/۲۷ ۰۹:۵۲
```

**After**
```
📌 معاملهٔ e9c4bd7f
🟢 خرید
🏷️ دارایی: آبشده/تومان
📊 مقدار: ۵۵ گرم
💰 قیمت هر مثقال: ۸۰٬۰۰۰٬۰۰۰ تومان
💵 پرداختی: ۱٬۰۱۵٬۷۴۴٬۰۳۳ تومان
🕓 زمان: ۱۴۰۵/۰۵/۰۵ ۱۳:۲۲
```

## Found while doing it: the date was wrong by up to 22 days

Note the last line above. `ConvertToPersianDate` subtracted 621 from the year and shifted the month, but returned the **Gregorian day unchanged**:

```csharp
var year = dateTime.Year - 621;
var month = dateTime.Month;
var day = dateTime.Day;        // ← never converted
```

So 27 July 2026 — which is **5 Mordad 1405** — displayed as `1405/05/27`. Users were reading their own trade dates 22 days wrong.

The function's comment said *"برای پیاده‌سازی کامل نیاز به کتابخانه PersianCalendar است"*. That is not true: `System.Globalization.PersianCalendar` ships with .NET. No new dependency.

**Times were also raw UTC.** Timestamps are stored with `DateTime.UtcNow`, so a trade made at 13:22 Tehran time displayed as 09:52. Now converted, trying the Windows (`Iran Standard Time`) and Linux (`Asia/Tehran`) ids and falling back to a fixed +3:30 — Iran has had no DST since 1401, so the fixed offset is correct today.

The function is shared, so the order list and active-orders list are fixed by the same change.

## Testing

`Wallet.Tests`: **52/52 pass** (was 39). Thirteen new tests.

`PersianDateTests` — the exact date that exposed the bug, plus the boundaries where the old approximation was worst: Nowruz, the day before Nowruz (year rollover), the last day of Tir and the first of Mordad. Also a late-UTC-evening case (22:00 UTC → 01:30 the *next* Persian day), which catches the mistake of converting only the clock and taking the date from UTC.

`TradeListSideTests` — buyer view, seller view, the money-direction labels, the date, and one test that renders **the same trade from both parties** and asserts it reads as a buy to one and a sell to the other. That last one is what catches a hardcoded label; the first two would pass against a constant if their fixtures happened to differ.

**Verified the tests catch the bugs:** reverting both fixes makes **all 13 fail**, then restored.

Full solution builds clean, 0 errors. All six services restarted and healthy.