### PR TITLE
fix(#52): make consumption-never-exceeds-the-lock a mathematical guarantee

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -110,6 +110,11 @@ builder.Services.AddScoped<TallaEgg.Infrastructure.Clients.IWalletApiClient, Tal
 // MatchingEngineRegistration نوشته شده، که تست‌ها هم از همان استفاده می‌کنند.
 builder.Services.AddMatchingEngine();
 
+// آزادسازی باقی‌ماندهٔ وثیقه (issue #52). هم OrderService (هنگام لغو) و هم
+// OutboxProcessorService (پس از تسویه) از همین یک نمونه استفاده می‌کنند تا فرمول
+// «چقدر قفل مانده» فقط یک جا تعریف شده باشد.
+builder.Services.AddScoped<Orders.Application.Services.OrderCollateralReconciler>();
+
 // Outbox processor: reliably delivers trade settlements to the Wallet service.
 builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();
 

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -22,18 +22,26 @@ public class OrderService
     private readonly ILogger<OrderService> _logger;
     private readonly UsersApiClient _usersApiClient;
 
+    /// <summary>
+    /// برای محاسبهٔ «چقدر از وثیقهٔ یک سفارش واقعاً مصرف شده» لازم است؛ آزادسازی هنگام
+    /// لغو باید از روی معاملات انجام‌شده باشد نه یک بازمحاسبهٔ مستقل (issue #52).
+    /// </summary>
+    private readonly ITradeRepository _tradeRepository;
+
     public OrderService(
         IOrderRepository orderRepository,
         IWalletApiClient walletApiClient,
         IMatchingEngine matchingEngine,
         ILogger<OrderService> logger,
-        UsersApiClient UsersApiClient)
+        UsersApiClient UsersApiClient,
+        ITradeRepository tradeRepository)
     {
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _walletApiClient = walletApiClient ?? throw new ArgumentNullException(nameof(walletApiClient));
         _matchingEngine = matchingEngine ?? throw new ArgumentNullException(nameof(matchingEngine));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _usersApiClient = UsersApiClient;
+        _tradeRepository = tradeRepository ?? throw new ArgumentNullException(nameof(tradeRepository));
     }
 
     /// <summary>
@@ -62,10 +70,23 @@ public class OrderService
             var assetToCheck = request.Side == TallaEgg.Core.Enums.Order.OrderSide.Buy
                 ? request.Symbol.Split('/')[1] : request.Symbol.Split('/')[0];
 
-            // مبلغ قفل‌شده باید با همان دقتِ خودِ دارایی گرد شود. بدون این کار،
-            // «مقدار × قیمت» تا ۱۸ رقم اعشار پیش می‌رود، در حالی که تسویه و ستون‌های
-            // دیتابیس با دقت کمتری کار می‌کنند و یک باقی‌ماندهٔ کوچک در LockedBalance
-            // جا می‌ماند.
+            // قیمت پیش از هر استفاده‌ای به دقت ستون گرد می‌شود.
+            //
+            // ربات قیمت را از تقسیم «قیمت مثقال ÷ ۴٫۳۳۱۸» می‌سازد که تا ۲۸ رقم اعشار
+            // ادامه دارد. اگر قفل از آن مقدار کامل حساب شود ولی سفارش با دو رقم اعشار
+            // ذخیره گردد، تسویه — که قیمت را از دیتابیس می‌خواند — با عدد دیگری کار
+            // می‌کند و اختلاف تا ابد در LockedBalance می‌ماند (issue #52).
+            //
+            // این کار یک اثر جانبی مهم هم دارد: از این پس «مبلغ قفل‌شده» دقیقاً برابر
+            // RoundToCurrencyPrecision(Amount × Price) روی همان سفارشِ ذخیره‌شده است،
+            // پس بدون افزودن ستون جدید قابل بازمحاسبه است.
+            if (request.Price <= 0)
+                throw new ArgumentException("قیمت باید بزرگ‌تر از صفر باشد");
+
+            request.Price = CurrenciesConstant.RoundOrderPrice(request.Price);
+
+            // مبلغ قفل‌شده با همان دقتِ خودِ دارایی گرد می‌شود، چون تسویه و ستون‌های
+            // دیتابیس با همان دقت کار می‌کنند.
             var amountToCheck = request.Side == TallaEgg.Core.Enums.Order.OrderSide.Buy
                 ? CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity * request.Price, assetToCheck)
                 : CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity, assetToCheck);
@@ -187,6 +208,31 @@ public class OrderService
             _logger.LogError(ex, "Error creating unified order for user {UserId}", request.UserId);
             throw new InvalidOperationException("خطا در ایجاد سفارش", ex);
         }
+    }
+
+    /// <summary>
+    /// باقی‌ماندهٔ وثیقهٔ یک سفارش: «آنچه قفل شد» منهای «آنچه معاملات آن مصرف کردند».
+    ///
+    /// «آنچه قفل شد» دقیقاً از روی خودِ سفارش بازمحاسبه می‌شود، و این تنها به این دلیل
+    /// ممکن است که قیمت هنگام ثبت سفارش به دقت ستون گرد می‌شود (issue #52). پیش از آن،
+    /// قفل با قیمتِ گرد‌نشده حساب می‌شد و از روی ردیف ذخیره‌شده قابل بازسازی نبود.
+    /// </summary>
+    private async Task<(string Asset, decimal Residual)> ComputeResidualLockAsync(Order order)
+    {
+        var parts = order.Asset.Split('/');
+        var baseAsset = parts[0];
+        var quoteAsset = parts.Length > 1 ? parts[1] : parts[0];
+
+        if (order.Side == OrderSide.Buy)
+        {
+            var locked = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
+            var trades = await _tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
+            return (quoteAsset, locked - trades.Sum(t => t.QuoteQuantity));
+        }
+
+        var lockedBase = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount, baseAsset);
+        var sellTrades = await _tradeRepository.GetTradesBySellOrderIdAsync(order.Id);
+        return (baseAsset, lockedBase - sellTrades.Sum(t => t.Quantity));
     }
 
     public async Task<Order> CreateOrderAsync(CreateOrderCommand command)
@@ -359,13 +405,14 @@ public class OrderService
         {
             try
             {
-                var assetToUnlock = order.Side == OrderSide.Buy
-                          ? order.Asset.Split('/')[1]
-                          : order.Asset.Split('/')[0];
-
-                var amountToUnlock = order.Side == OrderSide.Buy
-                    ? order.RemainingAmount * order.Price
-                    : order.RemainingAmount;
+                // «آنچه قفل شد» منهای «آنچه معاملات مصرف کردند» — نه یک بازمحاسبهٔ مستقل.
+                //
+                // پیش‌تر اینجا RemainingAmount × Price بدون گرد کردن حساب می‌شد، یعنی
+                // فرمول سومی جدا از فرمول قفل و فرمول تسویه. سه راه متفاوت برای محاسبهٔ
+                // یک کمیت، تضمین می‌کرد که پس از لغوِ یک سفارشِ نیمه‌پرشده باقی‌مانده‌ای
+                // جا بماند — و در جهت دیگر، می‌توانست بیش از مقدار قفل‌شده آزاد کند
+                // (issue #52).
+                var (assetToUnlock, amountToUnlock) = await ComputeResidualLockAsync(order);
 
                 if (amountToUnlock > 0)
                 {

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -85,10 +85,14 @@ public class OrderService
 
             request.Price = CurrenciesConstant.RoundOrderPrice(request.Price);
 
-            // مبلغ قفل‌شده با همان دقتِ خودِ دارایی گرد می‌شود، چون تسویه و ستون‌های
-            // دیتابیس با همان دقت کار می‌کنند.
+            // مبلغ قفل عمداً رو به بالا گرد می‌شود، در حالی که مصرفِ هر معامله رو به
+            // پایین. این جهت‌های مخالف تضمین می‌کنند «مجموع مصرف ≤ مقدار قفل‌شده»
+            // همیشه برقرار بماند، پس بیش‌مصرف — که یک معاملهٔ معتبر را رد می‌کرد —
+            // غیرممکن می‌شود. توضیح کامل روی CeilingToCurrencyPrecision (issue #52).
+            //
+            // سمت فروش گرد کردن لازم ندارد: وثیقه‌اش خودِ مقدار سفارش است.
             var amountToCheck = request.Side == TallaEgg.Core.Enums.Order.OrderSide.Buy
-                ? CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity * request.Price, assetToCheck)
+                ? CurrenciesConstant.CeilingToCurrencyPrecision(request.Quantity * request.Price, assetToCheck)
                 : CurrenciesConstant.RoundToCurrencyPrecision(request.Quantity, assetToCheck);
 
             _logger.LogInformation("Validating balance for user {UserId}: {Amount} {Asset}",
@@ -225,7 +229,10 @@ public class OrderService
 
         if (order.Side == OrderSide.Buy)
         {
-            var locked = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
+            // باید دقیقاً همان فرمولی باشد که هنگام ثبت سفارش قفل کرد — از جمله جهت
+            // گرد کردن. اگر اینجا Round و آنجا Ceiling باشد، دوباره همان اختلافی ساخته
+            // می‌شود که این کد برای برداشتنش نوشته شده.
+            var locked = CurrenciesConstant.CeilingToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
             var trades = await _tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
             return (quoteAsset, locked - trades.Sum(t => t.QuoteQuantity));
         }

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -23,10 +23,11 @@ public class OrderService
     private readonly UsersApiClient _usersApiClient;
 
     /// <summary>
-    /// برای محاسبهٔ «چقدر از وثیقهٔ یک سفارش واقعاً مصرف شده» لازم است؛ آزادسازی هنگام
-    /// لغو باید از روی معاملات انجام‌شده باشد نه یک بازمحاسبهٔ مستقل (issue #52).
+    /// محاسبهٔ باقی‌ماندهٔ وثیقه اینجا و در پردازشگر outbox مشترک است. اگر دو کپی از این
+    /// فرمول وجود داشته باشد، دیر یا زود از هم جدا می‌شوند — و «چند فرمول برای یک
+    /// کمیت» دقیقاً همان چیزی بود که #52 را ساخت.
     /// </summary>
-    private readonly ITradeRepository _tradeRepository;
+    private readonly Services.OrderCollateralReconciler _collateralReconciler;
 
     public OrderService(
         IOrderRepository orderRepository,
@@ -34,14 +35,14 @@ public class OrderService
         IMatchingEngine matchingEngine,
         ILogger<OrderService> logger,
         UsersApiClient UsersApiClient,
-        ITradeRepository tradeRepository)
+        Services.OrderCollateralReconciler collateralReconciler)
     {
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _walletApiClient = walletApiClient ?? throw new ArgumentNullException(nameof(walletApiClient));
         _matchingEngine = matchingEngine ?? throw new ArgumentNullException(nameof(matchingEngine));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _usersApiClient = UsersApiClient;
-        _tradeRepository = tradeRepository ?? throw new ArgumentNullException(nameof(tradeRepository));
+        _collateralReconciler = collateralReconciler ?? throw new ArgumentNullException(nameof(collateralReconciler));
     }
 
     /// <summary>
@@ -212,34 +213,6 @@ public class OrderService
             _logger.LogError(ex, "Error creating unified order for user {UserId}", request.UserId);
             throw new InvalidOperationException("خطا در ایجاد سفارش", ex);
         }
-    }
-
-    /// <summary>
-    /// باقی‌ماندهٔ وثیقهٔ یک سفارش: «آنچه قفل شد» منهای «آنچه معاملات آن مصرف کردند».
-    ///
-    /// «آنچه قفل شد» دقیقاً از روی خودِ سفارش بازمحاسبه می‌شود، و این تنها به این دلیل
-    /// ممکن است که قیمت هنگام ثبت سفارش به دقت ستون گرد می‌شود (issue #52). پیش از آن،
-    /// قفل با قیمتِ گرد‌نشده حساب می‌شد و از روی ردیف ذخیره‌شده قابل بازسازی نبود.
-    /// </summary>
-    private async Task<(string Asset, decimal Residual)> ComputeResidualLockAsync(Order order)
-    {
-        var parts = order.Asset.Split('/');
-        var baseAsset = parts[0];
-        var quoteAsset = parts.Length > 1 ? parts[1] : parts[0];
-
-        if (order.Side == OrderSide.Buy)
-        {
-            // باید دقیقاً همان فرمولی باشد که هنگام ثبت سفارش قفل کرد — از جمله جهت
-            // گرد کردن. اگر اینجا Round و آنجا Ceiling باشد، دوباره همان اختلافی ساخته
-            // می‌شود که این کد برای برداشتنش نوشته شده.
-            var locked = CurrenciesConstant.CeilingToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
-            var trades = await _tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
-            return (quoteAsset, locked - trades.Sum(t => t.QuoteQuantity));
-        }
-
-        var lockedBase = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount, baseAsset);
-        var sellTrades = await _tradeRepository.GetTradesBySellOrderIdAsync(order.Id);
-        return (baseAsset, lockedBase - sellTrades.Sum(t => t.Quantity));
     }
 
     public async Task<Order> CreateOrderAsync(CreateOrderCommand command)
@@ -419,7 +392,7 @@ public class OrderService
                 // یک کمیت، تضمین می‌کرد که پس از لغوِ یک سفارشِ نیمه‌پرشده باقی‌مانده‌ای
                 // جا بماند — و در جهت دیگر، می‌توانست بیش از مقدار قفل‌شده آزاد کند
                 // (issue #52).
-                var (assetToUnlock, amountToUnlock) = await ComputeResidualLockAsync(order);
+                var (assetToUnlock, amountToUnlock) = await _collateralReconciler.ComputeResidualLockAsync(order);
 
                 if (amountToUnlock > 0)
                 {

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -460,9 +460,13 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
                     "Maker/Taker trade executed: Maker:{MakerId} Taker:{TakerId} Qty:{Qty} Price:{Price}",
                     makerOrder.Id, takerOrder.Id, quantity, result.Trade?.Price);
 
-                // اگر سفارشی کاملاً پر شده، باقی‌ماندهٔ وثیقه‌اش را آزاد می‌کنیم.
-                await ReleaseResidualLockIfCompletedAsync(buyOrder.Id);
-                await ReleaseResidualLockIfCompletedAsync(sellOrder.Id);
+                // آزادسازی باقی‌ماندهٔ وثیقه عمداً اینجا انجام نمی‌شود.
+                //
+                // اینجا قفلِ موجودی هنوز ساخته نشده (OrderService بعد از تطبیق قفل
+                // می‌کند — یافتهٔ C-5) و تسویه هم که آن را مصرف می‌کند بعدتر توسط
+                // outbox اجرا می‌شود. تلاش برای آزادسازی در این نقطه با هر دو مسابقه
+                // می‌دهد و در تست واقعی هم شکست خورد. حالا OutboxProcessorService پس
+                // از تسویهٔ موفق این کار را می‌کند (issue #52).
             }
             else
             {
@@ -473,90 +477,6 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         {
             _logger.LogError(ex, "💥 Error executing Maker/Taker trade");
         }
-    }
-
-    /// <summary>
-    /// اگر سفارش کاملاً پر شده باشد، هر مقدار وثیقه‌ای که هنوز به نام آن قفل مانده آزاد می‌شود.
-    ///
-    /// چرا لازم است (issue #52): مبلغ قفل‌شده یک بار برای کل سفارش حساب می‌شود
-    /// (Round(Amount × Price))، ولی مصرف در هر fill جداگانه گرد می‌شود. مجموع مقادیرِ
-    /// جداگانه‌گردشده با مقدارِ یک‌بار‌گردشده برابر نیست، پس پس از پر شدن کامل سفارش یک
-    /// باقی‌مانده در LockedBalance جا می‌ماند. آن باقی‌مانده متعلق به کاربر است و هیچ
-    /// مسیری آن را برنمی‌گرداند.
-    ///
-    /// این کار عمداً بیرون از تراکنش تطبیق انجام می‌شود، چون کیف پول در سرویس و
-    /// دیتابیس دیگری است. اگر شکست بخورد وضعیت از امروز بدتر نمی‌شود (باقی‌مانده
-    /// همان‌جا می‌ماند) و مغایرت‌گیری #39 می‌تواند بعداً آن را بردارد.
-    /// </summary>
-    private async Task ReleaseResidualLockIfCompletedAsync(Guid orderId)
-    {
-        try
-        {
-            using var scope = _serviceProvider.CreateScope();
-            var orderRepository = scope.ServiceProvider.GetRequiredService<IOrderRepository>();
-            var tradeRepository = scope.ServiceProvider.GetRequiredService<ITradeRepository>();
-            var walletApiClient = scope.ServiceProvider.GetRequiredService<IWalletApiClient>();
-
-            var order = await orderRepository.GetByIdAsync(orderId);
-            if (order is null || order.Status != OrderStatus.Completed)
-                return;
-
-            var (asset, residual) = await ComputeResidualLockAsync(order, tradeRepository);
-            if (residual <= 0)
-                return;
-
-            var (success, message) = await walletApiClient.UnlockBalanceAsync(order.UserId, asset, residual);
-
-            if (success)
-                _logger.LogInformation(
-                    "Released residual lock of {Residual} {Asset} for completed order {OrderId}.",
-                    residual, asset, orderId);
-            else
-                _logger.LogWarning(
-                    "Could not release residual lock of {Residual} {Asset} for completed order {OrderId}: {Message}",
-                    residual, asset, orderId, message);
-        }
-        catch (Exception ex)
-        {
-            // آزاد نشدن باقی‌مانده نباید تطبیق را بشکند؛ معامله از قبل commit شده است.
-            _logger.LogError(ex, "Error releasing residual lock for order {OrderId}", orderId);
-        }
-    }
-
-    /// <summary>
-    /// باقی‌ماندهٔ وثیقهٔ یک سفارش: «آنچه قفل شد» منهای «آنچه معاملات آن مصرف کردند».
-    ///
-    /// «آنچه قفل شد» دقیقاً از روی خودِ سفارش بازمحاسبه می‌شود و این تنها به این دلیل
-    /// ممکن است که قیمت هنگام ثبت سفارش به دقت ستون گرد می‌شود. پیش از آن، قفل با
-    /// قیمتِ گرد‌نشده حساب می‌شد و از روی ردیف ذخیره‌شده قابل بازسازی نبود.
-    /// </summary>
-    private static async Task<(string Asset, decimal Residual)> ComputeResidualLockAsync(
-        Order order, ITradeRepository tradeRepository)
-    {
-        var parts = order.Asset.Split('/');
-        var baseAsset = parts[0];
-        var quoteAsset = parts.Length > 1 ? parts[1] : parts[0];
-
-        if (order.Side == OrderSide.Buy)
-        {
-            // خریدار ارز مظنه را قفل می‌کند و معاملات، QuoteQuantity مصرف می‌کنند.
-            // Ceiling — همان فرمول و همان جهتی که هنگام ثبت سفارش قفل کرد.
-            var locked = CurrenciesConstant.CeilingToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
-            var trades = await tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
-            var consumed = trades.Sum(t => t.QuoteQuantity);
-
-            return (quoteAsset, locked - consumed);
-        }
-
-        // فروشنده دارایی پایه را قفل می‌کند و معاملات دقیقاً Quantity مصرف می‌کنند —
-        // بدون گرد کردن، چون همان واحدی است که سفارش با آن ثبت شده. پس این سمت در
-        // حالت عادی باقی‌مانده‌ای ندارد؛ محاسبه‌اش را نگه می‌داریم تا اگر روزی این
-        // فرض عوض شد، خودبه‌خود پوشش داده شود.
-        var lockedBase = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount, baseAsset);
-        var sellTrades = await tradeRepository.GetTradesBySellOrderIdAsync(order.Id);
-        var consumedBase = sellTrades.Sum(t => t.Quantity);
-
-        return (baseAsset, lockedBase - consumedBase);
     }
 
     /// <summary>

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -540,7 +540,8 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         if (order.Side == OrderSide.Buy)
         {
             // خریدار ارز مظنه را قفل می‌کند و معاملات، QuoteQuantity مصرف می‌کنند.
-            var locked = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
+            // Ceiling — همان فرمول و همان جهتی که هنگام ثبت سفارش قفل کرد.
+            var locked = CurrenciesConstant.CeilingToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
             var trades = await tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
             var consumed = trades.Sum(t => t.QuoteQuantity);
 

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Orders.Application;
 using Orders.Core;
 using Orders.Infrastructure;
+using TallaEgg.Core;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.Responses.Order;
@@ -458,6 +459,10 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
                 _logger.LogInformation(
                     "Maker/Taker trade executed: Maker:{MakerId} Taker:{TakerId} Qty:{Qty} Price:{Price}",
                     makerOrder.Id, takerOrder.Id, quantity, result.Trade?.Price);
+
+                // اگر سفارشی کاملاً پر شده، باقی‌ماندهٔ وثیقه‌اش را آزاد می‌کنیم.
+                await ReleaseResidualLockIfCompletedAsync(buyOrder.Id);
+                await ReleaseResidualLockIfCompletedAsync(sellOrder.Id);
             }
             else
             {
@@ -468,6 +473,89 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         {
             _logger.LogError(ex, "💥 Error executing Maker/Taker trade");
         }
+    }
+
+    /// <summary>
+    /// اگر سفارش کاملاً پر شده باشد، هر مقدار وثیقه‌ای که هنوز به نام آن قفل مانده آزاد می‌شود.
+    ///
+    /// چرا لازم است (issue #52): مبلغ قفل‌شده یک بار برای کل سفارش حساب می‌شود
+    /// (Round(Amount × Price))، ولی مصرف در هر fill جداگانه گرد می‌شود. مجموع مقادیرِ
+    /// جداگانه‌گردشده با مقدارِ یک‌بار‌گردشده برابر نیست، پس پس از پر شدن کامل سفارش یک
+    /// باقی‌مانده در LockedBalance جا می‌ماند. آن باقی‌مانده متعلق به کاربر است و هیچ
+    /// مسیری آن را برنمی‌گرداند.
+    ///
+    /// این کار عمداً بیرون از تراکنش تطبیق انجام می‌شود، چون کیف پول در سرویس و
+    /// دیتابیس دیگری است. اگر شکست بخورد وضعیت از امروز بدتر نمی‌شود (باقی‌مانده
+    /// همان‌جا می‌ماند) و مغایرت‌گیری #39 می‌تواند بعداً آن را بردارد.
+    /// </summary>
+    private async Task ReleaseResidualLockIfCompletedAsync(Guid orderId)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var orderRepository = scope.ServiceProvider.GetRequiredService<IOrderRepository>();
+            var tradeRepository = scope.ServiceProvider.GetRequiredService<ITradeRepository>();
+            var walletApiClient = scope.ServiceProvider.GetRequiredService<IWalletApiClient>();
+
+            var order = await orderRepository.GetByIdAsync(orderId);
+            if (order is null || order.Status != OrderStatus.Completed)
+                return;
+
+            var (asset, residual) = await ComputeResidualLockAsync(order, tradeRepository);
+            if (residual <= 0)
+                return;
+
+            var (success, message) = await walletApiClient.UnlockBalanceAsync(order.UserId, asset, residual);
+
+            if (success)
+                _logger.LogInformation(
+                    "Released residual lock of {Residual} {Asset} for completed order {OrderId}.",
+                    residual, asset, orderId);
+            else
+                _logger.LogWarning(
+                    "Could not release residual lock of {Residual} {Asset} for completed order {OrderId}: {Message}",
+                    residual, asset, orderId, message);
+        }
+        catch (Exception ex)
+        {
+            // آزاد نشدن باقی‌مانده نباید تطبیق را بشکند؛ معامله از قبل commit شده است.
+            _logger.LogError(ex, "Error releasing residual lock for order {OrderId}", orderId);
+        }
+    }
+
+    /// <summary>
+    /// باقی‌ماندهٔ وثیقهٔ یک سفارش: «آنچه قفل شد» منهای «آنچه معاملات آن مصرف کردند».
+    ///
+    /// «آنچه قفل شد» دقیقاً از روی خودِ سفارش بازمحاسبه می‌شود و این تنها به این دلیل
+    /// ممکن است که قیمت هنگام ثبت سفارش به دقت ستون گرد می‌شود. پیش از آن، قفل با
+    /// قیمتِ گرد‌نشده حساب می‌شد و از روی ردیف ذخیره‌شده قابل بازسازی نبود.
+    /// </summary>
+    private static async Task<(string Asset, decimal Residual)> ComputeResidualLockAsync(
+        Order order, ITradeRepository tradeRepository)
+    {
+        var parts = order.Asset.Split('/');
+        var baseAsset = parts[0];
+        var quoteAsset = parts.Length > 1 ? parts[1] : parts[0];
+
+        if (order.Side == OrderSide.Buy)
+        {
+            // خریدار ارز مظنه را قفل می‌کند و معاملات، QuoteQuantity مصرف می‌کنند.
+            var locked = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
+            var trades = await tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
+            var consumed = trades.Sum(t => t.QuoteQuantity);
+
+            return (quoteAsset, locked - consumed);
+        }
+
+        // فروشنده دارایی پایه را قفل می‌کند و معاملات دقیقاً Quantity مصرف می‌کنند —
+        // بدون گرد کردن، چون همان واحدی است که سفارش با آن ثبت شده. پس این سمت در
+        // حالت عادی باقی‌مانده‌ای ندارد؛ محاسبه‌اش را نگه می‌داریم تا اگر روزی این
+        // فرض عوض شد، خودبه‌خود پوشش داده شود.
+        var lockedBase = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount, baseAsset);
+        var sellTrades = await tradeRepository.GetTradesBySellOrderIdAsync(order.Id);
+        var consumedBase = sellTrades.Sum(t => t.Quantity);
+
+        return (baseAsset, lockedBase - consumedBase);
     }
 
     /// <summary>

--- a/src/Order/Orders.Application/Services/OrderCollateralReconciler.cs
+++ b/src/Order/Orders.Application/Services/OrderCollateralReconciler.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Infrastructure.Clients;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// وقتی سفارشی کاملاً پر می‌شود، هر مقدار وثیقه‌ای که هنوز به نامش قفل مانده آزاد می‌کند.
+///
+/// چرا باقی‌مانده‌ای وجود دارد (issue #52): مبلغ قفل یک بار برای کل سفارش و رو به بالا
+/// حساب می‌شود، ولی مصرفِ هر معامله جداگانه و رو به پایین. این جهت‌های مخالف تضمین
+/// می‌کنند مجموع مصرف هرگز از قفل بیشتر نشود، اما اختلاف کوچکی باقی می‌گذارند که متعلق
+/// به کاربر است و باید برگردد.
+///
+/// <b>زمان‌بندی مهم است.</b> نسخهٔ اول این کد بلافاصله پس از تطبیق اجرا می‌شد و در عمل
+/// شکست می‌خورد: قفلِ موجودی <b>بعد از</b> تطبیق ساخته می‌شود (یافتهٔ ممیزی C-5) و
+/// <b>بعدتر</b> توسط تسویهٔ outbox مصرف می‌گردد. پس آزادسازی با هر دو مسابقه می‌داد و
+/// گاهی روی کیف پولی اجرا می‌شد که هنوز چیزی در آن قفل نشده بود.
+///
+/// حالا از پردازشگر outbox و پس از تسویهٔ موفق صدا زده می‌شود. آن نقطه ذاتاً بعد از
+/// ساخته‌شدن قفل است — چون تسویه بدون قفل اصلاً موفق نمی‌شود — و بعد از مصرف آن.
+/// </summary>
+public class OrderCollateralReconciler
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ITradeRepository _tradeRepository;
+    private readonly IWalletApiClient _walletApiClient;
+    private readonly ILogger<OrderCollateralReconciler> _logger;
+
+    public OrderCollateralReconciler(
+        IOrderRepository orderRepository,
+        ITradeRepository tradeRepository,
+        IWalletApiClient walletApiClient,
+        ILogger<OrderCollateralReconciler> logger)
+    {
+        _orderRepository = orderRepository;
+        _tradeRepository = tradeRepository;
+        _walletApiClient = walletApiClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// اگر سفارش کاملاً پر شده باشد، باقی‌ماندهٔ وثیقه‌اش را آزاد می‌کند. برای سفارشی که
+    /// هنوز باز است کاری نمی‌کند، چون وثیقهٔ باقی‌مانده هنوز پشتوانهٔ بخش پرنشده است.
+    /// </summary>
+    public async Task ReleaseResidualLockIfCompletedAsync(Guid orderId)
+    {
+        try
+        {
+            var order = await _orderRepository.GetByIdAsync(orderId);
+            if (order is null || order.Status != OrderStatus.Completed)
+                return;
+
+            var (asset, residual) = await ComputeResidualLockAsync(order);
+            if (residual <= 0)
+                return;
+
+            var (success, message) = await _walletApiClient.UnlockBalanceAsync(order.UserId, asset, residual);
+
+            if (success)
+                _logger.LogInformation(
+                    "Released residual lock of {Residual} {Asset} for completed order {OrderId}.",
+                    residual, asset, orderId);
+            else
+                // بی‌خطر است: باقی‌مانده سر جایش می‌ماند و مغایرت‌گیری (#39) می‌تواند
+                // بعداً برش دارد. هیچ پولی گم نمی‌شود، فقط آزاد نمی‌شود.
+                _logger.LogWarning(
+                    "Could not release residual lock of {Residual} {Asset} for completed order {OrderId}: {Message}",
+                    residual, asset, orderId, message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error releasing residual lock for order {OrderId}", orderId);
+        }
+    }
+
+    /// <summary>
+    /// باقی‌مانده = «آنچه قفل شد» منهای «آنچه معاملات این سفارش مصرف کردند».
+    ///
+    /// «آنچه قفل شد» با همان فرمول و همان جهتِ گرد کردنِ لحظهٔ ثبت سفارش بازمحاسبه
+    /// می‌شود. اگر اینجا Round و آنجا Ceiling باشد، دوباره همان اختلافی ساخته می‌شود
+    /// که این کد برای برداشتنش نوشته شده.
+    ///
+    /// بازمحاسبه فقط به این دلیل ممکن است که قیمت هنگام ثبت سفارش به دقت ستون گرد
+    /// می‌شود؛ پیش از آن، قفل با قیمتِ گرد‌نشده حساب می‌شد و از روی ردیف ذخیره‌شده
+    /// قابل بازسازی نبود.
+    /// </summary>
+    public async Task<(string Asset, decimal Residual)> ComputeResidualLockAsync(Order order)
+    {
+        var parts = order.Asset.Split('/');
+        var baseAsset = parts[0];
+        var quoteAsset = parts.Length > 1 ? parts[1] : parts[0];
+
+        if (order.Side == OrderSide.Buy)
+        {
+            var locked = CurrenciesConstant.CeilingToCurrencyPrecision(order.Amount * order.Price, quoteAsset);
+            var trades = await _tradeRepository.GetTradesByBuyOrderIdAsync(order.Id);
+            return (quoteAsset, locked - trades.Sum(t => t.QuoteQuantity));
+        }
+
+        // سمت فروش: وثیقه دارایی پایه است و هر معامله دقیقاً Quantity مصرف می‌کند،
+        // بدون گرد کردن — پس در حالت عادی باقی‌مانده‌ای ندارد. محاسبه‌اش نگه داشته
+        // می‌شود تا اگر روزی این فرض عوض شد، خودبه‌خود پوشش داده شود.
+        var lockedBase = CurrenciesConstant.RoundToCurrencyPrecision(order.Amount, baseAsset);
+        var sellTrades = await _tradeRepository.GetTradesBySellOrderIdAsync(order.Id);
+        return (baseAsset, lockedBase - sellTrades.Sum(t => t.Quantity));
+    }
+}

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -95,6 +95,19 @@ public class OutboxProcessorService : BackgroundService
                 message.MarkCompleted();
                 _logger.LogInformation("Outbox message {Id} ({Type}, aggregate {AggregateId}) completed.",
                     message.Id, message.Type, message.AggregateId);
+
+                // پس از تسویه، اگر سفارشی کاملاً پر شده باشد باقی‌ماندهٔ وثیقه‌اش آزاد
+                // می‌شود.
+                //
+                // چرا اینجا و نه بلافاصله پس از تطبیق: قفلِ موجودی بعد از تطبیق ساخته
+                // می‌شود (یافتهٔ C-5) و همین‌جا تازه مصرف شده است. اجرای زودتر با هر دو
+                // مسابقه می‌داد — و در تست واقعی روی کیف پولی اجرا شد که هنوز چیزی در
+                // آن قفل نشده بود و شکست خورد (issue #52).
+                //
+                // این فراخوانی گارد خودش را دارد و هرگز استثنا بیرون نمی‌دهد. اگر می‌داد،
+                // بلوک catch پایین یک پیامِ outbox که واقعاً موفق شده را «شکست‌خورده»
+                // علامت می‌زد و دوباره تحویلش می‌داد.
+                await ReleaseResidualCollateralAsync(message, scope);
             }
             catch (Exception ex)
             {
@@ -148,6 +161,35 @@ public class OutboxProcessorService : BackgroundService
                 // stall this guard exists to prevent.
                 db.Entry(message).State = EntityState.Detached;
             }
+        }
+    }
+
+    /// <summary>
+    /// پس از تسویهٔ موفقِ یک معامله، باقی‌ماندهٔ وثیقهٔ هر سفارشی که با آن کامل شده را آزاد می‌کند.
+    ///
+    /// عمداً هیچ استثنایی بیرون نمی‌دهد: تسویه از قبل موفق بوده و نباید به‌خاطر این کارِ
+    /// جانبی «شکست‌خورده» علامت بخورد و دوباره تحویل داده شود. اگر آزادسازی انجام نشود
+    /// هیچ پولی گم نمی‌شود — باقی‌مانده قفل می‌ماند و مغایرت‌گیری (#39) می‌تواند بعداً
+    /// برش دارد.
+    /// </summary>
+    private async Task ReleaseResidualCollateralAsync(OutboxMessage message, IServiceScope scope)
+    {
+        if (message.Type != "TradeSettlement") return;
+
+        try
+        {
+            var trade = JsonSerializer.Deserialize<TradeDto>(message.Payload);
+            if (trade is null) return;
+
+            var reconciler = scope.ServiceProvider.GetRequiredService<OrderCollateralReconciler>();
+
+            await reconciler.ReleaseResidualLockIfCompletedAsync(trade.BuyOrderId);
+            await reconciler.ReleaseResidualLockIfCompletedAsync(trade.SellOrderId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error releasing residual collateral after settling trade {AggregateId}.", message.AggregateId);
         }
     }
 

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -274,11 +274,18 @@ public class OrderMatchingRepository
     /// </summary>
     private static Trade CreateTrade(Order buyOrder, Order sellOrder, decimal quantity, decimal price)
     {
-        // ارزش معامله با دقت واقعی ارز مظنه گرد می‌شود (تومان: بدون اعشار). این همان
-        // مبلغی است که در تسویه از خریدار کسر و به فروشنده پرداخت می‌شود، پس باید با
-        // مبلغی که هنگام ثبت سفارش قفل شده هم‌دقت باشد، وگرنه باقی‌مانده جا می‌ماند.
+        // ارزش معامله رو به پایین گرد می‌شود، در حالی که مبلغ قفلِ سفارش رو به بالا.
+        //
+        // این عدد هم از خریدار کسر و هم به فروشنده پرداخت می‌شود (پس در هر معامله
+        // تراز است)، و همین عدد است که از وثیقهٔ قفل‌شده مصرف می‌گردد. قفل یک بار برای
+        // کل سفارش حساب می‌شود ولی مصرف در هر fill جداگانه؛ اگر هر دو با AwayFromZero
+        // گرد شوند، مجموع مصرف‌ها می‌تواند از قفل بیشتر شود و گاردِ «وثیقهٔ کافی نیست»
+        // یک معاملهٔ کاملاً معتبر را رد کند.
+        //
+        // با جهت‌های مخالف، «مجموع مصرف ≤ قفل» یک تضمین ریاضی است. توضیح کامل روی
+        // CurrenciesConstant.FloorToCurrencyPrecision (issue #52).
         var quoteAsset = buyOrder.Asset.Split('/').Last();
-        var quoteQuantity = CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, quoteAsset);
+        var quoteQuantity = CurrenciesConstant.FloorToCurrencyPrecision(quantity * price, quoteAsset);
 
         // Fees are DISABLED for the MVP (charged at 0%). The real maker/taker fee model —
         // which asset each fee is denominated in (buyer fee should be in the base asset it

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -154,6 +154,32 @@
             return Math.Round(amount, info.DecimalPlaces, MidpointRounding.AwayFromZero);
         }
 
+        /// <summary>
+        /// دقت ذخیره‌سازی قیمت سفارش. ستون Orders.Price از نوع decimal(18,2) است.
+        /// </summary>
+        public const int OrderPriceDecimalPlaces = 2;
+
+        /// <summary>
+        /// گرد کردن قیمت به همان دقتی که ستون دیتابیس می‌تواند نگه دارد.
+        ///
+        /// چرا لازم است: قیمت مثقال بر ۴٫۳۳۱۸ تقسیم می‌شود و نتیجه تا ۲۸ رقم اعشار ادامه
+        /// دارد (مثلاً ۷۹٬۰۰۰٬۰۰۰ ÷ ۴٫۳۳۱۸ = ۱۸۲۳۷۲۲۲٫۴۰۱۷۷۲۹…). مبلغِ قفل‌شده از همان
+        /// مقدارِ کاملِ حافظه حساب می‌شد، ولی خودِ قیمت هنگام ذخیره در ستون به دو رقم
+        /// اعشار گرد می‌شد و تسویه بعداً همان مقدار گردشده را از دیتابیس می‌خواند. دو
+        /// طرفِ یک تساوی با دو قیمتِ متفاوت حساب می‌شدند و اختلافش تا ابد در
+        /// LockedBalance می‌ماند (issue #52).
+        ///
+        /// با گرد کردن در ورودی، قفل و تسویه هر دو از یک عدد استفاده می‌کنند و
+        /// «مبلغ قفل‌شده» از روی خودِ سفارش ذخیره‌شده قابل بازمحاسبه می‌شود.
+        ///
+        /// عمداً به PriceDecimalPlaces جفت معاملاتی تکیه نمی‌کنیم: برای MAUA/IRT مقدار
+        /// آن صفر است در حالی که ستون دو رقم اعشار نگه می‌دارد. گرد کردن به صفر، دقت
+        /// قیمت را از ۰٫۰۱ به ۱ تومان بر گرم تغییر می‌داد که یک تصمیم کسب‌وکاری است نه
+        /// یک رفع باگ. مرجع اینجا ستون است، چون همان چیزی است که واقعاً محدود می‌کند.
+        /// </summary>
+        public static decimal RoundOrderPrice(decimal price) =>
+            Math.Round(price, OrderPriceDecimalPlaces, MidpointRounding.AwayFromZero);
+
         // 🔹 دیکشنری جفت‌های معاملاتی برای دسترسی سریع (case-insensitive)
         private static readonly Dictionary<string, TradingPairInfo> _pairMap =
             AllTradingPairs.ToDictionary(p => p.Symbol, p => p, StringComparer.OrdinalIgnoreCase);

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -155,6 +155,55 @@
         }
 
         /// <summary>
+        /// گرد کردن مبلغ به دقت دارایی، همیشه <b>رو به بالا</b>.
+        ///
+        /// برای مبلغی استفاده می‌شود که به‌عنوان وثیقه قفل می‌شود. با گرد کردن به بالا،
+        /// مقدار قفل‌شده هرگز کمتر از ارزش واقعی سفارش نیست.
+        /// </summary>
+        public static decimal CeilingToCurrencyPrecision(decimal amount, string assetCode)
+        {
+            var info = GetCurrencyInfo(assetCode);
+            if (info is null) return amount;
+
+            var factor = Pow10(info.DecimalPlaces);
+            return Math.Ceiling(amount * factor) / factor;
+        }
+
+        /// <summary>
+        /// گرد کردن مبلغ به دقت دارایی، همیشه <b>رو به پایین</b>.
+        ///
+        /// برای مبلغی استفاده می‌شود که در هر معامله از وثیقه مصرف می‌گردد.
+        ///
+        /// چرا جهت‌ها عمداً مخالف هم انتخاب شده‌اند (issue #52): مبلغ قفل یک بار برای کل
+        /// سفارش حساب می‌شود و مصرف در هر fill جداگانه. اگر هر دو با AwayFromZero گرد
+        /// شوند، مجموعِ مصرف‌ها می‌تواند از مقدار قفل‌شده بیشتر شود و گاردِ «وثیقهٔ کافی
+        /// نیست» یک معاملهٔ کاملاً معتبر را رد کند.
+        ///
+        /// با «قفل رو به بالا، مصرف رو به پایین» این نابرابری همیشه برقرار است:
+        ///
+        ///     Σ Floor(qᵢ × pᵢ) ≤ Σ qᵢ×pᵢ ≤ Σ qᵢ × p_سقف ≤ Q × p_سقف ≤ Ceiling(Q × p_سقف)
+        ///
+        /// یعنی «مجموع مصرف ≤ مقدار قفل‌شده» یک تضمین ریاضی است، نه یک احتمال — و به
+        /// یکسان بودن قیمت fillها هم وابسته نیست، چون خریدار هرگز بیش از قیمت سقف
+        /// سفارش خودش پرداخت نمی‌کند. اختلاف باقی‌مانده هنگام تکمیل یا لغو آزاد می‌شود.
+        /// </summary>
+        public static decimal FloorToCurrencyPrecision(decimal amount, string assetCode)
+        {
+            var info = GetCurrencyInfo(assetCode);
+            if (info is null) return amount;
+
+            var factor = Pow10(info.DecimalPlaces);
+            return Math.Floor(amount * factor) / factor;
+        }
+
+        private static decimal Pow10(int exponent)
+        {
+            decimal result = 1m;
+            for (var i = 0; i < exponent; i++) result *= 10m;
+            return result;
+        }
+
+        /// <summary>
         /// دقت ذخیره‌سازی قیمت سفارش. ستون Orders.Price از نوع decimal(18,2) است.
         /// </summary>
         public const int OrderPriceDecimalPlaces = 2;

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -144,6 +144,23 @@ public class WalletRepository : IWalletRepository
         var wallet = await GetWalletAsync(userId, asset);
         if (wallet == null) throw new ArgumentNullException("کیف پول پیدا نشد", nameof(wallet));
 
+        if (amount < 0)
+            throw new ArgumentOutOfRangeException(nameof(amount), "مقدار آزادسازی نمی‌تواند منفی باشد.");
+
+        // آزادسازیِ بیش از آنچه قفل است، LockedBalance را منفی می‌کند و همزمان Balance
+        // را بالا می‌برد — یعنی از هیچ، پول می‌سازد. پیش‌تر هیچ گاردی وجود نداشت و
+        // مسیر لغو سفارش مقدار را با فرمولی متفاوت از فرمول قفل حساب می‌کرد، پس این
+        // حالت واقعاً قابل رسیدن بود (issue #52).
+        if (amount > wallet.LockedBalance)
+        {
+            _logger.LogError(
+                "Refusing to unlock {Amount} {Asset} for user {UserId}: only {Locked} is locked.",
+                amount, asset, userId, wallet.LockedBalance);
+
+            throw new InvalidOperationException(
+                $"مقدار آزادسازی ({amount}) از موجودی قفل‌شده ({wallet.LockedBalance}) بیشتر است.");
+        }
+
         var transaction = Transaction.Create(
           wallet.Id,
           amount,

--- a/src/Wallet/Wallet.Tests/LockResidueTests.cs
+++ b/src/Wallet/Wallet.Tests/LockResidueTests.cs
@@ -24,11 +24,13 @@ public class LockResidueTests
     private static decimal PricePerGram(decimal perMesghal) =>
         perMesghal / CurrenciesConstant.GramsPerMesghal;
 
+    /// <summary>قفل: رو به بالا — همان چیزی که OrderService استفاده می‌کند.</summary>
     private static decimal Lock(decimal quantity, decimal price) =>
-        CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
+        CurrenciesConstant.CeilingToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
 
+    /// <summary>مصرف هر معامله: رو به پایین — همان چیزی که CreateTrade استفاده می‌کند.</summary>
     private static decimal Fill(decimal quantity, decimal price) =>
-        CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
+        CurrenciesConstant.FloorToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
 
     /// <summary>
     /// منبع ۱. قیمتِ گردشده همان است که ذخیره و بعداً برای تسویه خوانده می‌شود، پس قفل
@@ -74,41 +76,75 @@ public class LockResidueTests
         var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
 
         var locked = Lock(10m, price);
-
-        // اندازهٔ fillها اهمیت دارد و انتخابشان بی‌دلیل نیست: با ۳+۳+۴ گرد کردن‌ها
-        // یکدیگر را خنثی می‌کنند (−۰٫۲ −۰٫۲ +۰٫۴ = ۰) و باقی‌مانده صفر می‌شود. یعنی
-        // یک ترکیب خوش‌شانس می‌تواند این باگ را پنهان کند — که دقیقاً همان دلیلی است
-        // که چند ساعت به نظر می‌رسید باقی‌مانده «رشد نمی‌کند».
         var consumed = Fill(3m, price) + Fill(3m, price) + Fill(3m, price) + Fill(1m, price);
 
+        // باقی‌مانده وجود دارد و صرفاً با گرد کردن قیمت از بین نمی‌رود — برای همین
+        // آزادسازی در پایان سفارش لازم است و نمی‌توان به گرد کردن اکتفا کرد.
         Assert.NotEqual(locked, consumed);
-        Assert.Equal(1m, locked - consumed);
+        Assert.True(locked > consumed);
     }
 
     /// <summary>
-    /// ⚠️ این تست یک نقصِ <b>رفع‌نشده</b> را تثبیت می‌کند، نه رفتار مطلوب را.
-    ///
-    /// جهت دیگرِ همان مشکل و خطرناک‌ترش: مجموع fillها می‌تواند از مقدار قفل‌شده
-    /// **بیشتر** شود. آن‌وقت گاردِ «وثیقهٔ قفل‌شده کافی نیست» روی یک معاملهٔ کاملاً
-    /// معتبر فعال می‌شود، سفارش هرگز به Completed نمی‌رسد و در نتیجه آزادسازیِ
-    /// باقی‌مانده هم اجرا نمی‌شود.
-    ///
-    /// گرد کردن قیمت و آزادسازی باقی‌مانده — که در همین تغییر اضافه شدند — این حالت
-    /// را رفع نمی‌کنند. اینجا عمداً ثبت شده تا وقتی رفع شد، این تست شکست بخورد و
-    /// کسی مجبور شود آگاهانه به‌روزش کند. جزئیات در issue #52.
+    /// همان حالتی که پیش‌تر بیش‌مصرف می‌کرد: پنج fill دو گرمی، که هرکدام کسر ۰٫۸ دارد.
+    /// با AwayFromZero همه رو به بالا گرد می‌شدند و مجموعشان ۱ تومان از قفل بیشتر
+    /// می‌شد، پس گاردِ «وثیقهٔ کافی نیست» یک معاملهٔ کاملاً معتبر را رد می‌کرد.
     /// </summary>
     [Fact]
-    public void KnownGap_PerFillRounding_CanStillOverConsumeTheLock()
+    public void FillsThatUsedToOverConsume_NoLongerDo()
     {
         var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
 
         var locked = Lock(10m, price);
-        // پنج fill دو گرمی: هرکدام ۰٫۸ دارد که رو به بالا گرد می‌شود.
         var consumed = Fill(2m, price) * 5;
 
-        Assert.True(consumed > locked,
-            $"consumed {consumed} should exceed locked {locked}, which is what rejects a valid trade");
-        Assert.Equal(1m, consumed - locked);
+        Assert.True(consumed <= locked, $"consumed {consumed} must not exceed locked {locked}");
+    }
+
+    /// <summary>
+    /// خودِ تضمین، نه یک نمونه: برای هر ترکیبی از اندازهٔ fillها، مجموع مصرف هرگز از
+    /// مقدار قفل‌شده بیشتر نمی‌شود.
+    ///
+    ///     Σ Floor(qᵢ × p) ≤ Σ qᵢ×p = Q×p ≤ Ceiling(Q×p)
+    ///
+    /// این چیزی است که یک تست تک‌نمونه‌ای نمی‌تواند نشان دهد — یک ترکیب خوش‌شانس
+    /// می‌تواند سبز بماند در حالی که ترکیب دیگری می‌شکند. دقیقاً همان اتفاقی که با
+    /// ۳+۳+۴ افتاد و باعث شد چند ساعت به نظر برسد باقی‌مانده رشد نمی‌کند.
+    /// </summary>
+    [Theory]
+    [InlineData(new double[] { 2, 2, 2, 2, 2 })]
+    [InlineData(new double[] { 3, 3, 3, 1 })]
+    [InlineData(new double[] { 3, 3, 4 })]
+    [InlineData(new double[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 })]
+    [InlineData(new double[] { 0.1, 0.3, 0.7, 1.9, 7 })]
+    [InlineData(new double[] { 9.99, 0.01 })]
+    public void ConsumptionNeverExceedsTheLock_ForAnyFillPattern(double[] fills)
+    {
+        var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
+        var total = fills.Sum(f => (decimal)f);
+
+        var locked = Lock(total, price);
+        var consumed = fills.Sum(f => Fill((decimal)f, price));
+
+        Assert.True(consumed <= locked,
+            $"fills [{string.Join(", ", fills)}] consumed {consumed} but only {locked} was locked");
+    }
+
+    /// <summary>
+    /// و باقی‌مانده باید ناچیز بماند — حداکثر یک واحد به‌ازای هر fill. اگر روزی جهت
+    /// گرد کردن اشتباه عوض شود، مجموع مصرف کمتر می‌شود ولی این تست هم می‌شکند.
+    /// </summary>
+    [Theory]
+    [InlineData(new double[] { 2, 2, 2, 2, 2 })]
+    [InlineData(new double[] { 3, 3, 3, 1 })]
+    [InlineData(new double[] { 0.1, 0.3, 0.7, 1.9, 7 })]
+    public void TheResidueStaysBoundedByOneUnitPerFill(double[] fills)
+    {
+        var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
+        var total = fills.Sum(f => (decimal)f);
+
+        var residue = Lock(total, price) - fills.Sum(f => Fill((decimal)f, price));
+
+        Assert.InRange(residue, 0m, fills.Length + 1);
     }
 
     /// <summary>
@@ -125,6 +161,7 @@ public class LockResidueTests
         var residue = locked - consumed;
 
         Assert.NotEqual(0m, residue);           // اول مطمئن شویم چیزی برای آزاد کردن هست
+        Assert.True(residue > 0);               // و همیشه در جهت آزادسازی، نه بدهکاری
         Assert.Equal(0m, locked - consumed - residue);
     }
 

--- a/src/Wallet/Wallet.Tests/LockResidueTests.cs
+++ b/src/Wallet/Wallet.Tests/LockResidueTests.cs
@@ -1,0 +1,144 @@
+using TallaEgg.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// وثیقهٔ قفل‌شده باید پس از پر شدن کامل سفارش، کاملاً مصرف یا آزاد شود.
+///
+/// دو منبع مستقل باقی‌مانده وجود داشت (issue #52):
+///
+/// ۱. یک‌باره، هنگام قفل: ربات قیمت را گرد‌نشده می‌فرستاد (قیمت مثقال ÷ ۴٫۳۳۱۸) و قفل
+///    از همان مقدار حساب می‌شد، ولی ستون Orders.Price فقط دو رقم اعشار نگه می‌دارد و
+///    تسویه قیمتِ گردشده را از دیتابیس می‌خواند.
+///
+/// ۲. در هر fill: مصرف هر معامله جداگانه گرد می‌شود، و مجموعِ مقادیرِ جداگانه‌گردشده
+///    با مقدارِ یک‌بار‌گردشده برابر نیست.
+///
+/// این تست‌ها روی خودِ حسابِ عددی کار می‌کنند، چون همین حساب است که اشتباه بود.
+/// </summary>
+public class LockResidueTests
+{
+    private const decimal AskPerMesghal = 80_000_000m;
+    private const decimal BidPerMesghal = 79_000_000m;
+
+    private static decimal PricePerGram(decimal perMesghal) =>
+        perMesghal / CurrenciesConstant.GramsPerMesghal;
+
+    private static decimal Lock(decimal quantity, decimal price) =>
+        CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
+
+    private static decimal Fill(decimal quantity, decimal price) =>
+        CurrenciesConstant.RoundToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
+
+    /// <summary>
+    /// منبع ۱. قیمتِ گردشده همان است که ذخیره و بعداً برای تسویه خوانده می‌شود، پس قفل
+    /// باید از همان حساب شود. نرخ خرید انتخاب شده چون ۷۹٬۰۰۰٬۰۰۰ ÷ ۴٫۳۳۱۸ به دو رقم
+    /// اعشار بسته نمی‌شود — همان حالتی که باگ را نشان داد.
+    /// </summary>
+    [Fact]
+    public void LockUsesTheSamePriceThatWillBeStored()
+    {
+        var raw = PricePerGram(BidPerMesghal);              // 18237222.401772935…
+        var stored = CurrenciesConstant.RoundOrderPrice(raw); // 18237222.40
+
+        var lockedFromRawPrice = Lock(1000m, raw);
+        var lockedFromStoredPrice = Lock(1000m, stored);
+
+        // این دو عدد پیش‌تر ۲ تومان اختلاف داشتند و همان اختلاف تا ابد قفل می‌ماند.
+        Assert.NotEqual(lockedFromRawPrice, lockedFromStoredPrice);
+        Assert.Equal(18_237_222_400m, lockedFromStoredPrice);
+    }
+
+    /// <summary>قیمت باید دقیقاً به دقت ستون گرد شود، نه بیشتر و نه کمتر.</summary>
+    [Theory]
+    [InlineData(80_000_000, 18_468_073.32)]
+    [InlineData(79_000_000, 18_237_222.40)]
+    public void PriceIsRoundedToTheColumnScale(decimal perMesghal, decimal expected)
+    {
+        var stored = CurrenciesConstant.RoundOrderPrice(PricePerGram(perMesghal));
+
+        Assert.Equal(expected, stored);
+        Assert.Equal(stored, Math.Round(stored, CurrenciesConstant.OrderPriceDecimalPlaces));
+    }
+
+    /// <summary>
+    /// منبع ۲، و دلیل اینکه گرد کردن قیمت به‌تنهایی کافی نیست: حتی با قیمت یکسان،
+    /// مجموع fillهای جداگانه‌گردشده با قفلِ یک‌بار‌گردشده برابر نیست.
+    ///
+    /// این تست وجودِ باقی‌مانده را اثبات می‌کند تا روشن باشد چرا آزادسازی در پایان
+    /// سفارش لازم است و نمی‌توان صرفاً به گرد کردن قیمت اکتفا کرد.
+    /// </summary>
+    [Fact]
+    public void PerFillRounding_LeavesAResidue_EvenWithTheStoredPrice()
+    {
+        var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
+
+        var locked = Lock(10m, price);
+
+        // اندازهٔ fillها اهمیت دارد و انتخابشان بی‌دلیل نیست: با ۳+۳+۴ گرد کردن‌ها
+        // یکدیگر را خنثی می‌کنند (−۰٫۲ −۰٫۲ +۰٫۴ = ۰) و باقی‌مانده صفر می‌شود. یعنی
+        // یک ترکیب خوش‌شانس می‌تواند این باگ را پنهان کند — که دقیقاً همان دلیلی است
+        // که چند ساعت به نظر می‌رسید باقی‌مانده «رشد نمی‌کند».
+        var consumed = Fill(3m, price) + Fill(3m, price) + Fill(3m, price) + Fill(1m, price);
+
+        Assert.NotEqual(locked, consumed);
+        Assert.Equal(1m, locked - consumed);
+    }
+
+    /// <summary>
+    /// ⚠️ این تست یک نقصِ <b>رفع‌نشده</b> را تثبیت می‌کند، نه رفتار مطلوب را.
+    ///
+    /// جهت دیگرِ همان مشکل و خطرناک‌ترش: مجموع fillها می‌تواند از مقدار قفل‌شده
+    /// **بیشتر** شود. آن‌وقت گاردِ «وثیقهٔ قفل‌شده کافی نیست» روی یک معاملهٔ کاملاً
+    /// معتبر فعال می‌شود، سفارش هرگز به Completed نمی‌رسد و در نتیجه آزادسازیِ
+    /// باقی‌مانده هم اجرا نمی‌شود.
+    ///
+    /// گرد کردن قیمت و آزادسازی باقی‌مانده — که در همین تغییر اضافه شدند — این حالت
+    /// را رفع نمی‌کنند. اینجا عمداً ثبت شده تا وقتی رفع شد، این تست شکست بخورد و
+    /// کسی مجبور شود آگاهانه به‌روزش کند. جزئیات در issue #52.
+    /// </summary>
+    [Fact]
+    public void KnownGap_PerFillRounding_CanStillOverConsumeTheLock()
+    {
+        var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
+
+        var locked = Lock(10m, price);
+        // پنج fill دو گرمی: هرکدام ۰٫۸ دارد که رو به بالا گرد می‌شود.
+        var consumed = Fill(2m, price) * 5;
+
+        Assert.True(consumed > locked,
+            $"consumed {consumed} should exceed locked {locked}, which is what rejects a valid trade");
+        Assert.Equal(1m, consumed - locked);
+    }
+
+    /// <summary>
+    /// باقی‌مانده = «آنچه قفل شد» منهای «آنچه مصرف شد». همان فرمولی که مسیر لغو و
+    /// مسیر تکمیل هر دو استفاده می‌کنند. با آزاد کردن این مقدار، قفل به صفر می‌رسد.
+    /// </summary>
+    [Fact]
+    public void ReleasingTheResidue_BringsTheLockToZero()
+    {
+        var price = CurrenciesConstant.RoundOrderPrice(PricePerGram(BidPerMesghal));
+
+        var locked = Lock(10m, price);
+        var consumed = Fill(3m, price) + Fill(3m, price) + Fill(3m, price) + Fill(1m, price);
+        var residue = locked - consumed;
+
+        Assert.NotEqual(0m, residue);           // اول مطمئن شویم چیزی برای آزاد کردن هست
+        Assert.Equal(0m, locked - consumed - residue);
+    }
+
+    /// <summary>
+    /// سمت فروشنده باقی‌مانده ندارد: وثیقه‌اش دارایی پایه است و هر معامله دقیقاً
+    /// Quantity مصرف می‌کند، بدون گرد کردن. این تست آن فرض را تثبیت می‌کند تا اگر
+    /// روزی عوض شد، سکوت نکند.
+    /// </summary>
+    [Fact]
+    public void SellSide_HasNoResidue()
+    {
+        var locked = CurrenciesConstant.RoundToCurrencyPrecision(10m, CurrenciesConstant.Maua);
+        var consumed = 3m + 3m + 4m;
+
+        Assert.Equal(locked, consumed);
+    }
+}


### PR DESCRIPTION
Closes #52. **Complete fix** — an earlier revision of this PR left the over-consumption half open; it is now closed too.

## Type
- [x] Bug fix (money path — stranded collateral, and a valid trade being rejected)

## The insight

The problem was never that the lock and the fills use two different formulas. It is that the **direction** of their rounding was uncontrolled. Choosing opposite directions makes the inequality hold by construction:

```
lock      = Ceiling(Q × p)        rounded UP
each fill = Floor(qᵢ × pᵢ)        rounded DOWN

Σ Floor(qᵢ × pᵢ)  ≤  Σ qᵢ×pᵢ  ≤  Σ qᵢ × p_limit  ≤  Q × p_limit  ≤  Ceiling(Q × p_limit)
```

**"Total consumed ≤ amount locked" is now a guarantee, not a likelihood.** It does not depend on all fills sharing a price — a buyer never pays above their own limit price — so it survives a real order book, not just today's quote model.

Over-consumption becomes *impossible* rather than improbable, so the settlement guard can no longer reject a valid trade. The residual release collects whatever difference remains.

This replaces the two options considered earlier: telescoping `quoteQuantity` (exact only when every fill trades at the same price) and letting settlement draw from unlocked balance (which would have weakened the C-5 collateral guard). Both were more invasive than the problem deserved.

## What is fixed

**1. Price rounded at entry.** The bot divides the mesghal price by `4.3318`, giving 28 decimals; the lock used that full value while `Orders.Price` stores 2 and settlement read the stored value back. Two sides of one equation, two different prices.

Rounded to 2 decimals — the column — deliberately **not** to the pair's `PriceDecimalPlaces`, which is `0` for MAUA/IRT. Rounding to 0 would change price granularity from 0.01 to 1 toman per gram: a business decision, not a bug fix.

Side effect the rest of the fix depends on: the locked amount is now exactly recomputable from the stored order, so no new column is needed to know what was locked.

**2. Opposite rounding directions**, as above.

**3. Residual released** on completion (matching engine) and cancellation (`OrderService`), computed as *"what was locked" − "what its trades consumed"*. The cancel path previously used `RemainingAmount × Price` with no rounding at all — a **third** formula for the same quantity. Both residual calculations now use `Ceiling`, mirroring what actually locked.

**4. `UnlockBalanceAsync` refuses to unlock more than is locked.** Without it an overshoot drives `LockedBalance` negative while raising `Balance` — money from nothing — and the cancel path's divergent formula made that reachable.

## What does not change

The settlement contract, the C-5 collateral guard, and the fact that each trade's amount is a single number debited from the buyer and credited to the seller — so every trade still balances exactly.

## Testing

`Wallet.Tests`: **68/68 pass** (was 52).

The single-example over-consumption test is replaced by a `Theory` over six fill patterns, because **a single example proves nothing here**: 3+3+4 g happens to cancel exactly (`−0.2 −0.2 +0.4 = 0`). That is precisely why the residue appeared not to grow during hours of manual testing — a lucky fill sequence hides the bug completely.

Verified the guarantee comes from the rounding direction and not from the examples: switching the fill helper back to `AwayFromZero` fails 5 tests, including both `Theory` cases that mix round-up and round-down fills.

Full solution builds clean, 0 errors.

## Note on placement

The completion-time release runs **outside** the match transaction, because the wallet lives in another service and database. If it fails the state is no worse than today — the residue simply stays — and #39's reconciliation can pick it up later.