### PR TITLE
refactor(#65): make BotHandler testable — message builders, messenger, conversation store, flow tests

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Core/Interfaces/IBotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Core/Interfaces/IBotHandler.cs
@@ -1,4 +1,4 @@
-using Telegram.Bot.Types;
+﻿using Telegram.Bot.Types;
 
 namespace TallaEgg.TelegramBot.Core.Interfaces;
 
@@ -7,4 +7,10 @@ public interface IBotHandler
     Task HandleMessageAsync(Message message);
     
     Task HandleCallbackQueryAsync(CallbackQuery callbackQuery);
+
+    /// <summary>
+    /// Starts background work (the conversation sweep and the startup announcement).
+    /// Separate from construction so building the handler has no side effects (issue #65).
+    /// </summary>
+    void Start(CancellationToken cancellationToken = default);
 } 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -16,9 +16,11 @@ using TallaEgg.TelegramBot.Core.Interfaces;
 using TallaEgg.TelegramBot.Core.Utilties;
 using TallaEgg.TelegramBot.Infrastructure;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
 using TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram;
 using TallaEgg.TelegramBot.Infrastructure.Handlers;
 using TallaEgg.TelegramBot.Infrastructure.Messages;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
 using TallaEgg.TelegramBot.Infrastructure.Services;
 using Telegram.Bot;
 using Telegram.Bot.Exceptions;
@@ -31,26 +33,22 @@ using static TallaEgg.TelegramBot.Infrastructure.Clients.OrderApiClient;
 
 namespace TallaEgg.TelegramBot
 {
-    public class OrderState
-    {
-        public OrderType OrderType { get; set; } // "Limit" or "Market"
-        public TradingType TradingType { get; set; } // "Spot" or "Futures"
-        public OrderSide OrderSide { get; set; } // "Buy" or "Sell"
-        public string Asset { get; set; } = "";
-        public decimal Amount { get; set; }
-        public decimal Price { get; set; }
-        public decimal? BestBidPrice { get; set; }
-        public decimal? BestAskPrice { get; set; }
-        public Guid UserId { get; set; }
-        public bool IsConfirmed { get; set; } = false;
-        public string? Notes { get; set; } = null;
-        public string State { get; internal set; } = "";
-    }
-
     public partial class BotHandler : IBotHandler
     {
         private readonly ILogger<BotHandler> _logger;
+
+        /// <summary>
+        /// Everything this handler says to a chat goes through here, so a test can record
+        /// it instead of Telegram receiving it (issue #65).
+        /// </summary>
+        private readonly IBotMessenger _messenger;
+
+        /// <summary>
+        /// Retained only for the chat-administrator lookup, which is not a messaging
+        /// operation and so is deliberately absent from <see cref="IBotMessenger"/>.
+        /// </summary>
         private readonly ITelegramBotClient _botClient;
+
         private readonly OrderApiClient _orderApi;
         private readonly UsersApiClient _usersApi;
         private readonly AffiliateApiClient _affiliateApi;
@@ -58,19 +56,28 @@ namespace TallaEgg.TelegramBot
         private readonly TelegramLoggerService _telegramLogger;
         private readonly IVersionService _versionService;
 
-        private readonly Dictionary<long, OrderState> _userOrderStates = new();
+        /// <summary>
+        /// Where each customer is in the middle of placing an order. Injected rather than
+        /// owned, so a test can place a customer mid-flow and assert the state is cleared
+        /// afterwards (issue #65).
+        /// </summary>
+        private readonly IConversationStore _conversations;
 
         private bool _requireReferralCode;
         private string _defaultReferralCode;
 
         public BotHandler(ILogger<BotHandler> logger,
-                         ITelegramBotClient botClient, OrderApiClient orderApi, UsersApiClient usersApi,
+                         ITelegramBotClient botClient, IBotMessenger messenger,
+                         IConversationStore conversations,
+                         OrderApiClient orderApi, UsersApiClient usersApi,
                          AffiliateApiClient affiliateApi, WalletApiClient walletApi, TelegramLoggerService telegramLogger, IVersionService versionService,
                          bool requireReferralCode = false, string defaultReferralCode = "ADMIN2024")
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             _botClient = botClient;
+            _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+            _conversations = conversations ?? throw new ArgumentNullException(nameof(conversations));
             _orderApi = orderApi;
             _usersApi = usersApi;
             _affiliateApi = affiliateApi;
@@ -80,7 +87,9 @@ namespace TallaEgg.TelegramBot
             _defaultReferralCode = defaultReferralCode;
             _versionService = versionService;
 
-            // Cleanup old states every hour
+            // Sweep completed conversations hourly. A safety net, not the mechanism: each
+            // order flow clears its own state on the way out. This only catches whatever
+            // an unexpected exit path left behind.
             _ = Task.Run(async () =>
             {
                 while (true)
@@ -88,16 +97,14 @@ namespace TallaEgg.TelegramBot
                     await Task.Delay(TimeSpan.FromHours(1));
                     try
                     {
-                        var expiredKeys = _userOrderStates.Keys
-                            .Where(k => _userOrderStates[k].IsConfirmed)
-                            .ToList();
-                        foreach (var key in expiredKeys)
-                            _userOrderStates.Remove(key);
+                        var removed = _conversations.ClearCompleted();
+                        if (removed > 0)
+                            _logger.LogInformation("Swept {Count} completed conversations.", removed);
                     }
                     catch (Exception ex)
                     {
                         await _telegramLogger.ErrorAsync(ex, "Error in cleanup");
-                        Console.WriteLine($"Error in cleanup: {ex.Message}");
+                        _logger.LogError(ex, "Error sweeping completed conversations.");
                     }
                 }
             });
@@ -120,15 +127,15 @@ namespace TallaEgg.TelegramBot
 
                 if (user == null)
                 {
-                    await _botClient.SendMessage(chatId, "حساب شما پیدا نشد. لطفاً ابتدا با دستور شروع ثبت‌نام کنید.");
+                    await _messenger.SendAsync(chatId, "حساب شما پیدا نشد. لطفاً ابتدا با دستور شروع ثبت‌نام کنید.");
                     await HandleNewUserAsync(chatId, telegramId, message);
                     return;
                 }
 
-                _userOrderStates.TryAdd(chatId, new OrderState
-                {
-                    UserId = user.Id
-                });
+                // Keyed on the Telegram user id, as every other access is. This one line
+                // used the chat id; the two are equal in a private chat, so it worked, but
+                // the entry was written under one key and read under another anywhere else.
+                _conversations.GetOrStart(telegramId, user.Id);
 
                 if (string.IsNullOrEmpty(user?.PhoneNumber))
                 {
@@ -138,7 +145,7 @@ namespace TallaEgg.TelegramBot
 
                 if (user.Status != TallaEgg.Core.Enums.User.UserStatus.Approved)
                 {
-                    await _botClient.SendMessage(
+                    await _messenger.SendAsync(
                          chatId,
                          string.Format(BotMsgs.MsgAccountNotApproved, user.FirstName).AutoRtl()
                      );
@@ -186,7 +193,7 @@ namespace TallaEgg.TelegramBot
                     // Check if referral code is required
                     if (_requireReferralCode)
                     {
-                        await _botClient.SendMessage(chatId, BotMsgs.MsgEnterInvite);
+                        await _messenger.SendAsync(chatId, BotMsgs.MsgEnterInvite);
                     }
                     else
                     {
@@ -212,16 +219,16 @@ namespace TallaEgg.TelegramBot
 
                 //if (useSuccess)
                 //{
-                await _botClient.SendContactKeyboardAsync(chatId);
+                await _messenger.SendContactKeyboardAsync(chatId);
 
                 //else
                 //{
-                //    await _botClient.SendMessage(chatId, $"خطا در استفاده از کد دعوت: {useMessage}");
+                //    await _messenger.SendAsync(chatId, $"خطا در استفاده از کد دعوت: {useMessage}");
                 //}
             }
             else
             {
-                await _botClient.SendMessage(chatId, $"خطا در ثبت‌نام: {regMessage}");
+                await _messenger.SendAsync(chatId, $"خطا در ثبت‌نام: {regMessage}");
             }
         }
 
@@ -242,19 +249,22 @@ namespace TallaEgg.TelegramBot
 
                 if (response.Success)
                 {
-                    await _botClient.SendMessage(chatId, BotMsgs.MsgPhoneSuccess,
+                    await _messenger.SendAsync(chatId, BotMsgs.MsgPhoneSuccess,
                         replyMarkup: new ReplyKeyboardRemove());
                     await ShowMainMenuAsync(chatId);
-                    await _botClient.SendApproveOrRejectUserToAdminsKeyboard(response.Data, Constants.GroupId);
+                    // Looking the admins up needs the raw client; deciding what they see
+                    // does not. Splitting the two keeps the message itself testable.
+                    var adminIds = await _botClient.GetAdminUserIdsAsync(Constants.GroupId);
+                    await _messenger.SendApproveOrRejectUserToAdminsKeyboard(adminIds, response.Data);
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId, response.Message);
+                    await _messenger.SendAsync(chatId, response.Message);
                 }
             }
             else
             {
-                await _botClient.SendContactKeyboardAsync(chatId);
+                await _messenger.SendContactKeyboardAsync(chatId);
             }
         }
 
@@ -276,7 +286,9 @@ namespace TallaEgg.TelegramBot
                                            msgText == BotBtns.BtnSpotSubmitPrice) ?
                                            OrderType.Limit : OrderType.Market;
 
-                    _userOrderStates[telegramId].OrderType = orderType;
+                    // Starts the conversation if the customer has none: this is the first
+                    // step of the order flow, so there is nothing yet to find.
+                    _conversations.GetOrStart(telegramId, userId).OrderType = orderType;
 
                     await ShowSymbolsAsync(chatId, telegramId);
 
@@ -304,9 +316,9 @@ namespace TallaEgg.TelegramBot
 
                 default:
                     // Check if user is in order flow
-                    if (_userOrderStates.ContainsKey(telegramId))
+                    if (_conversations.TryGet(telegramId, out var conversation))
                     {
-                        var orderState = _userOrderStates[telegramId];
+                        var orderState = conversation;
                         if (!orderState.IsConfirmed && orderState.State == "waiting_for_amount")
                         {
                             await HandleOrderAmountInputAsync(chatId, telegramId, msgText);
@@ -337,13 +349,22 @@ namespace TallaEgg.TelegramBot
                 case InlineCallBackData.sell_spot:
 
                     OrderSide orderSide = data == InlineCallBackData.buy_spot ? OrderSide.Buy : OrderSide.Sell;
-                    _userOrderStates[telegramId].OrderSide = orderSide;
 
-                    _userOrderStates[telegramId].State = "waiting_for_amount";
+                    if (!_conversations.TryGet(telegramId, out var sideConversation))
+                    {
+                        // The customer tapped a button from a message whose conversation is
+                        // gone — after a restart, or after the flow already finished. Sending
+                        // them back to the menu beats a NullReferenceException.
+                        await _messenger.SendAsync(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
+                        break;
+                    }
 
-                    await _botClient.DeleteMessage(chatId, message.Id);
+                    sideConversation.OrderSide = orderSide;
+                    sideConversation.State = "waiting_for_amount";
 
-                    await _botClient.SendMessage(chatId,
+                    await _messenger.DeleteAsync(chatId, message.Id);
+
+                    await _messenger.SendAsync(chatId,
                                                  $"لطفاً مقدار را وارد کنید.",
                                                  replyMarkup: new ReplyKeyboardRemove());
 
@@ -354,10 +375,7 @@ namespace TallaEgg.TelegramBot
                     break;
 
                 case InlineCallBackData.cancel_order:
-                    if (_userOrderStates.ContainsKey(telegramId))
-                    {
-                        _userOrderStates.Remove(telegramId);
-                    }
+                    _conversations.Clear(telegramId);
                     await ShowMainMenuAsync(chatId);
                     break;
 
@@ -365,15 +383,11 @@ namespace TallaEgg.TelegramBot
                 // وجود ندارد و شارژ حساب توسط طلافروشی انجام می‌شود.
                 case InlineCallBackData.charge_card:
                 case InlineCallBackData.charge_bank:
-                    await _botClient.SendMessage(chatId, BotMsgs.MsgChargeInfo);
+                    await _messenger.SendAsync(chatId, BotMsgs.MsgChargeInfo);
                     break;
 
                 case InlineCallBackData.back_to_main:
-                    // Clear any order state
-                    if (_userOrderStates.ContainsKey(telegramId))
-                    {
-                        _userOrderStates.Remove(telegramId);
-                    }
+                    _conversations.Clear(telegramId);
                     await ShowMainMenuAsync(chatId);
                     break;
 
@@ -383,15 +397,14 @@ namespace TallaEgg.TelegramBot
                     {
                         var asset = data.Substring(6); // Remove "asset_" prefix
 
-                        if (!_userOrderStates.ContainsKey(telegramId))
+                        if (!_conversations.TryGet(telegramId, out var assetConversation))
                         {
-                            await _botClient.SendMessage(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
+                            await _messenger.SendAsync(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
                             return;
                         }
 
-                        _userOrderStates[telegramId].Asset = asset;
-
-                        _userOrderStates[telegramId].State = "waiting_for_select_side";
+                        assetConversation.Asset = asset;
+                        assetConversation.State = "waiting_for_select_side";
 
                         TallaEgg.Core.DTOs.ApiResponse<BestPricesDto> apiResponse = await _orderApi.GetBestPricesAsync(asset);
                         if (apiResponse != null && apiResponse.Success)
@@ -399,7 +412,7 @@ namespace TallaEgg.TelegramBot
                             apiResponse.Data.BestBidPrice *= 4.3318m;
                             apiResponse.Data.BestAskPrice *= 4.3318m;
 
-                            await _botClient.DeleteMessage(chatId, message.Id);
+                            await _messenger.DeleteAsync(chatId, message.Id);
 
                             // قیمت می‌تواند خالی باشد (وقتی در آن سمت بازار سفارشی نیست).
                             // نمایش صفر گمراه‌کننده است، پس پیام صریح نشان داده می‌شود.
@@ -407,16 +420,16 @@ namespace TallaEgg.TelegramBot
                                 ? $"{PersianFormat.Number(price.Value)} تومان"
                                 : BotMsgs.MsgPriceNotAvailable;
 
-                            await _botClient.SendMessage(chatId,
+                            await _messenger.SendAsync(chatId,
                                             string.Format(BotMsgs.MsgBestPrices,
                                                 FormatPrice(apiResponse.Data.BestBidPrice),
                                                 FormatPrice(apiResponse.Data.BestAskPrice)));
 
-                            _userOrderStates[telegramId].BestBidPrice = apiResponse.Data.BestBidPrice;
-                            _userOrderStates[telegramId].BestAskPrice = apiResponse.Data.BestAskPrice;
+                            assetConversation.BestBidPrice = apiResponse.Data.BestBidPrice;
+                            assetConversation.BestAskPrice = apiResponse.Data.BestAskPrice;
                         }
 
-                        await _botClient.SendSpotSideMenuKeyboard(chatId);
+                        await _messenger.SendSpotSideMenuKeyboard(chatId);
 
                     }
                     else if (data.StartsWith("approve_"))
@@ -446,7 +459,7 @@ namespace TallaEgg.TelegramBot
                             var text = await OrderListHandler.BuildOrdersListAsync(page.Data!, pageNum);
 
                             // ویرایش پیام قبلی
-                            await _botClient.EditMessageText(
+                            await _messenger.EditTextAsync(
                                 chatId: callbackQuery.Message.Chat.Id,
                                 messageId: callbackQuery.Message.MessageId,
                                 text: text,
@@ -454,7 +467,7 @@ namespace TallaEgg.TelegramBot
                             );
 
                             // بستن "لطفاً چند لحظه صبر کنید…" روی دکمه
-                            await _botClient.AnswerCallbackQuery(callbackQuery.Id);
+                            await _messenger.AnswerCallbackAsync(callbackQuery.Id);
                         }
                     }
                     else if (data.StartsWith("trades_"))
@@ -471,7 +484,7 @@ namespace TallaEgg.TelegramBot
                             var text = await TradeListHandler.BuildTradesListAsync(page.Data!, pageNum, uid);
 
                             // ویرایش پیام قبلی
-                            await _botClient.EditMessageText(
+                            await _messenger.EditTextAsync(
                                 chatId: callbackQuery.Message.Chat.Id,
                                 messageId: callbackQuery.Message.MessageId,
                                 text: text,
@@ -479,7 +492,7 @@ namespace TallaEgg.TelegramBot
                             );
 
                             // بستن "لطفاً چند لحظه صبر کنید…" روی دکمه
-                            await _botClient.AnswerCallbackQuery(callbackQuery.Id);
+                            await _messenger.AnswerCallbackAsync(callbackQuery.Id);
                         }
                     }
                     else if (data.StartsWith("cancel_order_"))
@@ -490,10 +503,10 @@ namespace TallaEgg.TelegramBot
                             var result = await _orderApi.CancelOrderAsync(orderId);
                             if (result.success)
                             {
-                                await _botClient.AnswerCallbackQuery(callbackQuery.Id, "✅ سفارش شما لغو شد و مبلغ درگیر آزاد گردید.");
+                                await _messenger.AnswerCallbackAsync(callbackQuery.Id, "✅ سفارش شما لغو شد و مبلغ درگیر آزاد گردید.");
                                 
                                 // حذف پیام یا به‌روزرسانی آن
-                                await _botClient.EditMessageText(
+                                await _messenger.EditTextAsync(
                                     chatId: callbackQuery.Message.Chat.Id,
                                     messageId: callbackQuery.Message.MessageId,
                                     text: "✅ سفارش لغو شد و از فهرست حذف گردید.",
@@ -502,7 +515,7 @@ namespace TallaEgg.TelegramBot
                             }
                             else
                             {
-                                await _botClient.AnswerCallbackQuery(callbackQuery.Id, $"❌ خطا در لغو سفارش: {result.message}");
+                                await _messenger.AnswerCallbackAsync(callbackQuery.Id, $"❌ خطا در لغو سفارش: {result.message}");
                             }
                         }
                     }
@@ -520,7 +533,7 @@ namespace TallaEgg.TelegramBot
                             var text = await UserListHandler.BuildUsersListAsync(page.Data!, newPage, query);
 
                             // ویرایش پیام قبلی
-                            await _botClient.EditMessageText(
+                            await _messenger.EditTextAsync(
                                 chatId: callbackQuery.Message.Chat.Id,
                                 messageId: callbackQuery.Message.MessageId,
                                 text: text,
@@ -529,13 +542,13 @@ namespace TallaEgg.TelegramBot
                             );
 
                             // بستن "لطفاً چند لحظه صبر کنید…" روی دکمه
-                            await _botClient.AnswerCallbackQuery(callbackQuery.Id);
+                            await _messenger.AnswerCallbackAsync(callbackQuery.Id);
                         }
                     }
                     break;
             }
 
-            await _botClient.AnswerCallbackQuery(callbackQuery.Id);
+            await _messenger.AnswerCallbackAsync(callbackQuery.Id);
         }
         /// <summary>
         /// شاید بهتر باشه یوزرو کش کنیم که زیاد ریکئست نفرستیم
@@ -549,7 +562,7 @@ namespace TallaEgg.TelegramBot
 
             if (user == null)
             {
-                await _botClient.SendMessage(chatId, "حساب شما پیدا نشد. لطفاً ابتدا با دستور شروع ثبت‌نام کنید.");
+                await _messenger.SendAsync(chatId, "حساب شما پیدا نشد. لطفاً ابتدا با دستور شروع ثبت‌نام کنید.");
                 throw new Exception("User not found");
             }
 
@@ -563,11 +576,11 @@ namespace TallaEgg.TelegramBot
 
             if (await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin)
             {
-                await _botClient.SendMainKeyboardForAdminAsync(chatId);
+                await _messenger.SendMainKeyboardForAdminAsync(chatId);
             }
             else
             {
-                await _botClient.SendMainKeyboardForUserAsync(chatId);
+                await _messenger.SendMainKeyboardForUserAsync(chatId);
             }
         }
 
@@ -575,11 +588,11 @@ namespace TallaEgg.TelegramBot
         {
             if (await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin)
             {
-                await _botClient.SendAccountingMenuKeyboardForAdmin(chatId);
+                await _messenger.SendAccountingMenuKeyboardForAdmin(chatId);
             }
             else
             {
-                await _botClient.SendAccountingMenuKeyboard(chatId);
+                await _messenger.SendAccountingMenuKeyboard(chatId);
             }
         }
 
@@ -596,7 +609,7 @@ namespace TallaEgg.TelegramBot
 
             helpText += BotMsgs.MsgSupportFooter;
 
-            await _botClient.SendMessage(chatId, helpText);
+            await _messenger.SendAsync(chatId, helpText);
         }
         private async Task ShowOrderHistory(long chatId, Guid userId)
         {
@@ -606,7 +619,7 @@ namespace TallaEgg.TelegramBot
             {
                 var text = await OrderListHandler.BuildOrdersListAsync(page.Data!, 1);
 
-                await _botClient.SendMessage(
+                await _messenger.SendAsync(
                     chatId: chatId,
                     text: text,
                     replyMarkup: OrderListHandler.BuildPagingKeyboard(page.Data!, 1, userId)
@@ -621,7 +634,7 @@ namespace TallaEgg.TelegramBot
             {
                 var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1, userId);
 
-                await _botClient.SendMessage(
+                await _messenger.SendAsync(
                     chatId: chatId,
                     text: text,
                     replyMarkup: TradeListHandler.BuildPagingKeyboard(page.Data!, 1, userId)
@@ -645,7 +658,7 @@ namespace TallaEgg.TelegramBot
 
                 // متن ساده ارسال می‌شود؛ با MarkdownV2 نشانه‌های قالب‌بندی escape می‌شدند
                 // و به‌صورت ستارهٔ خام به کاربر نمایش داده می‌شدند.
-                await _botClient.SendMessage(
+                await _messenger.SendAsync(
                     chatId: chatId,
                     text: text,
                     replyMarkup: keyboard
@@ -653,7 +666,7 @@ namespace TallaEgg.TelegramBot
             }
             else
             {
-                await _botClient.SendMessage(chatId,
+                await _messenger.SendAsync(chatId,
                     string.Format(BotMsgs.MsgActiveOrdersFailed, response.Message));
             }
         }
@@ -693,19 +706,19 @@ namespace TallaEgg.TelegramBot
 
                     stringBuilder.Append(BotMsgs.MsgBalanceFooter);
 
-                    await _botClient.SendMessage(chatId, stringBuilder.ToString());
+                    await _messenger.SendAsync(chatId, stringBuilder.ToString());
 
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId, BotMsgs.MsgNoWallet);
+                    await _messenger.SendAsync(chatId, BotMsgs.MsgNoWallet);
 
                 }
             }
             else
             {
 
-                await _botClient.SendMessage(chatId, res.Message);
+                await _messenger.SendAsync(chatId, res.Message);
             }
 
 
@@ -723,7 +736,7 @@ namespace TallaEgg.TelegramBot
             try
             {
                 // بررسی وجود state کاربر
-                if (!_userOrderStates.ContainsKey(telegramId))
+                if (!_conversations.TryGet(telegramId, out var conversation))
                 {
                     _logger.LogWarning("User order state not found for telegramId: {TelegramId}", telegramId);
                     await SendErrorMessageAsync(chatId, "خطا در پردازش سفارش. لطفاً از منوی اصلی دوباره شروع کنید.");
@@ -878,22 +891,17 @@ namespace TallaEgg.TelegramBot
         }
 
         /// <summary>
-        /// ارسال پیام با retry mechanism
+        /// Sends a message, retrying on transient failure.
         /// </summary>
-        /// <param name="chatId">شناسه چت</param>
-        /// <param name="text">متن پیام</param>
-        /// <param name="keyboard">کیبورد inline (اختیاری)</param>
-        /// <param name="maxRetries">حداکثر تعداد تلاش مجدد</param>
-        /// <returns>پیام ارسال شده یا null در صورت شکست</returns>
-        private async Task<Message?> SendMessageWithRetryAsync(long chatId, string text,
+        /// <returns>The sent message's id, or null if every attempt failed.</returns>
+        private async Task<int?> SendMessageWithRetryAsync(long chatId, string text,
             InlineKeyboardMarkup? keyboard = null, int maxRetries = 3)
         {
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {
                 try
                 {
-                    var message = await _botClient.SendMessage(chatId, text, replyMarkup: keyboard);
-                    return message;
+                    return await _messenger.SendAsync(chatId, text, replyMarkup: keyboard);
                 }
                 catch (ApiRequestException apiEx) when (apiEx.ErrorCode == 429) // Rate limiting
                 {
@@ -924,7 +932,7 @@ namespace TallaEgg.TelegramBot
         {
             try
             {
-                await _botClient.SendMessage(chatId, $"❌ {errorMessage}");
+                await _messenger.SendAsync(chatId, $"❌ {errorMessage}");
             }
             catch (Exception ex)
             {
@@ -934,19 +942,19 @@ namespace TallaEgg.TelegramBot
 
         private async Task HandleOrderAmountInputAsync(long chatId, long telegramId, string amountText)
         {
-            if (!_userOrderStates.ContainsKey(telegramId))
+            if (!_conversations.TryGet(telegramId, out var conversation))
             {
-                await _botClient.SendMessage(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
+                await _messenger.SendAsync(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
                 return;
             }
 
             if (!decimal.TryParse(amountText, out var amount) || amount <= 0)
             {
-                await _botClient.SendMessage(chatId, "لطفاً مقدار معتبر وارد کنید.");
+                await _messenger.SendAsync(chatId, "لطفاً مقدار معتبر وارد کنید.");
                 return;
             }
 
-            var orderState = _userOrderStates[telegramId];
+            var orderState = conversation;
 
             orderState.Amount = amount;
 
@@ -974,7 +982,7 @@ namespace TallaEgg.TelegramBot
                 var quoteMessage = OrderConfirmationMessage.Build(
                     orderState.Asset, orderState.OrderSide, orderState.Amount, pricePerGram);
 
-                await _botClient.SendMessage(chatId, quoteMessage,
+                await _messenger.SendAsync(chatId, quoteMessage,
                     replyMarkup: new InlineKeyboardMarkup(new[]
                     {
                         new InlineKeyboardButton[]
@@ -996,7 +1004,7 @@ namespace TallaEgg.TelegramBot
                     ? BotMsgs.MsgEnterPriceGold
                     : string.Format(BotMsgs.MsgEnterPrice, PersianFormat.Symbol(orderState.Asset));
 
-                await _botClient.SendMessage(chatId, pricePrompt,
+                await _messenger.SendAsync(chatId, pricePrompt,
                  replyMarkup: new ReplyKeyboardRemove());
             }
             else if (orderState.OrderType == OrderType.Market)
@@ -1011,8 +1019,8 @@ namespace TallaEgg.TelegramBot
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId, "خطا در دریافت بهترین قیمت بازار. لطفاً دوباره تلاش کنید.");
-                    _userOrderStates.Remove(telegramId);
+                    await _messenger.SendAsync(chatId, "خطا در دریافت بهترین قیمت بازار. لطفاً دوباره تلاش کنید.");
+                    _conversations.Clear(telegramId);
                     return;
                 }
 
@@ -1022,19 +1030,19 @@ namespace TallaEgg.TelegramBot
 
         private async Task HandleOrderPriceInputAsync(long chatId, long telegramId, string priceStr)
         {
-            if (!_userOrderStates.ContainsKey(telegramId))
+            if (!_conversations.TryGet(telegramId, out var conversation))
             {
-                await _botClient.SendMessage(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
+                await _messenger.SendAsync(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
                 return;
             }
 
             if (!decimal.TryParse(priceStr, out var price) || price <= 0)
             {
-                await _botClient.SendMessage(chatId, "لطفاً قیمت معتبر وارد کنید.");
+                await _messenger.SendAsync(chatId, "لطفاً قیمت معتبر وارد کنید.");
                 return;
             }
 
-            var orderState = _userOrderStates[telegramId];
+            var orderState = conversation;
             orderState.Price = price;
             orderState.State = "";
 
@@ -1064,7 +1072,7 @@ namespace TallaEgg.TelegramBot
             if (!validateCreditAndBalance.Success || !hasSufficientBalance)
             {
                 var backBtn = new KeyboardButton(BotBtns.BtnBack);
-                await _botClient.SendMessage(chatId,
+                await _messenger.SendAsync(chatId,
                     string.Format(BotMsgs.MsgInsufficientBalance, validateCreditAndBalance.Message),
                     replyMarkup: new ReplyKeyboardMarkup(new[]
                     {
@@ -1073,7 +1081,7 @@ namespace TallaEgg.TelegramBot
                     {
                         ResizeKeyboard = true
                     });
-                _userOrderStates.Remove(telegramId);
+                _conversations.Clear(telegramId);
                 return;
             }
 
@@ -1098,18 +1106,18 @@ namespace TallaEgg.TelegramBot
             });
 
             //orderState.IsConfirmed = true;
-            await _botClient.SendMessage(chatId, confirmationMessage, replyMarkup: keyboard);
+            await _messenger.SendAsync(chatId, confirmationMessage, replyMarkup: keyboard);
         }
 
         private async Task HandleOrderConfirmationAsync(long chatId, long telegramId)
         {
-            if (!_userOrderStates.ContainsKey(telegramId))
+            if (!_conversations.TryGet(telegramId, out var conversation))
             {
-                await _botClient.SendMessage(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
+                await _messenger.SendAsync(chatId, "خطا در پردازش سفارش. لطفاً دوباره تلاش کنید.");
                 return;
             }
 
-            var orderState = _userOrderStates[telegramId];
+            var orderState = conversation;
 
             try
             {
@@ -1139,7 +1147,7 @@ namespace TallaEgg.TelegramBot
                 var backBtn = new KeyboardButton(BotBtns.BtnBack);
                 if (orderSuccess)
                 {
-                    await _botClient.SendMessage(chatId, BotMsgs.MsgOrderSuccess,
+                    await _messenger.SendAsync(chatId, BotMsgs.MsgOrderSuccess,
                         replyMarkup: new ReplyKeyboardMarkup(new[]
                         {
                             new KeyboardButton[] { backBtn }
@@ -1158,7 +1166,7 @@ namespace TallaEgg.TelegramBot
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId,
+                    await _messenger.SendAsync(chatId,
                         string.Format(BotMsgs.MsgOrderFailed, orderMessage),
                         replyMarkup: new ReplyKeyboardMarkup(new[]
                         {
@@ -1171,11 +1179,11 @@ namespace TallaEgg.TelegramBot
             }
             catch (Exception ex)
             {
-                await _botClient.SendMessage(chatId, $"خطا در ثبت سفارش: {ex.Message}");
+                await _messenger.SendAsync(chatId, $"خطا در ثبت سفارش: {ex.Message}");
             }
             finally
             {
-                _userOrderStates.Remove(telegramId);
+                _conversations.Clear(telegramId);
             }
         }
 
@@ -1194,7 +1202,7 @@ namespace TallaEgg.TelegramBot
         {
             try
             {
-                await _botClient.SendMessage(chatId, TradeExecutedMessage.Build(
+                await _messenger.SendAsync(chatId, TradeExecutedMessage.Build(
                     orderState.Asset, orderState.OrderSide, orderState.Amount, orderState.Price));
             }
             catch (Exception ex)
@@ -1223,7 +1231,7 @@ namespace TallaEgg.TelegramBot
         public async Task NotifyUpdate(User user)
         {
             var (message, _) = BuildStartupAnnouncement();
-            await _botClient.SendMessage(user.Id, message);
+            await _messenger.SendAsync(user.Id, message);
         }
 
         public async Task NotifyUpdateToAllUsers()
@@ -1258,7 +1266,7 @@ namespace TallaEgg.TelegramBot
                 {
                     try
                     {
-                        await _botClient.SendMessage(user.TelegramId, message);
+                        await _messenger.SendAsync(user.TelegramId, message);
 
                         // ⏱ جلوگیری از Rate Limit تلگرام
                         await Task.Delay(50);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -49,11 +49,13 @@ namespace TallaEgg.TelegramBot
         /// </summary>
         private readonly ITelegramBotClient _botClient;
 
-        private readonly OrderApiClient _orderApi;
-        private readonly UsersApiClient _usersApi;
-        private readonly AffiliateApiClient _affiliateApi;
-        private readonly WalletApiClient _walletApi;
-        private readonly TelegramLoggerService _telegramLogger;
+        // Interfaces, not the concrete HTTP clients: a conversation test supplies known
+        // answers instead of standing up five services (issue #65).
+        private readonly IOrderApiClient _orderApi;
+        private readonly IUsersApiClient _usersApi;
+        private readonly IAffiliateApiClient _affiliateApi;
+        private readonly IWalletApiClient _walletApi;
+        private readonly ITelegramLogger _telegramLogger;
         private readonly IVersionService _versionService;
 
         /// <summary>
@@ -69,8 +71,9 @@ namespace TallaEgg.TelegramBot
         public BotHandler(ILogger<BotHandler> logger,
                          ITelegramBotClient botClient, IBotMessenger messenger,
                          IConversationStore conversations,
-                         OrderApiClient orderApi, UsersApiClient usersApi,
-                         AffiliateApiClient affiliateApi, WalletApiClient walletApi, TelegramLoggerService telegramLogger, IVersionService versionService,
+                         IOrderApiClient orderApi, IUsersApiClient usersApi,
+                         IAffiliateApiClient affiliateApi, IWalletApiClient walletApi,
+                         ITelegramLogger telegramLogger, IVersionService versionService,
                          bool requireReferralCode = false, string defaultReferralCode = "ADMIN2024")
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -87,28 +90,40 @@ namespace TallaEgg.TelegramBot
             _defaultReferralCode = defaultReferralCode;
             _versionService = versionService;
 
-            // Sweep completed conversations hourly. A safety net, not the mechanism: each
-            // order flow clears its own state on the way out. This only catches whatever
-            // an unexpected exit path left behind.
+        }
+
+        /// <summary>
+        /// Begins the background work: the hourly conversation sweep and the startup
+        /// announcement.
+        ///
+        /// Called by the hosted service rather than from the constructor. Constructing an
+        /// object should not start threads or send messages to every customer — it made
+        /// the handler impossible to build in a test, and it ran before the rest of the
+        /// container had finished being wired.
+        /// </summary>
+        public void Start(CancellationToken cancellationToken = default)
+        {
             _ = Task.Run(async () =>
             {
-                while (true)
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    await Task.Delay(TimeSpan.FromHours(1));
+                    await Task.Delay(TimeSpan.FromHours(1), cancellationToken);
                     try
                     {
                         var removed = _conversations.ClearCompleted();
                         if (removed > 0)
                             _logger.LogInformation("Swept {Count} completed conversations.", removed);
                     }
+                    catch (OperationCanceledException) { return; }
                     catch (Exception ex)
                     {
                         await _telegramLogger.ErrorAsync(ex, "Error in cleanup");
                         _logger.LogError(ex, "Error sweeping completed conversations.");
                     }
                 }
-            });
-            NotifyUpdateToAllUsers();
+            }, cancellationToken);
+
+            _ = NotifyUpdateToAllUsers();
         }
 
         public async Task HandleMessageAsync(Message message)
@@ -414,16 +429,8 @@ namespace TallaEgg.TelegramBot
 
                             await _messenger.DeleteAsync(chatId, message.Id);
 
-                            // قیمت می‌تواند خالی باشد (وقتی در آن سمت بازار سفارشی نیست).
-                            // نمایش صفر گمراه‌کننده است، پس پیام صریح نشان داده می‌شود.
-                            string FormatPrice(decimal? price) => price.HasValue
-                                ? $"{PersianFormat.Number(price.Value)} تومان"
-                                : BotMsgs.MsgPriceNotAvailable;
-
-                            await _messenger.SendAsync(chatId,
-                                            string.Format(BotMsgs.MsgBestPrices,
-                                                FormatPrice(apiResponse.Data.BestBidPrice),
-                                                FormatPrice(apiResponse.Data.BestAskPrice)));
+                            await _messenger.SendAsync(chatId, BestPricesMessage.Build(
+                                apiResponse.Data.BestBidPrice, apiResponse.Data.BestAskPrice));
 
                             assetConversation.BestBidPrice = apiResponse.Data.BestBidPrice;
                             assetConversation.BestAskPrice = apiResponse.Data.BestAskPrice;
@@ -678,35 +685,7 @@ namespace TallaEgg.TelegramBot
             {
                 if (res.Data.Any())
                 {
-                    StringBuilder stringBuilder = new StringBuilder();
-                    stringBuilder.Append(BotMsgs.MsgBalanceHeader);
-
-                    foreach (var item in res.Data)
-                    {
-                        var code = item.Asset;
-                        var unit = PersianFormat.Unit(code);
-
-                        // نام فارسی دارایی؛ کد لاتین هرگز به کاربر نشان داده نمی‌شود.
-                        stringBuilder.Append(string.Format(BotMsgs.MsgBalanceRow,
-                            PersianFormat.Asset(code),
-                            $"{PersianFormat.Amount(item.Balance, code)} {unit}",
-                            $"{PersianFormat.Amount(item.LockedBalance, code)} {unit}"));
-
-                        // در مدل اعتباری موجودی آزاد می‌تواند منفی شود (کاربر با اعتبار
-                        // معامله کرده است). عدد منفی بدون توضیح گیج‌کننده است، پس مبلغ
-                        // بدهی به‌صورت مثبت و با برچسب صریح نمایش داده می‌شود.
-                        if (item.Balance < 0)
-                        {
-                            stringBuilder.Append(string.Format(BotMsgs.MsgBalanceDebtNote,
-                                $"{PersianFormat.Amount(-item.Balance, code)} {unit}"));
-                        }
-
-                        stringBuilder.AppendLine();
-                    }
-
-                    stringBuilder.Append(BotMsgs.MsgBalanceFooter);
-
-                    await _messenger.SendAsync(chatId, stringBuilder.ToString());
+                    await _messenger.SendAsync(chatId, WalletBalanceMessage.Build(res.Data));
 
                 }
                 else

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -18,6 +18,7 @@ using TallaEgg.TelegramBot.Infrastructure;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram;
 using TallaEgg.TelegramBot.Infrastructure.Handlers;
+using TallaEgg.TelegramBot.Infrastructure.Messages;
 using TallaEgg.TelegramBot.Infrastructure.Services;
 using Telegram.Bot;
 using Telegram.Bot.Exceptions;
@@ -965,31 +966,13 @@ namespace TallaEgg.TelegramBot
                 orderState.Price = pricePerGram;
                 orderState.State = "";
 
-                // از همان قالب‌های تأیید سفارش استفاده می‌شود که برای مسیر عادی نوشته
-                // شده‌اند. یک قالب دوم برای همان اطلاعات، دو جا برای نگهداری می‌ساخت — و
-                // کاربر هم انتظار دارد پیام تأیید همیشه یک شکل باشد.
-                var quoteIsGold = orderState.Asset == CurrenciesConstant.MAUA_IRT;
-                var quoteBaseAsset = orderState.Asset.Split('/')[0];
-                var quoteAmountText =
-                    $"{PersianFormat.Amount(orderState.Amount, quoteBaseAsset)} {PersianFormat.Unit(quoteBaseAsset)}";
-                var quoteSideText = TallaEgg.Core.Utilties.Utils.GetEnumDescription(orderState.OrderSide);
-                var quoteTotal = CurrenciesConstant.RoundToCurrencyPrecision(
-                    orderState.Amount * pricePerGram, CurrenciesConstant.Toman);
-
-                var quoteMessage = quoteIsGold
-                    ? string.Format(BotMsgs.MsgOrderConfirmationGold,
-                        PersianFormat.Symbol(orderState.Asset),
-                        quoteSideText,
-                        quoteAmountText,
-                        PersianFormat.Number(pricePerGram * CurrenciesConstant.GramsPerMesghal),
-                        PersianFormat.Number(pricePerGram),
-                        PersianFormat.Number(quoteTotal))
-                    : string.Format(BotMsgs.MsgOrderConfirmation,
-                        PersianFormat.Symbol(orderState.Asset),
-                        quoteSideText,
-                        quoteAmountText,
-                        PersianFormat.Number(pricePerGram),
-                        PersianFormat.Number(quoteTotal));
+                // The same confirmation templates as the ordinary order path. A second
+                // template carrying the same information would be a second place to
+                // maintain, and the customer expects the confirmation to always look the
+                // same. No per-mesghal override here: the quote is the source of the
+                // price, so the derived figure is the authoritative one.
+                var quoteMessage = OrderConfirmationMessage.Build(
+                    orderState.Asset, orderState.OrderSide, orderState.Amount, pricePerGram);
 
                 await _botClient.SendMessage(chatId, quoteMessage,
                     replyMarkup: new InlineKeyboardMarkup(new[]
@@ -1055,24 +1038,19 @@ namespace TallaEgg.TelegramBot
             orderState.Price = price;
             orderState.State = "";
 
-            var confirmationMsg = "";
-
-            // قیمتی که کاربر وارد می‌کند برای «یک مثقال» است؛ برای طلای آبشده به قیمت
-            // «هر گرم» تبدیل و ذخیره می‌شود. عدد ورودی نگه داشته می‌شود تا در پیام تایید
-            // هم نمایش داده شود، وگرنه کاربر عددی غیر از ورودی خود می‌بیند.
+            // The customer types the price of one mesghal; gold is stored per gram. The
+            // number they typed is kept so the confirmation can show it back to them,
+            // otherwise they see a figure that is not the one they entered.
             var enteredPricePerMesghal = price;
             var isGold = orderState.Asset == CurrenciesConstant.MAUA_IRT;
 
             if (isGold)
             {
-                orderState.Price /= 4.3318m;
-                confirmationMsg = BotMsgs.MsgOrderConfirmationGold;
+                // Was a literal 4.3318 here, duplicating the constant. Two copies of a
+                // conversion factor is one copy too many: changing one and not the other
+                // would misprice every gold order with nothing failing.
+                orderState.Price /= CurrenciesConstant.GramsPerMesghal;
             }
-            else
-            {
-                confirmationMsg = BotMsgs.MsgOrderConfirmation;
-            }
-            var totalValue = orderState.Amount * orderState.Price;
 
             var validateCreditAndBalance =
                 await _walletApi.ValidateCreditAndBalanceAsync(orderState.UserId, orderState.Asset, orderState.Amount, orderState.Price);
@@ -1099,27 +1077,16 @@ namespace TallaEgg.TelegramBot
                 return;
             }
 
-            // مقادیر پیش از درج در پیام فارسی‌سازی می‌شوند: نماد به نام فارسی، نوع سفارش
-            // به «خرید/فروش»، و اعداد با ارقام فارسی و محافظ راست‌به‌چپ.
-            var baseAsset = orderState.Asset.Split('/')[0];
-            var amountText = $"{PersianFormat.Amount(orderState.Amount, baseAsset)} {PersianFormat.Unit(baseAsset)}";
-            var sideText = TallaEgg.Core.Utilties.Utils.GetEnumDescription(orderState.OrderSide);
-
-            // قالب طلا یک آرگومان بیشتر دارد: قیمت هر مثقال و قیمت هر گرم.
-            var confirmationMessage = isGold
-                ? string.Format(confirmationMsg,
-                    PersianFormat.Symbol(orderState.Asset),
-                    sideText,
-                    amountText,
-                    PersianFormat.Number(enteredPricePerMesghal),
-                    PersianFormat.Number(orderState.Price),
-                    PersianFormat.Number(totalValue))
-                : string.Format(confirmationMsg,
-                    PersianFormat.Symbol(orderState.Asset),
-                    sideText,
-                    amountText,
-                    PersianFormat.Number(orderState.Price),
-                    PersianFormat.Number(totalValue));
+            // The per-mesghal figure shown is the customer's own input, not one derived
+            // back from the stored per-gram price: the division does not round-trip, and a
+            // confirmation quoting a slightly different number than they typed reads as
+            // the bot having mis-recorded the order.
+            var confirmationMessage = OrderConfirmationMessage.Build(
+                orderState.Asset,
+                orderState.OrderSide,
+                orderState.Amount,
+                orderState.Price,
+                displayPricePerMesghal: enteredPricePerMesghal);
 
             var keyboard = new InlineKeyboardMarkup(new[]
             {
@@ -1213,39 +1180,22 @@ namespace TallaEgg.TelegramBot
         }
 
         /// <summary>
-        /// گزارش معامله‌ای که انجام شده.
+        /// Reports a trade that has actually executed.
         ///
-        /// از همان مقادیری استفاده می‌کند که در پیام تأیید به کاربر نشان داده شد، پس عددی
-        /// که کاربر تأیید کرد و عددی که گزارش می‌شود قطعاً یکی است. خواندن دوبارهٔ معامله
-        /// از سرور این تضمین را نمی‌داد و یک فراخوانی شبکه هم اضافه می‌کرد.
+        /// Uses the same values the customer was shown in the confirmation, so the number
+        /// they approved and the number reported back are necessarily the same. Re-reading
+        /// the trade from the server would not give that guarantee and would add a network
+        /// call.
         ///
-        /// اگر ارسال این پیام شکست بخورد نباید چیزی بشکند: معامله انجام و تسویه شده و
-        /// در «تاریخچه معاملات» دیده می‌شود.
+        /// A failure to send must break nothing: the trade is executed and settled, and it
+        /// is visible under "trade history".
         /// </summary>
         private async Task SendTradeExecutedAsync(long chatId, OrderState orderState)
         {
             try
             {
-                var baseAsset = orderState.Asset.Split('/')[0];
-                var isGold = orderState.Asset == CurrenciesConstant.MAUA_IRT;
-                var isBuy = orderState.OrderSide == OrderSide.Buy;
-
-                // قیمت در حافظه بر حسب گرم است؛ برای نمایش به مثقال تبدیل می‌شود، چون
-                // کاربر قیمت را با همان واحد می‌شناسد.
-                var displayPrice = isGold
-                    ? orderState.Price * CurrenciesConstant.GramsPerMesghal
-                    : orderState.Price;
-
-                var total = CurrenciesConstant.RoundToCurrencyPrecision(
-                    orderState.Amount * orderState.Price, CurrenciesConstant.Toman);
-
-                await _botClient.SendMessage(chatId, string.Format(BotMsgs.MsgTradeExecuted,
-                    TallaEgg.Core.Utilties.Utils.GetEnumDescription(orderState.OrderSide),
-                    $"{PersianFormat.Amount(orderState.Amount, baseAsset)} {PersianFormat.Unit(baseAsset)}",
-                    isGold ? "قیمت هر مثقال" : "قیمت هر واحد",
-                    PersianFormat.Number(displayPrice),
-                    isBuy ? "پرداختی" : "دریافتی",
-                    PersianFormat.Number(total)));
+                await _botClient.SendMessage(chatId, TradeExecutedMessage.Build(
+                    orderState.Asset, orderState.OrderSide, orderState.Amount, orderState.Price));
             }
             catch (Exception ex)
             {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -15,6 +15,7 @@ using TallaEgg.TelegramBot.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram;
 using TallaEgg.TelegramBot.Infrastructure.Handlers;
 using TallaEgg.TelegramBot.Infrastructure.Messages;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
 using Telegram.Bot;
 using Telegram.Bot.Requests.Abstractions;
 using Telegram.Bot.Types;
@@ -42,7 +43,7 @@ namespace TallaEgg.TelegramBot
                 if (!match.Success)
                 {
                     // بازگشت لازم است؛ بدون آن ادامهٔ کد روی match ناموفق اجرا می‌شد و خطا می‌داد.
-                    await _botClient.SendMessage(message.Chat.Id,
+                    await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminChargeFormatError, CurrenciesConstant.GetPersianNamesList()));
                     return true;
                 }
@@ -58,7 +59,7 @@ namespace TallaEgg.TelegramBot
 
                 if (currency is null)
                 {
-                    await _botClient.SendMessage(message.Chat.Id,
+                    await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
                     return true;
                 }
@@ -83,7 +84,7 @@ namespace TallaEgg.TelegramBot
                         var amountText = $"{PersianFormat.Amount(amount, currency)} {info.Unit}";
                         var newCreditText = $"{PersianFormat.Amount(result.Data.BalanceAfter, currency)} {info.Unit}";
 
-                        await _botClient.SendMessage(
+                        await _messenger.SendAsync(
                            message.Chat.Id,
                            string.Format(BotMsgs.MsgAdminChargeDone,
                                info.PersianName,
@@ -91,7 +92,7 @@ namespace TallaEgg.TelegramBot
                                PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
                                newCreditText));
 
-                        await _botClient.SendMessage(
+                        await _messenger.SendAsync(
                            userDto.TelegramId,
                            string.Format(BotMsgs.MsgUserCreditIncreased,
                                info.PersianName,
@@ -100,13 +101,13 @@ namespace TallaEgg.TelegramBot
                     }
                     else
                     {
-                        await _botClient.SendMessage(message.Chat.Id,
+                        await _messenger.SendAsync(message.Chat.Id,
                             string.Format(BotMsgs.MsgAdminOperationFailed, result.Message));
                     }
                 }
                 else
                 {
-                    await _botClient.SendMessage(message.Chat.Id, BotMsgs.MsgAdminUserNotFound);
+                    await _messenger.SendAsync(message.Chat.Id, BotMsgs.MsgAdminUserNotFound);
                 }
 
                 return true;
@@ -123,7 +124,7 @@ namespace TallaEgg.TelegramBot
                 if (!match.Success)
                 {
                     // بازگشت لازم است؛ بدون آن ادامهٔ کد روی match ناموفق اجرا می‌شد و خطا می‌داد.
-                    await _botClient.SendMessage(message.Chat.Id,
+                    await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminDeductFormatError, CurrenciesConstant.GetPersianNamesList()));
                     return true;
                 }
@@ -141,7 +142,7 @@ namespace TallaEgg.TelegramBot
 
                 if (currency is null)
                 {
-                    await _botClient.SendMessage(message.Chat.Id,
+                    await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
                     return true;
                 }
@@ -166,7 +167,7 @@ namespace TallaEgg.TelegramBot
                         var deductAmountText = $"{PersianFormat.Amount(amount, currency)} {info.Unit}";
                         var newBalanceText = $"{PersianFormat.Amount(result.Data.BalanceAfter, currency)} {info.Unit}";
 
-                        await _botClient.SendMessage(
+                        await _messenger.SendAsync(
                                message.Chat.Id,
                                string.Format(BotMsgs.MsgAdminDeductDone,
                                    info.PersianName,
@@ -174,7 +175,7 @@ namespace TallaEgg.TelegramBot
                                    PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
                                    newBalanceText));
 
-                        await _botClient.SendMessage(
+                        await _messenger.SendAsync(
                                userDto.TelegramId,
                                string.Format(BotMsgs.MsgUserBalanceDeducted,
                                    info.PersianName,
@@ -185,13 +186,13 @@ namespace TallaEgg.TelegramBot
                     }
                     else
                     {
-                        await _botClient.SendMessage(message.Chat.Id,
+                        await _messenger.SendAsync(message.Chat.Id,
                             string.Format(BotMsgs.MsgAdminOperationFailed, result.Message));
                     }
                 }
                 else
                 {
-                    await _botClient.SendMessage(message.Chat.Id, BotMsgs.MsgAdminUserNotFound);
+                    await _messenger.SendAsync(message.Chat.Id, BotMsgs.MsgAdminUserNotFound);
                 }
 
                 return true;
@@ -213,14 +214,14 @@ namespace TallaEgg.TelegramBot
                 {
                     var text = await UserListHandler.BuildUsersListAsync(page.Data!, 1, q);
 
-                    await _botClient.SendMessage(
+                    await _messenger.SendAsync(
                         chatId: chatId,
                         text: text,
                         parseMode: ParseMode.MarkdownV2,
                         replyMarkup: UserListHandler.BuildPagingKeyboard(page.Data!, 1, q)
                     );
                 }
-                else await _botClient.SendMessage(chatId, page.Message);
+                else await _messenger.SendAsync(chatId, page.Message);
                 return true;
             }
             if (msgText.StartsWith("م "))
@@ -235,7 +236,7 @@ namespace TallaEgg.TelegramBot
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId, "شماره تلفن پیدا نشد");
+                    await _messenger.SendAsync(chatId, "شماره تلفن پیدا نشد");
                 }
                 return true;
             }
@@ -251,7 +252,7 @@ namespace TallaEgg.TelegramBot
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId, "شماره تلفن پیدا نشد");
+                    await _messenger.SendAsync(chatId, "شماره تلفن پیدا نشد");
                 }
                 return true;
             }
@@ -276,21 +277,21 @@ namespace TallaEgg.TelegramBot
             //{
             //    case "/admin_referral_on":
             //        _requireReferralCode = true;
-            //        await _botClient.SendMessage(chatId,
+            //        await _messenger.SendAsync(chatId,
             //            "✅ اجباری بودن کد دعوت فعال شد.\n" +
             //            "کاربران جدید باید کد دعوت داشته باشند.");
             //        return true;
 
             //    case "/admin_referral_off":
             //        _requireReferralCode = false;
-            //        await _botClient.SendMessage(chatId,
+            //        await _messenger.SendAsync(chatId,
             //            "❌ اجباری بودن کد دعوت غیرفعال شد.\n" +
             //            $"کاربران جدید با کد پیش‌فرض '{_defaultReferralCode}' ثبت‌نام خواهند شد.");
             //        return true;
 
             //    case "/admin_referral_status":
             //        var status = _requireReferralCode ? "فعال" : "غیرفعال";
-            //        await _botClient.SendMessage(chatId,
+            //        await _messenger.SendAsync(chatId,
             //            $"📊 وضعیت فعلی:\n" +
             //            $"اجباری بودن کد دعوت: {status}\n" +
             //            $"کد پیش‌فرض: {_defaultReferralCode}\n\n" +
@@ -329,14 +330,14 @@ namespace TallaEgg.TelegramBot
             await _usersApi.UpdateUserStatusAsync(telegramUserId, TallaEgg.Core.Enums.User.UserStatus.Approved);
 
             // ویرایش پیام ادمین
-            await _botClient.EditMessageText(
+            await _messenger.EditTextAsync(
                 chatId: originalMsg.Chat.Id,
                 messageId: originalMsg.MessageId,
                 text: originalMsg.Text + BotMsgs.MsgAdminApprovedSuffix,
                 replyMarkup: null);
 
             // اطلاع‌رسانی به کاربر
-            await _botClient.SendMessage(telegramUserId, BotMsgs.MsgUserApproved);
+            await _messenger.SendAsync(telegramUserId, BotMsgs.MsgUserApproved);
             await _telegramLogger.Notif<Message>($"کاربر تایید شد \n userId : {telegramUserId} adminId : {adminTgId}", originalMsg);
         }
 
@@ -344,14 +345,14 @@ namespace TallaEgg.TelegramBot
         {
             await _usersApi.UpdateUserStatusAsync(telegramUserId, TallaEgg.Core.Enums.User.UserStatus.Rejected);
 
-            await _botClient.EditMessageText(
+            await _messenger.EditTextAsync(
                 chatId: originalMsg.Chat.Id,
                 messageId: originalMsg.MessageId,
                 text: originalMsg.Text + BotMsgs.MsgAdminRejectedSuffix,
                 replyMarkup: null);
 
             // اطلاع‌رسانی به کاربر
-            await _botClient.SendMessage(telegramUserId, BotMsgs.MsgUserRejected);
+            await _messenger.SendAsync(telegramUserId, BotMsgs.MsgUserRejected);
             await _telegramLogger.Notif<Message>($"کاربر رد شد \n userId : {telegramUserId} adminId : {adminTgId}", originalMsg);
 
         }
@@ -380,19 +381,19 @@ namespace TallaEgg.TelegramBot
                 const decimal defaultAmount = 1000m;    // Default amount
 
                 // First, cancel all existing active orders for this user
-                //await _botClient.SendMessage(chatId, "⏳ در حال کنسل سفارشات قبلی...");
-                await _botClient.SendMessage(chatId, BotMsgs.MsgAdminProcessing);
+                //await _messenger.SendAsync(chatId, "⏳ در حال کنسل سفارشات قبلی...");
+                await _messenger.SendAsync(chatId, BotMsgs.MsgAdminProcessing);
 
                 var cancelResults = await CancelUserActiveOrdersAsync(userId);
                 if (cancelResults.CancelledCount > 0)
                 {
-                    await _botClient.SendMessage(chatId,
+                    await _messenger.SendAsync(chatId,
                         string.Format(BotMsgs.MsgAdminPreviousPricesCancelled,
                             PersianFormat.Number(cancelResults.CancelledCount)));
                 }
                 else if (cancelResults.HasError)
                 {
-                    await _botClient.SendMessage(chatId,
+                    await _messenger.SendAsync(chatId,
                         string.Format(BotMsgs.MsgAdminCancelPreviousFailed, cancelResults.ErrorMessage));
                 }
 
@@ -412,17 +413,17 @@ namespace TallaEgg.TelegramBot
 
                 if (published)
                 {
-                    await _botClient.SendMessage(chatId, quote.Text);
+                    await _messenger.SendAsync(chatId, quote.Text);
                 }
                 else
                 {
-                    await _botClient.SendMessage(chatId,
+                    await _messenger.SendAsync(chatId,
                         string.Format(BotMsgs.MsgAdminQuoteFailed, publishMessage));
                 }
             }
             catch (Exception ex)
             {
-                await _botClient.SendMessage(chatId,
+                await _messenger.SendAsync(chatId,
                     string.Format(BotMsgs.MsgAdminPriceSubmitError, ex.Message));
             }
         }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using TallaEgg.Core;
@@ -14,6 +14,7 @@ using TallaEgg.TelegramBot.Infrastructure;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram;
 using TallaEgg.TelegramBot.Infrastructure.Handlers;
+using TallaEgg.TelegramBot.Infrastructure.Messages;
 using Telegram.Bot;
 using Telegram.Bot.Requests.Abstractions;
 using Telegram.Bot.Types;
@@ -395,29 +396,23 @@ namespace TallaEgg.TelegramBot
                         string.Format(BotMsgs.MsgAdminCancelPreviousFailed, cancelResults.ErrorMessage));
                 }
 
-                // مظنه منتشر می‌شود — دیگر دو سفارش ۱۰۰۰ گرمی ثبت نمی‌شود (issue #48).
+                // A quote is published — no more pair of 1000-gram orders (issue #48).
                 //
-                // مقدار ۱۰۰۰ کاملاً دلبخواه بود و حدود ۱۹ میلیارد تومان و ۱۰۰۰ گرم وثیقهٔ
-                // ادمین را فقط برای «اعلام قیمت» قفل می‌کرد. حالا انتشار مظنه هیچ چیزی قفل
-                // نمی‌کند؛ سفارش‌ها فقط وقتی مشتری معامله می‌کند ساخته می‌شوند، دقیقاً به
-                // اندازهٔ مقدار درخواستی، و در همان لحظه مصرف می‌شوند.
-                var buyPricePerGram = CurrenciesConstant.RoundOrderPrice(
-                    buyPrice / CurrenciesConstant.GramsPerMesghal);
-
-                var sellPricePerGram = CurrenciesConstant.RoundOrderPrice(
-                    sellPrice / CurrenciesConstant.GramsPerMesghal);
+                // The 1000 was arbitrary and locked roughly 19 billion toman and 1000 grams
+                // of the admin's collateral purely to announce a price. Publishing a quote
+                // locks nothing; orders are created only when a customer trades, for exactly
+                // the requested quantity, and are consumed in the same moment.
+                //
+                // Conversion and confirmation text come from one call, so the price
+                // published and the price shown cannot drift apart (issue #65).
+                var quote = QuoteMessage.Prepare(defaultAsset, buyPrice, sellPrice);
 
                 var (published, publishMessage) = await _orderApi.PublishQuoteAsync(
-                    defaultAsset, buyPricePerGram, sellPricePerGram, userId);
+                    defaultAsset, quote.BuyPricePerGram, quote.SellPricePerGram, userId);
 
                 if (published)
                 {
-                    await _botClient.SendMessage(chatId, string.Format(BotMsgs.MsgAdminQuotePublished,
-                        PersianFormat.Symbol(defaultAsset),
-                        PersianFormat.Number(buyPrice),
-                        PersianFormat.Number(buyPricePerGram),
-                        PersianFormat.Number(sellPrice),
-                        PersianFormat.Number(sellPricePerGram)));
+                    await _botClient.SendMessage(chatId, quote.Text);
                 }
                 else
                 {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerRegistration.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerRegistration.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.DependencyInjection;
+using TallaEgg.Core.Services;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Core.Interfaces;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
+
+namespace TallaEgg.TelegramBot.Infrastructure;
+
+public static class BotHandlerRegistration
+{
+    /// <summary>
+    /// Registers the bot handler and the abstractions it depends on.
+    ///
+    /// Split out of <c>Program.cs</c> so it can be exercised by a test (issue #65). When
+    /// <c>BotHandler</c> moved from the concrete API clients to their interfaces the code
+    /// still compiled, because a constructor parameter type is only matched against the
+    /// container at run time — the bot would have failed on startup with "unable to resolve
+    /// IOrderApiClient" and nothing before that point would have noticed.
+    ///
+    /// Assumes the concrete clients are already registered; the interface registrations
+    /// below forward to those single instances rather than constructing second ones, which
+    /// would each carry their own HttpClient.
+    /// </summary>
+    public static IServiceCollection AddBotHandler(this IServiceCollection services)
+    {
+        services.AddSingleton<IOrderApiClient>(p => p.GetRequiredService<OrderApiClient>());
+        services.AddSingleton<IUsersApiClient>(p => p.GetRequiredService<UsersApiClient>());
+        services.AddSingleton<IAffiliateApiClient>(p => p.GetRequiredService<AffiliateApiClient>());
+        services.AddSingleton<IWalletApiClient>(p => p.GetRequiredService<WalletApiClient>());
+        services.AddSingleton<ITelegramLogger>(p => p.GetRequiredService<TelegramLoggerService>());
+
+        // Everything the handler says to a chat goes through the messenger; the raw client
+        // stays registered for lifecycle and lookup calls.
+        services.AddSingleton<IBotMessenger, TelegramBotMessenger>();
+
+        // Singleton because a conversation must survive between the customer's messages;
+        // a scoped store would forget the flow at every update.
+        services.AddSingleton<IConversationStore, InMemoryConversationStore>();
+
+        services.AddSingleton<IBotHandler, BotHandler>();
+
+        return services;
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Net.Http;
@@ -8,7 +8,7 @@ using TallaEgg.Core;
 
 namespace TallaEgg.TelegramBot;
 
-public class AffiliateApiClient
+public class AffiliateApiClient : IAffiliateApiClient
 {
     private readonly string _apiUrl;
     private readonly HttpClient _httpClient;

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IAffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IAffiliateApiClient.cs
@@ -1,0 +1,13 @@
+﻿namespace TallaEgg.TelegramBot;
+
+/// <summary>
+/// The Affiliate service as the Telegram bot uses it (issue #65).
+///
+/// Only the invitation redemption is here, because that is the only call the bot makes
+/// during a conversation.
+/// </summary>
+public interface IAffiliateApiClient
+{
+    Task<(bool success, string message, Guid? invitationId)> UseInvitationAsync(
+        string invitationCode, Guid usedByUserId);
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
@@ -1,4 +1,4 @@
-using TallaEgg.Core.DTOs;
+﻿using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.Requests.Order;
@@ -25,6 +25,9 @@ public interface IOrderApiClient
 
     /// <summary>مظنهٔ فعال یک نماد، یا null اگر منتشر نشده باشد.</summary>
     Task<QuoteDto?> GetActiveQuoteAsync(string symbol);
+
+    /// <summary>Best bid and ask, used by the market-order path.</summary>
+    Task<ApiResponse<BestPricesDto>> GetBestPricesAsync(string symbol);
 
     /// <summary>پذیرش مظنه توسط مشتری. قیمت فرستاده نمی‌شود؛ سرور از مظنه می‌خواند.</summary>
     Task<(bool success, string message)> AcceptQuoteAsync(

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/IConversationStore.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/IConversationStore.cs
@@ -1,0 +1,46 @@
+namespace TallaEgg.TelegramBot.Infrastructure.Conversations;
+
+/// <summary>
+/// Where a customer is in the middle of placing an order (issue #65).
+///
+/// This was a <c>private readonly Dictionary&lt;long, OrderState&gt;</c> inside
+/// <c>BotHandler</c>. Private and in-memory meant a test could neither put a customer
+/// mid-conversation nor observe whether their state was cleaned up afterwards — and the
+/// cleanup is the part that matters, because a stale state is what makes the next order
+/// inherit the previous one's asset or side.
+///
+/// Keyed on the Telegram user id throughout. The old code keyed one write on the chat id
+/// instead; in a private chat the two are equal, so it worked, but the inconsistency meant
+/// the entry was created under one key and read under another the moment the bot was used
+/// anywhere but a one-to-one chat.
+/// </summary>
+public interface IConversationStore
+{
+    /// <summary>
+    /// The customer's current conversation, starting a fresh one if they have none.
+    /// </summary>
+    OrderState GetOrStart(long telegramId, Guid userId);
+
+    /// <summary>
+    /// The customer's conversation, if one is in progress. Returns false when there is
+    /// nothing in flight — the case every step must handle, because a customer can always
+    /// tap a stale button from an old message.
+    /// </summary>
+    bool TryGet(long telegramId, out OrderState state);
+
+    /// <summary>
+    /// Ends the conversation. Must be called on every exit from an order flow — success,
+    /// failure and cancellation alike — or the next order starts from the previous one's
+    /// half-filled state.
+    /// </summary>
+    void Clear(long telegramId);
+
+    /// <summary>
+    /// Drops conversations that reached a confirmed order, for the periodic sweep.
+    /// </summary>
+    /// <returns>How many were removed.</returns>
+    int ClearCompleted();
+
+    /// <summary>Number of conversations in flight. Exists so tests can assert cleanup.</summary>
+    int Count { get; }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/InMemoryConversationStore.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/InMemoryConversationStore.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Conversations;
+
+/// <summary>
+/// Keeps conversations in process memory.
+///
+/// Uses <see cref="ConcurrentDictionary{TKey,TValue}"/>, not <c>Dictionary</c>. The
+/// original field was a plain <c>Dictionary</c> written from two places at once: the
+/// message-handling path, and an hourly background loop started in the constructor that
+/// enumerated the keys and removed from them. Mutating a <c>Dictionary</c> while another
+/// thread enumerates it can throw, and concurrent writes can corrupt its internal buckets
+/// outright — a failure that would surface as an unrelated exception, or as a lost
+/// conversation, long after the fact.
+///
+/// State is deliberately not persisted. A restart drops every in-flight conversation,
+/// which is the right outcome: prices move, and resuming an order the customer began
+/// before a restart would confirm it at a stale price.
+/// </summary>
+public sealed class InMemoryConversationStore : IConversationStore
+{
+    private readonly ConcurrentDictionary<long, OrderState> _states = new();
+
+    public int Count => _states.Count;
+
+    public OrderState GetOrStart(long telegramId, Guid userId) =>
+        _states.GetOrAdd(telegramId, _ => new OrderState { UserId = userId });
+
+    public bool TryGet(long telegramId, out OrderState state) =>
+        _states.TryGetValue(telegramId, out state!);
+
+    public void Clear(long telegramId) => _states.TryRemove(telegramId, out _);
+
+    public int ClearCompleted()
+    {
+        // Snapshot the keys first: removing while enumerating the live collection is the
+        // pattern that made the old Dictionary unsafe.
+        var completed = _states
+            .Where(pair => pair.Value.IsConfirmed)
+            .Select(pair => pair.Key)
+            .ToList();
+
+        var removed = 0;
+        foreach (var key in completed)
+        {
+            if (_states.TryRemove(key, out _))
+                removed++;
+        }
+
+        return removed;
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/OrderState.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Conversations/OrderState.cs
@@ -1,0 +1,41 @@
+using TallaEgg.Core.Enums.Order;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Conversations;
+
+/// <summary>
+/// What the customer has chosen so far while placing an order.
+///
+/// Moved out of <c>BotHandler.cs</c> in issue #65: it is the conversation's data, not the
+/// handler's, and it is now reachable from <see cref="IConversationStore"/> without
+/// dragging the handler along.
+/// </summary>
+public class OrderState
+{
+    public OrderType OrderType { get; set; }
+    public TradingType TradingType { get; set; }
+    public OrderSide OrderSide { get; set; }
+
+    /// <summary>Trading pair, e.g. <c>MAUA/IRT</c>.</summary>
+    public string Asset { get; set; } = "";
+
+    public decimal Amount { get; set; }
+
+    /// <summary>
+    /// Price in the unit the system stores, which for gold is per gram — not the per-mesghal
+    /// figure the customer typed. Converting on the way in keeps a single unit everywhere
+    /// past this point.
+    /// </summary>
+    public decimal Price { get; set; }
+
+    public decimal? BestBidPrice { get; set; }
+    public decimal? BestAskPrice { get; set; }
+    public Guid UserId { get; set; }
+    public bool IsConfirmed { get; set; } = false;
+    public string? Notes { get; set; } = null;
+
+    /// <summary>
+    /// Which step the conversation is waiting on, e.g. <c>waiting_for_amount</c>. Empty
+    /// means no step is pending.
+    /// </summary>
+    public string State { get; set; } = "";
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
@@ -9,6 +9,7 @@ using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.TelegramBot.Core.Utilties;
 using Telegram.Bot;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
@@ -17,7 +18,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
 {
     public static class Keyboards
     {
-        public static async Task RequestContactKeyboard(this ITelegramBotClient _botClient, long chatId)
+        public static async Task RequestContactKeyboard(this IBotMessenger _botClient, long chatId)
         {
             var keyboard = new ReplyKeyboardMarkup(
                  new[]
@@ -33,7 +34,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             };
 
 
-            await _botClient.SendMessage(
+            await _botClient.SendAsync(
                 chatId,
                 "برای ثبت نام شماره خود را از طریق کلید زیر ارسال کنید",
             replyMarkup: keyboard);
@@ -44,7 +45,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
         // «📈 آتی» را نشان می‌داد — دکمه‌ای برای بازاری که وجود ندارد و هیچ handlerی هم
         // نداشت. منوی اصلیِ واقعی جای دیگری ساخته می‌شود.
 
-        public static async Task SendContactKeyboardAsync(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendContactKeyboardAsync(this IBotMessenger _botClient, long chatId)
         {
             var sharePhoneButton = new KeyboardButton(BotBtns.BtnSharePhone) { RequestContact = true };
 
@@ -56,7 +57,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
                 ResizeKeyboard = true
             };
 
-            await _botClient.SendMessage(
+            await _botClient.SendAsync(
                 chatId,
                 BotMsgs.MsgPhoneRequest,
             replyMarkup: keyboard);
@@ -68,7 +69,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
         /// <param name="_botClient"></param>
         /// <param name="chatId"></param>
         /// <returns></returns>
-        public static async Task SendMainKeyboardForAdminAsync(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendMainKeyboardForAdminAsync(this IBotMessenger _botClient, long chatId)
         {
             var keyboard = new ReplyKeyboardMarkup(new[]
             {
@@ -81,7 +82,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
                 ResizeKeyboard = true
             };
 
-            await _botClient.SendMessage(chatId, BotMsgs.MsgMainMenu, replyMarkup: keyboard);
+            await _botClient.SendAsync(chatId, BotMsgs.MsgMainMenu, replyMarkup: keyboard);
         }
         /// <summary>
         /// منوی اصلی برای کاربر عادی و مدیر فرق میکنه
@@ -89,7 +90,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
         /// <param name="_botClient"></param>
         /// <param name="chatId"></param>
         /// <returns></returns>
-        public static async Task SendMainKeyboardForUserAsync(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendMainKeyboardForUserAsync(this IBotMessenger _botClient, long chatId)
         {
             var keyboard = new ReplyKeyboardMarkup(new[]
             {
@@ -100,10 +101,10 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
                 ResizeKeyboard = true
             };
 
-            await _botClient.SendMessage(chatId, BotMsgs.MsgMainMenu, replyMarkup: keyboard);
+            await _botClient.SendAsync(chatId, BotMsgs.MsgMainMenu, replyMarkup: keyboard);
         }
 
-        public static async Task SendAccountingMenuKeyboard(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendAccountingMenuKeyboard(this IBotMessenger _botClient, long chatId)
         {
 
             var keyboard = new ReplyKeyboardMarkup(
@@ -124,14 +125,14 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             };
 
 
-            await _botClient.SendMessage(
+            await _botClient.SendAsync(
                 chatId,
                 "📑 منوی حسابداری\n" +
                 "لطفاً یکی از گزینه‌های را انتخاب کنید:",
             replyMarkup: keyboard);
 
         }
-        public static async Task SendAccountingMenuKeyboardForAdmin(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendAccountingMenuKeyboardForAdmin(this IBotMessenger _botClient, long chatId)
         {
 
             var keyboard = new ReplyKeyboardMarkup(
@@ -147,14 +148,14 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             };
 
 
-            await _botClient.SendMessage(
+            await _botClient.SendAsync(
                 chatId,
                 "📑 منوی حسابداری\n" +
                 "لطفاً یکی از گزینه‌های را انتخاب کنید:",
             replyMarkup: keyboard);
 
         }
-        public static async Task SendSpotSideMenuKeyboard(this ITelegramBotClient _botClient, long chatId)
+        public static async Task SendSpotSideMenuKeyboard(this IBotMessenger _botClient, long chatId)
         {
             var keyboard = new InlineKeyboardMarkup(new[]
             {
@@ -169,7 +170,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
                 }
             });
 
-            await _botClient.SendMessage(chatId, "📈 معاملات نقدی\n\nلطفاً نوع معامله خود را انتخاب کنید:", replyMarkup: keyboard);
+            await _botClient.SendAsync(chatId, "📈 معاملات نقدی\n\nلطفاً نوع معامله خود را انتخاب کنید:", replyMarkup: keyboard);
         }
 
         // SendUserOrdersWithPagingAsync و کمکی‌هایش (GetTypeIcon/GetStatusEmoji) حذف شدند.
@@ -179,51 +180,45 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
         // همیشه Maker است و درست نیست (issue #35). یعنی یک مقدار نادرست فقط یک
         // فراخوانی با آن فاصله داشت.
 
+        /// <summary>
+        /// Notifies every group admin that a user is waiting for approval.
+        ///
+        /// Takes the admin ids rather than looking them up: the lookup needs the raw
+        /// Telegram client, which IBotMessenger deliberately does not expose, and keeping
+        /// the two apart means this — the part that decides what each admin sees — can be
+        /// tested with a fake messenger.
+        /// </summary>
         public static async Task SendApproveOrRejectUserToAdminsKeyboard(
-     this ITelegramBotClient botClient,
-     UserDto user,
-     long groupId)
+            this IBotMessenger messenger,
+            IReadOnlyCollection<long> adminIds,
+            UserDto user)
         {
-            // 1) لیست ادمین‌ها
-            var adminIds = await botClient.GetAdminUserIdsAsync(groupId);
-
-            // 2) متن پیام
             var text =
-     $"📌 درخواست عضویت جدید\n\n" +
-     $"👤 نام: {Utils.EscapeHtml(user.FirstName)} {Utils.EscapeHtml(user.LastName)}\n" +
-     $"🆔 Telegram ID: <code>{user.TelegramId}</code>\n" +
-     $"🔖 Username: {Utils.UsernameLink(user.Username)}\n" +
-     $"📞 Phone: {Utils.EscapeHtml(user.PhoneNumber ?? "-")}\n" +
-     $"📅 ثبت‌نام: <code>{user.CreatedAt:yyyy/MM/dd HH:mm}</code>";
+                $"📌 درخواست عضویت جدید\n\n" +
+                $"👤 نام: {Utils.EscapeHtml(user.FirstName)} {Utils.EscapeHtml(user.LastName)}\n" +
+                $"🆔 Telegram ID: <code>{user.TelegramId}</code>\n" +
+                $"🔖 Username: {Utils.UsernameLink(user.Username)}\n" +
+                $"📞 Phone: {Utils.EscapeHtml(user.PhoneNumber ?? "-")}\n" +
+                $"📅 ثبت‌نام: <code>{user.CreatedAt:yyyy/MM/dd HH:mm}</code>";
 
-            // 3) ساخت اینلاین کیبورد
             var keyboard = new InlineKeyboardMarkup(new[]
             {
-        new[]
-        {
-            InlineKeyboardButton.WithCallbackData(
-                "✅ تأیید",
-                $"approve_{user.TelegramId}"),
-            InlineKeyboardButton.WithCallbackData(
-                "❌ رد",
-                $"reject_{user.TelegramId}")
-        }
-    });
+                new[]
+                {
+                    InlineKeyboardButton.WithCallbackData("✅ تأیید", $"approve_{user.TelegramId}"),
+                    InlineKeyboardButton.WithCallbackData("❌ رد", $"reject_{user.TelegramId}")
+                }
+            });
 
-            // 4) ارسال به هر ادمین
             foreach (var adminId in adminIds)
             {
                 try
                 {
-                    await botClient.SendMessage(
-                        chatId: adminId,
-                        text: text,
-                        parseMode: ParseMode.Html,
-                        replyMarkup: keyboard);
+                    await messenger.SendAsync(adminId, text, keyboard, ParseMode.Html);
                 }
                 catch (Exception ex)
                 {
-                    // لاگ خطا برای ادمینی که پیام نتوانست ارسال شود
+                    // One unreachable admin must not stop the others from being told.
                     Console.WriteLine($"ارسال به ادمین {adminId} ناموفق: {ex.Message}");
                 }
             }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/BestPricesMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/BestPricesMessage.cs
@@ -1,0 +1,21 @@
+using TallaEgg.Core.Utilties;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messages;
+
+/// <summary>
+/// Builds the "best market prices" message (issue #65).
+///
+/// Extracted for the absent-price case. When one side of the book is empty the price is
+/// null, and rendering it as a number gives "۰ تومان" — which reads as a price of zero, not
+/// as the absence of a price. A customer seeing gold bid at zero would reasonably conclude
+/// the market had collapsed.
+/// </summary>
+public static class BestPricesMessage
+{
+    public static string Build(decimal? bestBidPrice, decimal? bestAskPrice) =>
+        string.Format(BotMsgs.MsgBestPrices, Format(bestBidPrice), Format(bestAskPrice));
+
+    private static string Format(decimal? price) => price.HasValue
+        ? $"{PersianFormat.Number(price.Value)} تومان"
+        : BotMsgs.MsgPriceNotAvailable;
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/OrderConfirmationMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/OrderConfirmationMessage.cs
@@ -1,0 +1,78 @@
+﻿using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.Utilties;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messages;
+
+/// <summary>
+/// Builds the "confirm this order" message shown before the customer commits.
+///
+/// Extracted from the two places in <c>BotHandler</c> that built it inline: the dealer
+/// path, where the price comes from the admin's published quote, and the limit path,
+/// where the customer typed the price (issue #65).
+///
+/// Those two call sites used the same templates but assembled the arguments separately.
+/// That is the shape of defect this class exists to prevent: the gold and non-gold
+/// templates take a *different number* of arguments (6 and 5), and
+/// <see cref="string.Format(string, object[])"/> with a missing argument does not fail to
+/// compile — it throws at run time, in front of the customer, or silently leaves a
+/// literal <c>{4}</c> in the text if the count happens to line up wrongly.
+/// </summary>
+public static class OrderConfirmationMessage
+{
+    /// <param name="symbol">Trading pair, e.g. <c>MAUA/IRT</c>.</param>
+    /// <param name="side">The side from the customer's point of view.</param>
+    /// <param name="quantity">Requested quantity, in the base asset's own unit.</param>
+    /// <param name="pricePerGram">The price as the system stores it, and as the order will be placed.</param>
+    /// <param name="displayPricePerMesghal">
+    /// What to show on the "per mesghal" line for gold. Defaults to the value derived from
+    /// <paramref name="pricePerGram"/>.
+    ///
+    /// The limit path passes the number the customer actually typed. Deriving it instead
+    /// would show them a figure a few rials away from their own input — because the stored
+    /// price is their input divided by <see cref="CurrenciesConstant.GramsPerMesghal"/> and
+    /// the division does not round-trip exactly — and they would reasonably read that as
+    /// the bot having mis-recorded their order. Ignored for non-gold pairs.
+    /// </param>
+    public static string Build(
+        string symbol,
+        OrderSide side,
+        decimal quantity,
+        decimal pricePerGram,
+        decimal? displayPricePerMesghal = null)
+    {
+        var isGold = symbol == CurrenciesConstant.MAUA_IRT;
+        var baseAsset = symbol.Split('/')[0];
+
+        var amountText = $"{PersianFormat.Amount(quantity, baseAsset)} {PersianFormat.Unit(baseAsset)}";
+        var sideText = TallaEgg.Core.Utilties.Utils.GetEnumDescription(side);
+
+        var total = CurrenciesConstant.RoundToCurrencyPrecision(
+            quantity * pricePerGram, CurrenciesConstant.Toman);
+
+        if (!isGold)
+        {
+            return string.Format(BotMsgs.MsgOrderConfirmation,
+                PersianFormat.Symbol(symbol),
+                sideText,
+                amountText,
+                PersianFormat.Number(pricePerGram),
+                PersianFormat.Number(total));
+        }
+
+        var pricePerMesghal = displayPricePerMesghal
+                              ?? pricePerGram * CurrenciesConstant.GramsPerMesghal;
+
+        // Gold shows both units. Showing only one is what made an earlier version
+        // ambiguous: the same number can be read as a per-gram or a per-mesghal price, and
+        // the two differ by 4.3318x — large enough to look like a different market, small
+        // enough not to look like an obvious bug.
+        return string.Format(BotMsgs.MsgOrderConfirmationGold,
+            PersianFormat.Symbol(symbol),
+            sideText,
+            amountText,
+            PersianFormat.Number(pricePerMesghal),
+            PersianFormat.Number(pricePerGram),
+            PersianFormat.Number(total));
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/QuoteMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/QuoteMessage.cs
@@ -1,0 +1,55 @@
+﻿using TallaEgg.Core;
+using TallaEgg.Core.Utilties;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messages;
+
+/// <summary>
+/// Prepares an admin quote for publication: converts the prices the admin typed into the
+/// prices the system stores, and builds the confirmation the admin sees.
+///
+/// Extracted from <c>BotHandlerAdmin.HandlePricePairOrdersAsync</c> (issue #65).
+///
+/// Conversion and message are deliberately produced together by
+/// <see cref="Prepare"/> rather than exposed as two independent steps. The caller used to
+/// compute the per-gram prices, publish them, and then separately format a message from
+/// the same inputs — two calculations that were only equal by convention. Returning one
+/// value carrying both makes "the price published is the price displayed" true by
+/// construction, which matters here because a mismatch would mean every customer trades
+/// at a price the shop owner never saw.
+/// </summary>
+public static class QuoteMessage
+{
+    /// <param name="symbol">Trading pair, e.g. <c>MAUA/IRT</c>.</param>
+    /// <param name="buyPricePerMesghal">The price the admin buys at — what the customer sells at.</param>
+    /// <param name="sellPricePerMesghal">The price the admin sells at — what the customer buys at.</param>
+    public static QuotePublication Prepare(
+        string symbol, decimal buyPricePerMesghal, decimal sellPricePerMesghal)
+    {
+        // The admin types prices per mesghal; orders and quotes are stored per gram.
+        // Rounded to the precision of the price column, so the value published is exactly
+        // the value that will be persisted rather than one the database silently truncates.
+        var buyPricePerGram = CurrenciesConstant.RoundOrderPrice(
+            buyPricePerMesghal / CurrenciesConstant.GramsPerMesghal);
+
+        var sellPricePerGram = CurrenciesConstant.RoundOrderPrice(
+            sellPricePerMesghal / CurrenciesConstant.GramsPerMesghal);
+
+        var text = string.Format(BotMsgs.MsgAdminQuotePublished,
+            PersianFormat.Symbol(symbol),
+            PersianFormat.Number(buyPricePerMesghal),
+            PersianFormat.Number(buyPricePerGram),
+            PersianFormat.Number(sellPricePerMesghal),
+            PersianFormat.Number(sellPricePerGram));
+
+        return new QuotePublication(buyPricePerGram, sellPricePerGram, text);
+    }
+}
+
+/// <summary>
+/// The per-gram prices to publish and the confirmation text describing them. Always
+/// obtained together so the two cannot disagree.
+/// </summary>
+public sealed record QuotePublication(
+    decimal BuyPricePerGram,
+    decimal SellPricePerGram,
+    string Text);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/TradeExecutedMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/TradeExecutedMessage.cs
@@ -1,0 +1,58 @@
+﻿using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.Utilties;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messages;
+
+/// <summary>
+/// Builds the message reporting a trade that has actually executed.
+///
+/// Extracted from <c>BotHandler.SendTradeExecutedAsync</c>, where the arithmetic and the
+/// send were a single private async method and so could not be exercised without a live
+/// Telegram connection (issue #65).
+///
+/// The formatting logic in this file's original home produced four defects that all
+/// compiled cleanly and looked plausible in Telegram: a Persian date wrong by up to
+/// 22 days, trade history that did not say whether a trade was a buy or a sell, times
+/// shown in UTC, and log statements with unfilled placeholders. Each was found by a
+/// person reading a message. A pure builder can be asserted on instead.
+/// </summary>
+public static class TradeExecutedMessage
+{
+    /// <param name="symbol">Trading pair, e.g. <c>MAUA/IRT</c>.</param>
+    /// <param name="side">The side from the customer's point of view.</param>
+    /// <param name="quantity">Filled quantity, in the base asset's own unit.</param>
+    /// <param name="pricePerGram">
+    /// The execution price in the unit the system stores prices in. For gold this is per
+    /// gram and is converted to per mesghal for display, because the customer only ever
+    /// quotes and reads gold prices per mesghal. Showing the stored number here would
+    /// understate the price by a factor of 4.3318.
+    /// </param>
+    public static string Build(string symbol, OrderSide side, decimal quantity, decimal pricePerGram)
+    {
+        var baseAsset = symbol.Split('/')[0];
+        var isGold = symbol == CurrenciesConstant.MAUA_IRT;
+        var isBuy = side == OrderSide.Buy;
+
+        var displayPrice = isGold
+            ? pricePerGram * CurrenciesConstant.GramsPerMesghal
+            : pricePerGram;
+
+        // The total is computed from the per-gram price, never from the per-mesghal
+        // display price: the displayed price is a presentation detail, and multiplying by
+        // it would overstate the total by the same 4.3318.
+        var total = CurrenciesConstant.RoundToCurrencyPrecision(
+            quantity * pricePerGram, CurrenciesConstant.Toman);
+
+        // "پرداختی" (paid) vs "دریافتی" (received): the same amount means opposite things
+        // to the two sides of a trade, and a single neutral label leaves the customer
+        // unable to tell which happened.
+        return string.Format(BotMsgs.MsgTradeExecuted,
+            TallaEgg.Core.Utilties.Utils.GetEnumDescription(side),
+            $"{PersianFormat.Amount(quantity, baseAsset)} {PersianFormat.Unit(baseAsset)}",
+            isGold ? "قیمت هر مثقال" : "قیمت هر واحد",
+            PersianFormat.Number(displayPrice),
+            isBuy ? "پرداختی" : "دریافتی",
+            PersianFormat.Number(total));
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Utilties;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messages;
+
+/// <summary>
+/// Builds the customer's balance screen (issue #65).
+///
+/// Extracted because it is the only message in the bot that has a branch in it: a negative
+/// available balance is normal under the credit model — the customer traded on credit — but
+/// a bare minus sign reads as an error, so the debt is shown as a positive number under an
+/// explicit label. Getting the sign flip wrong shows a customer who owes 5,000,000 that
+/// they owe -5,000,000, or that they owe nothing at all.
+///
+/// This is also the only place a customer can see their debt, which is the gap issue #61 is
+/// about on the shop's side.
+/// </summary>
+public static class WalletBalanceMessage
+{
+    public static string Build(IEnumerable<WalletDTO> wallets)
+    {
+        var sb = new StringBuilder();
+        sb.Append(BotMsgs.MsgBalanceHeader);
+
+        foreach (var wallet in wallets)
+        {
+            var code = wallet.Asset;
+            var unit = PersianFormat.Unit(code);
+
+            // The Persian asset name, never the latin code: the customer chose "طلای آبشده",
+            // not "MAUA".
+            sb.Append(string.Format(BotMsgs.MsgBalanceRow,
+                PersianFormat.Asset(code),
+                $"{PersianFormat.Amount(wallet.Balance, code)} {unit}",
+                $"{PersianFormat.Amount(wallet.LockedBalance, code)} {unit}"));
+
+            if (wallet.Balance < 0)
+            {
+                // Negated so the customer reads "you owe 5,000,000", not "-5,000,000".
+                sb.Append(string.Format(BotMsgs.MsgBalanceDebtNote,
+                    $"{PersianFormat.Amount(-wallet.Balance, code)} {unit}"));
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.Append(BotMsgs.MsgBalanceFooter);
+        return sb.ToString();
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messaging/IBotMessenger.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messaging/IBotMessenger.cs
@@ -1,0 +1,55 @@
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messaging;
+
+/// <summary>
+/// Everything the conversation handlers do to a Telegram chat, behind an interface this
+/// project owns (issue #65).
+///
+/// <c>ITelegramBotClient</c> is injected and looks mockable, but <c>SendMessage</c>,
+/// <c>EditMessageText</c>, <c>AnswerCallbackQuery</c> and <c>DeleteMessage</c> are all
+/// <b>extension methods</b> on it. Extension methods are static and cannot be substituted,
+/// so any test of a handler would attempt a real network call to Telegram. That single fact
+/// is why the busiest class in the product had no automated coverage at all.
+///
+/// This interface is deliberately narrow: it is the set of operations the handlers actually
+/// perform, not a mirror of the Telegram API. A wider surface would be more to fake and
+/// would not buy any more coverage.
+///
+/// Non-messaging calls — <c>StartReceiving</c>, <c>GetMe</c>, <c>DeleteWebhook</c>,
+/// <c>GetAdminUserIdsAsync</c> — stay on the raw client. They are lifecycle and lookup
+/// concerns, not part of a conversation, and none of them appear in a flow worth testing.
+/// </summary>
+public interface IBotMessenger
+{
+    /// <returns>The id of the sent message, so a later edit or delete can address it.</returns>
+    Task<int> SendAsync(
+        long chatId,
+        string text,
+        ReplyMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default);
+
+    Task EditTextAsync(
+        long chatId,
+        int messageId,
+        string text,
+        InlineKeyboardMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Dismisses the spinner Telegram shows on an inline button. Skipping it leaves the
+    /// button visibly stuck for the customer even though the action has completed.
+    /// </summary>
+    Task AnswerCallbackAsync(
+        string callbackQueryId,
+        string? text = null,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        long chatId,
+        int messageId,
+        CancellationToken cancellationToken = default);
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messaging/TelegramBotMessenger.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messaging/TelegramBotMessenger.cs
@@ -1,0 +1,53 @@
+using Telegram.Bot;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Messaging;
+
+/// <summary>
+/// The production <see cref="IBotMessenger"/>: a thin pass-through to
+/// <c>ITelegramBotClient</c>.
+///
+/// Deliberately contains no logic beyond forwarding. Anything decided here would be
+/// invisible to the tests that use a fake messenger, which would quietly reopen the gap
+/// this abstraction exists to close.
+/// </summary>
+public sealed class TelegramBotMessenger : IBotMessenger
+{
+    private readonly ITelegramBotClient _botClient;
+
+    public TelegramBotMessenger(ITelegramBotClient botClient) =>
+        _botClient = botClient ?? throw new ArgumentNullException(nameof(botClient));
+
+    public async Task<int> SendAsync(
+        long chatId,
+        string text,
+        ReplyMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default)
+    {
+        var message = await _botClient.SendMessage(
+            chatId, text, parseMode, replyMarkup: replyMarkup, cancellationToken: cancellationToken);
+
+        return message.MessageId;
+    }
+
+    public Task EditTextAsync(
+        long chatId,
+        int messageId,
+        string text,
+        InlineKeyboardMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default) =>
+        _botClient.EditMessageText(
+            chatId, messageId, text, parseMode, replyMarkup: replyMarkup, cancellationToken: cancellationToken);
+
+    public Task AnswerCallbackAsync(
+        string callbackQueryId,
+        string? text = null,
+        CancellationToken cancellationToken = default) =>
+        _botClient.AnswerCallbackQuery(callbackQueryId, text, cancellationToken: cancellationToken);
+
+    public Task DeleteAsync(long chatId, int messageId, CancellationToken cancellationToken = default) =>
+        _botClient.DeleteMessage(chatId, messageId, cancellationToken);
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -126,16 +126,8 @@ public class Program
 
                 services.AddSingleton<IVersionService, VersionService>();
 
-                // Everything the handlers say to a chat goes through this; the raw client
-                // stays registered for lifecycle and lookup calls (issue #65).
-                services.AddSingleton<IBotMessenger, TelegramBotMessenger>();
-
-                // Singleton because a conversation must survive between the customer's
-                // messages; a scoped store would forget the flow at every update.
-                services.AddSingleton<IConversationStore, InMemoryConversationStore>();
-
-                services.AddSingleton<IBotHandler, BotHandler>();
-
+                // One place, so a test can exercise the same wiring (issue #65).
+                services.AddBotHandler();
 
                 services.AddHostedService<TelegramBotHostedService>();
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -14,6 +14,8 @@ using TallaEgg.Core.Services;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Core.Interfaces;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
 using TallaEgg.TelegramBot.Infrastructure.Options;
 using TallaEgg.TelegramBot.Infrastructure.Services;
 using Telegram.Bot;
@@ -123,6 +125,14 @@ public class Program
                 });
 
                 services.AddSingleton<IVersionService, VersionService>();
+
+                // Everything the handlers say to a chat goes through this; the raw client
+                // stays registered for lifecycle and lookup calls (issue #65).
+                services.AddSingleton<IBotMessenger, TelegramBotMessenger>();
+
+                // Singleton because a conversation must survive between the customer's
+                // messages; a scoped store would forget the flow at every update.
+                services.AddSingleton<IConversationStore, InMemoryConversationStore>();
 
                 services.AddSingleton<IBotHandler, BotHandler>();
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
@@ -79,6 +79,11 @@ public class TelegramBotHostedService : BackgroundService
             receiverOptions: receiverOptions,
             cancellationToken: _receiverCts.Token);
 
+        // The handler's background work starts here rather than in its constructor, so
+        // that constructing it — in a test, or during container setup — has no side
+        // effects (issue #65).
+        _botHandler.Start(_receiverCts.Token);
+
         _logger.LogInformation("Bot is now running and listening for messages...");
         return Task.CompletedTask;
     }

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -122,11 +122,16 @@ public class OutboxProcessorService : BackgroundService
                     // A trade is now recorded but unsettled, with the participants' collateral
                     // still locked. It needs an operator: inspect /api/outbox/unsettled and
                     // re-drive once the cause is fixed (settlement is idempotent).
+                    // The template had four placeholders and three arguments: {Id} appeared
+                    // again in the re-drive URL. Placeholders bind positionally, so the
+                    // fourth had nothing to bind to and the operator's one actionable line
+                    // ended in a literal "{Id}" instead of the id to re-drive. Naming the
+                    // repeat separately and passing it keeps the URL copy-pasteable.
                     _logger.LogError(ex,
                         "SETTLEMENT STUCK — outbox message {Id} (trade {AggregateId}) permanently failed after {Retries} attempts. " +
                         "The trade is recorded but NOT settled and collateral remains locked. " +
-                        "Fix the cause, then POST /api/outbox/{Id}/redrive.",
-                        message.Id, message.AggregateId, message.RetryCount);
+                        "Fix the cause, then POST /api/outbox/{RedriveId}/redrive.",
+                        message.Id, message.AggregateId, message.RetryCount, message.Id);
                 else
                     _logger.LogWarning(ex, "Outbox message {Id} (aggregate {AggregateId}) failed attempt {Retry}; will retry.",
                         message.Id, message.AggregateId, message.RetryCount);

--- a/src/TallaEgg/TallaEgg.Core/Services/ITelegramLogger.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/ITelegramLogger.cs
@@ -1,0 +1,18 @@
+namespace TallaEgg.Core.Services;
+
+/// <summary>
+/// Diagnostic and audit messages the bot posts to its private Telegram channels
+/// (issue #65).
+///
+/// Extracted so a conversation test does not post to a real channel — and, more to the
+/// point, so a missing logger cannot stop a test from constructing the handler at all.
+/// These calls are observational: a failure here must never change what the customer sees.
+/// </summary>
+public interface ITelegramLogger
+{
+    Task Notif(string message, string chatId = "-1002988196234", string parseMode = "");
+    Task Notif<T>(string message, T dto, string chatId = "-1002988196234", string parseMode = "");
+    Task LogAsync<T>(string message, T dto, string chatId = "-822161060", string parseMode = "");
+    Task LogAsync(string log, string chatId = "-822161060");
+    Task ErrorAsync(Exception ex, string message = "");
+}

--- a/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace TallaEgg.Core.Services
 {
-    public class TelegramLoggerService
+    public class TelegramLoggerService : ITelegramLogger
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly string _botToken;

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
@@ -1,0 +1,25 @@
+﻿using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Enums.User;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Clients;
+
+/// <summary>
+/// The Users service as the Telegram bot uses it (issue #65).
+///
+/// Extracted so a conversation test can supply a known customer instead of reaching a
+/// running Users API over HTTP. Covers what the bot actually calls, not the whole client:
+/// a wider interface would be more to fake for no extra coverage, and the unused methods
+/// remain available on the concrete class.
+/// </summary>
+public interface IUsersApiClient
+{
+    Task<UserDto?> GetUserAsync(long telegramId);
+    Task<UserDto?> GetUserAsync(string phone);
+    Task<ApiResponse<PagedResult<UserDto>>> GetUsersAsync(int pageNumber = 1, int pageSize = 10, string? searchTerm = null);
+    Task<(bool success, string message, Guid? userId)> RegisterUserAsync(
+        long telegramId, string invitationCode, string? username, string? firstName, string? lastName);
+    Task<ApiResponse<UserDto>> UpdatePhoneAsync(long telegramId, string phoneNumber);
+    Task<ApiResponse<UserDto>> UpdateUserStatusAsync(long telegramId, UserStatus newStatus);
+    Task<Guid?> GetUserIdByPhoneNumberAsync(string phonenumber);
+}

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/IWalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/IWalletApiClient.cs
@@ -1,6 +1,7 @@
-using TallaEgg.Core.DTOs;
+﻿using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Requests.Wallet;
 using TallaEgg.Core.Responses.Order;
 
 namespace TallaEgg.Infrastructure.Clients;
@@ -16,6 +17,11 @@ public interface IWalletApiClient
     /// دریافت موجودی کاربر برای دارایی مشخص
     /// </summary>
     Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset);
+
+    // Admin credit/debit and the balance screen, used by the bot (issue #65).
+    Task<ApiResponse<IEnumerable<WalletDTO>>> GetUserWalletsBalanceAsync(Guid userId);
+    Task<ApiResponse<WalletBallanceDTO>> DepositeAsync(WalletRequest request);
+    Task<ApiResponse<WalletBallanceDTO>> WithdrawalAsync(WalletRequest request);
     
     /// <summary>
     /// ثبت تراکنش معامله و تغییر بالانس ها

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -14,7 +14,7 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace TallaEgg.TelegramBot.Infrastructure.Clients;
 
-public class UsersApiClient
+public class UsersApiClient : IUsersApiClient
 {
     private readonly HttpClient _httpClient;
     private readonly string _baseUrl;

--- a/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
@@ -1,0 +1,157 @@
+﻿using TallaEgg.Core;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Utilties;
+using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Messages;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The two remaining messages with a branch in them (issue #65): the balance screen, which
+/// changes shape when the customer is in debt, and the market prices, which change shape
+/// when one side of the book is empty.
+///
+/// The other <c>string.Format</c> calls left in the handlers substitute a single error
+/// reason into a fixed sentence. There is no arithmetic, no unit, and no branch in those,
+/// so a builder for each would add indirection without pinning anything down.
+/// </summary>
+public class BalanceAndPriceMessageTests
+{
+    private static WalletDTO Wallet(string asset, decimal balance, decimal locked = 0m) =>
+        new() { Asset = asset, Balance = balance, LockedBalance = locked };
+
+    // ── the balance screen ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A negative available balance is normal under the credit model, but a bare minus sign
+    /// reads as a malfunction. The debt is shown as a positive number under its own label —
+    /// so the sign must be flipped exactly once.
+    /// </summary>
+    [Fact]
+    public void ANegativeBalance_IsShownAsAPositiveDebt()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Toman, -5_000_000m)]);
+
+        // The debt line specifically — the available-balance row above it still carries the
+        // negative figure, which is correct: that is the raw ledger value.
+        var debtLine = text.Split('\n').Single(l => l.Contains("بدهی شما"));
+
+        Assert.Contains(PersianFormat.Amount(5_000_000m, CurrenciesConstant.Toman), debtLine);
+        Assert.DoesNotContain("-", debtLine);
+        Assert.DoesNotContain("−", debtLine); // the Unicode minus, in case a formatter emits it
+    }
+
+    /// <summary>A customer in credit must not be told they owe anything.</summary>
+    [Fact]
+    public void APositiveBalance_ShowsNoDebtLine()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Toman, 5_000_000m)]);
+
+        Assert.DoesNotContain("بدهی", text);
+    }
+
+    /// <summary>
+    /// Zero is not debt. An off-by-one in the comparison would tell every customer with an
+    /// empty wallet that they owe nothing — as a warning.
+    /// </summary>
+    [Fact]
+    public void AZeroBalance_ShowsNoDebtLine()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Toman, 0m)]);
+
+        Assert.DoesNotContain("بدهی", text);
+    }
+
+    /// <summary>
+    /// Locked collateral is money the customer still owns but cannot spend. Folding it into
+    /// the available balance would overstate what they can trade with.
+    /// </summary>
+    [Fact]
+    public void LockedCollateral_IsReportedSeparatelyFromTheAvailableBalance()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Maua, 10m, locked: 2.5m)]);
+
+        Assert.Contains("موجودی آزاد", text);
+        Assert.Contains("درگیر در سفارش", text);
+        Assert.Contains(PersianFormat.Amount(10m, CurrenciesConstant.Maua), text);
+        Assert.Contains(PersianFormat.Amount(2.5m, CurrenciesConstant.Maua), text);
+    }
+
+    /// <summary>Assets are named in Persian; the latin code is an internal detail.</summary>
+    [Fact]
+    public void AssetsAreNamedInPersian_NotByTheirLatinCode()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Maua, 10m)]);
+
+        Assert.DoesNotContain("MAUA", text);
+        Assert.Contains(PersianFormat.Asset(CurrenciesConstant.Maua), text);
+    }
+
+    [Fact]
+    public void EveryWalletGetsARow_AndNoPlaceholderSurvives()
+    {
+        var text = WalletBalanceMessage.Build([
+            Wallet(CurrenciesConstant.Maua, 10m),
+            Wallet(CurrenciesConstant.Toman, -5_000_000m)
+        ]);
+
+        Assert.Contains(PersianFormat.Asset(CurrenciesConstant.Maua), text);
+        Assert.Contains(PersianFormat.Asset(CurrenciesConstant.Toman), text);
+        Assert.DoesNotContain("{", text);
+    }
+
+    // ── best market prices ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An empty side of the book has no price. Rendering null as a number gives "۰ تومان",
+    /// which says the price is zero rather than that there is no price — a customer seeing
+    /// gold bid at zero would read the market as collapsed.
+    /// </summary>
+    [Fact]
+    public void AMissingPrice_SaysSoInsteadOfShowingZero()
+    {
+        var text = BestPricesMessage.Build(bestBidPrice: null, bestAskPrice: 80_000_000m);
+
+        // Only the missing side is affected; the present one still shows its number.
+        var buyLine = text.Split('\n').Single(l => l.Contains("خرید"));
+        var sellLine = text.Split('\n').Single(l => l.Contains("فروش"));
+
+        Assert.Contains(BotMsgs.MsgPriceNotAvailable, buyLine);
+        Assert.DoesNotContain("تومان", buyLine);
+        Assert.Contains(PersianFormat.Number(80_000_000m), sellLine);
+    }
+
+    [Fact]
+    public void BothSidesMissing_ProducesNoNumbersAtAll()
+    {
+        var text = BestPricesMessage.Build(null, null);
+
+        Assert.Equal(2, text.Split(BotMsgs.MsgPriceNotAvailable).Length - 1);
+    }
+
+    [Fact]
+    public void PresentPricesAreShownWithTheirUnit()
+    {
+        var text = BestPricesMessage.Build(79_000_000m, 80_000_000m);
+
+        Assert.Contains(PersianFormat.Number(79_000_000m), text);
+        Assert.Contains(PersianFormat.Number(80_000_000m), text);
+        Assert.DoesNotContain("{", text);
+    }
+
+    /// <summary>
+    /// Bid before ask, matching the labels. Swapping them would show the customer they can
+    /// sell above the buy price — an arbitrage that does not exist.
+    /// </summary>
+    [Fact]
+    public void TheBidIsShownOnTheBuyLineAndTheAskOnTheSellLine()
+    {
+        var text = BestPricesMessage.Build(bestBidPrice: 79_000_000m, bestAskPrice: 80_000_000m);
+
+        var buyLine = text.Split('\n').Single(l => l.Contains("خرید"));
+        var sellLine = text.Split('\n').Single(l => l.Contains("فروش"));
+
+        Assert.Contains(PersianFormat.Number(79_000_000m), buyLine);
+        Assert.Contains(PersianFormat.Number(80_000_000m), sellLine);
+    }
+}

--- a/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
+++ b/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
@@ -1,0 +1,361 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.Enums.User;
+using TallaEgg.TelegramBot;
+using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
+using Wallet.Tests.Fakes;
+using Telegram.Bot.Types;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// A customer's whole ordering conversation, driven end to end (issue #65).
+///
+/// This is what slices 2 and 3 were for. <c>BotHandler</c> is the busiest class in the
+/// product and the only part of the money path with no automated coverage, because
+/// three things made it untestable: the send methods were extension methods and could not
+/// be substituted, conversation state was a private dictionary, and the constructor started
+/// a background thread and messaged every user. With a messenger interface, an injected
+/// store, and startup work moved out of the constructor, the handler can now simply be
+/// built and talked to.
+///
+/// The flow under test is the dealer model (issue #48): the admin publishes a quote and the
+/// customer trades on it. Its defining property — that the customer is <b>never asked for a
+/// price</b> — had no test at all until now, and it is the property that removes the whole
+/// gram/mesghal ambiguity from the customer's side.
+/// </summary>
+public class BotConversationFlowTests
+{
+    private const long ChatId = 555_000;
+    private const long TelegramId = 555_000;
+    private static readonly Guid CustomerId = Guid.NewGuid();
+
+    private const string Gold = CurrenciesConstant.MAUA_IRT;
+
+    /// <summary>80,000,000 per mesghal, in the per-gram unit quotes are stored in.</summary>
+    private const decimal AskPerGram = 18_468_073.32m;
+    private const decimal BidPerGram = 18_237_000m;
+
+    private readonly FakeBotMessenger _messenger = new();
+    private readonly FakeOrderApiClient _orderApi = new();
+    private readonly FakeUsersApiClient _usersApi = new();
+    private readonly InMemoryConversationStore _conversations = new();
+    private readonly BotHandler _handler;
+
+    public BotConversationFlowTests()
+    {
+        _usersApi.User = new UserDto
+        {
+            Id = CustomerId,
+            TelegramId = TelegramId,
+            FirstName = "مشتری",
+            PhoneNumber = "09121234567",
+            Status = UserStatus.Approved,
+            Role = UserRole.User
+        };
+
+        _handler = new BotHandler(
+            NullLogger<BotHandler>.Instance,
+            botClient: null!, // only used for the chat-admin lookup, which this flow never reaches
+            messenger: _messenger,
+            conversations: _conversations,
+            orderApi: _orderApi,
+            usersApi: _usersApi,
+            affiliateApi: new FakeAffiliateApiClient(),
+            walletApi: new StubWalletApiClient(),
+            telegramLogger: new SilentTelegramLogger(),
+            versionService: new FakeVersionService());
+    }
+
+    // ── driving the conversation ────────────────────────────────────────────────
+
+    private Task SayAsync(string text) => _handler.HandleMessageAsync(new Message
+    {
+        Text = text,
+        Chat = new Chat { Id = ChatId },
+        From = new User { Id = TelegramId }
+    });
+
+    private Task TapAsync(string callbackData) => _handler.HandleCallbackQueryAsync(new CallbackQuery
+    {
+        Id = Guid.NewGuid().ToString(),
+        Data = callbackData,
+        From = new User { Id = TelegramId },
+        Message = new Message { Chat = new Chat { Id = ChatId } }
+    });
+
+    private void PublishQuote() => _orderApi.ActiveQuote = new QuoteDto
+    {
+        Id = Guid.NewGuid(),
+        Symbol = Gold,
+        BuyPrice = BidPerGram,
+        SellPrice = AskPerGram,
+        PublishedAt = DateTime.UtcNow
+    };
+
+    /// <summary>Menu → asset → side → amount. Leaves the confirmation on screen.</summary>
+    private async Task WalkToConfirmationAsync(string amount = "2.5", string side = InlineCallBackData.buy_spot)
+    {
+        await SayAsync(BotBtns.BtnSpotMarket);
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(side);
+        await SayAsync(amount);
+    }
+
+    // ── the dealer-model guarantee ──────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole point of the dealer model: the customer states a quantity and nothing else.
+    /// If a price prompt ever reappeared here, the gram/mesghal ambiguity would come back
+    /// with it — and that ambiguity is what made an earlier version show prices off by a
+    /// factor of 4.3318.
+    /// </summary>
+    [Fact]
+    public async Task WithAPublishedQuote_TheCustomerIsNeverAskedForAPrice()
+    {
+        PublishQuote();
+
+        await WalkToConfirmationAsync();
+
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("قیمت را وارد کنید"));
+        Assert.False(_messenger.AnyTextContains(BotMsgs.MsgEnterPriceGold));
+    }
+
+    /// <summary>
+    /// A buying customer pays the admin's <b>sell</b> price. Swapping the two is the
+    /// buyer/seller inversion in another guise, and here it would quote the customer a
+    /// price better than the shop ever offered.
+    /// </summary>
+    [Fact]
+    public async Task ABuyingCustomerIsQuotedTheAdminsSellPrice()
+    {
+        PublishQuote();
+
+        await WalkToConfirmationAsync(side: InlineCallBackData.buy_spot);
+
+        Assert.Equal(AskPerGram, CurrentConversation().Price);
+    }
+
+    [Fact]
+    public async Task ASellingCustomerIsQuotedTheAdminsBuyPrice()
+    {
+        PublishQuote();
+
+        await WalkToConfirmationAsync(side: InlineCallBackData.sell_spot);
+
+        Assert.Equal(BidPerGram, CurrentConversation().Price);
+    }
+
+    /// <summary>
+    /// With no quote published the bot must fall back to asking for a price — the order-book
+    /// path. Without this, the previous test would also pass if the confirmation step were
+    /// simply broken and no messages were sent at all.
+    /// </summary>
+    [Fact]
+    public async Task WithNoQuotePublished_TheCustomerIsAskedForAPrice()
+    {
+        _orderApi.ActiveQuote = null;
+
+        await SayAsync(BotBtns.BtnSpotCreateOrder); // limit order, so a price is expected
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(InlineCallBackData.buy_spot);
+        await SayAsync("2.5");
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("مثقال") && t.Contains("قیمت"));
+    }
+
+    // ── what the customer is shown, and in what order ───────────────────────────
+
+    [Fact]
+    public async Task TheConfirmationShowsTheQuantityAndBothPriceUnits()
+    {
+        PublishQuote();
+
+        await WalkToConfirmationAsync(amount: "2.5");
+
+        var confirmation = _messenger.Texts.Last();
+        Assert.Contains("تایید سفارش", confirmation);
+        Assert.Contains("قیمت هر مثقال", confirmation);
+        Assert.Contains("قیمت هر گرم", confirmation);
+        Assert.DoesNotContain("{", confirmation);
+    }
+
+    /// <summary>
+    /// Two messages, in this order: the order was accepted, then the trade executed.
+    /// Reversed, the customer is told the outcome of something they have not yet been told
+    /// was accepted.
+    /// </summary>
+    [Fact]
+    public async Task OnConfirmation_TheOrderAcknowledgementPrecedesTheTradeReport()
+    {
+        PublishQuote();
+        await WalkToConfirmationAsync();
+        var before = _messenger.Sent.Count;
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        var after = _messenger.Texts.Skip(before).ToList();
+
+        var acknowledged = after.FindIndex(t => t.Contains("ثبت شد") || t == BotMsgs.MsgOrderSuccess);
+        var executed = after.FindIndex(t => t.Contains("معاملهٔ شما انجام شد"));
+
+        Assert.True(acknowledged >= 0, $"no order acknowledgement in: {string.Join(" | ", after)}");
+        Assert.True(executed > acknowledged, "the trade report must come after the acknowledgement");
+    }
+
+    /// <summary>
+    /// In the order-book path the order may rest unfilled for hours, so reporting a trade
+    /// would be a lie. The report is tied to a fill, not to the order being accepted.
+    /// </summary>
+    [Fact]
+    public async Task WithoutAQuote_NoTradeReportIsSent_BecauseNothingHasExecuted()
+    {
+        _orderApi.ActiveQuote = null;
+        await SayAsync(BotBtns.BtnSpotCreateOrder);
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(InlineCallBackData.buy_spot);
+
+        _conversations.TryGet(TelegramId, out var conversation);
+        conversation.Amount = 2.5m;
+        conversation.Price = AskPerGram;
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("معاملهٔ شما انجام شد"));
+    }
+
+    // ── what reaches the Orders service ─────────────────────────────────────────
+
+    /// <summary>
+    /// The quantity the customer typed must arrive unchanged. The mesghal conversion applies
+    /// to prices, never to quantities — applying it here would place an order 4.3318x the
+    /// size the customer asked for.
+    /// </summary>
+    [Fact]
+    public async Task TheQuantityTheCustomerTyped_IsWhatTheOrdersServiceReceives()
+    {
+        PublishQuote();
+        await WalkToConfirmationAsync(amount: "2.5");
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        var accepted = Assert.Single(_orderApi.AcceptedQuotes);
+        Assert.Equal(2.5m, accepted.Quantity);
+        Assert.Equal(Gold, accepted.Symbol);
+        Assert.Equal(OrderSide.Buy, accepted.Side);
+        Assert.Equal(CustomerId, accepted.UserId);
+    }
+
+    /// <summary>
+    /// The dealer path accepts a quote; it must not also place an ordinary order. Doing both
+    /// would trade twice on one confirmation.
+    /// </summary>
+    [Fact]
+    public async Task TheDealerPathAcceptsTheQuoteAndDoesNotAlsoSubmitAnOrder()
+    {
+        PublishQuote();
+        await WalkToConfirmationAsync();
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        Assert.Single(_orderApi.AcceptedQuotes);
+        Assert.Empty(_orderApi.SubmittedOrders);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("abc")]
+    public async Task AnInvalidQuantity_IsRejectedAndNothingIsSentToTheOrdersService(string amount)
+    {
+        PublishQuote();
+
+        await WalkToConfirmationAsync(amount: amount);
+
+        Assert.Empty(_orderApi.AcceptedQuotes);
+        Assert.Contains(_messenger.Texts, t => t.Contains("مقدار معتبر"));
+    }
+
+    // ── conversation lifecycle ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// The state must be gone once the order is placed. A leftover conversation is what
+    /// makes the customer's <i>next</i> order inherit this one's asset, side or amount —
+    /// a defect that would look like the bot inventing an order they never asked for.
+    /// </summary>
+    [Fact]
+    public async Task AfterASuccessfulOrder_TheConversationIsCleared()
+    {
+        PublishQuote();
+        await WalkToConfirmationAsync();
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        Assert.Equal(0, _conversations.Count);
+    }
+
+    /// <summary>Failure must clear it too, or a rejected order strands the customer mid-flow.</summary>
+    [Fact]
+    public async Task AfterARejectedOrder_TheConversationIsAlsoCleared()
+    {
+        PublishQuote();
+        _orderApi.AcceptResult = (false, "موجودی کافی نیست");
+        await WalkToConfirmationAsync();
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        Assert.Equal(0, _conversations.Count);
+        Assert.Contains(_messenger.Texts, t => t.Contains("موجودی کافی نیست"));
+    }
+
+    [Fact]
+    public async Task CancellingClearsTheConversation()
+    {
+        PublishQuote();
+        await WalkToConfirmationAsync();
+
+        await TapAsync(InlineCallBackData.cancel_order);
+
+        Assert.Equal(0, _conversations.Count);
+    }
+
+    /// <summary>
+    /// A button tapped from an old message, after the conversation is gone — a restart, or a
+    /// flow that already finished. The customer gets a message rather than the bot throwing.
+    /// </summary>
+    [Fact]
+    public async Task TappingAStaleSideButton_WithNoConversation_DoesNotThrow()
+    {
+        PublishQuote();
+
+        await TapAsync(InlineCallBackData.buy_spot);
+
+        Assert.NotEmpty(_messenger.Texts);
+        Assert.Empty(_orderApi.AcceptedQuotes);
+    }
+
+    /// <summary>
+    /// Confirming with no conversation must not reach the Orders service. Without the guard
+    /// this would place an order with a zero quantity and a zero price.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmingWithNoConversation_PlacesNoOrder()
+    {
+        PublishQuote();
+
+        await TapAsync(InlineCallBackData.confirm_order);
+
+        Assert.Empty(_orderApi.AcceptedQuotes);
+        Assert.Empty(_orderApi.SubmittedOrders);
+    }
+
+    private OrderState CurrentConversation()
+    {
+        Assert.True(_conversations.TryGet(TelegramId, out var conversation), "no conversation in flight");
+        return conversation;
+    }
+}

--- a/src/Wallet/Wallet.Tests/BotHandlerRegistrationTests.cs
+++ b/src/Wallet/Wallet.Tests/BotHandlerRegistrationTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core.Services;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.TelegramBot;
+using TallaEgg.TelegramBot.Core.Interfaces;
+using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
+using TallaEgg.TelegramBot.Infrastructure.Services;
+using Telegram.Bot;
+using Wallet.Tests.Fakes;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The bot's dependency wiring must actually resolve (issue #65).
+///
+/// A constructor parameter type is matched against the container at run time, not build
+/// time. When <c>BotHandler</c> moved from the concrete API clients to their interfaces the
+/// solution still compiled cleanly and every other test still passed — but the bot would
+/// have died on startup with "unable to resolve IOrderApiClient", and the only way to find
+/// out was to launch it.
+///
+/// This calls the very same <c>AddBotHandler</c> that <c>Program.cs</c> calls, so it covers
+/// the production wiring rather than a copy that could drift.
+/// </summary>
+public class BotHandlerRegistrationTests
+{
+    /// <summary>
+    /// Registers the concrete clients the way <c>Program.cs</c> does, but built from
+    /// harmless values — no HTTP call is made by construction, only by use.
+    /// </summary>
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddLogging();
+        services.AddHttpClient();
+
+        services.AddSingleton<ITelegramBotClient>(_ => new TelegramBotClient("1:AA"));
+        services.AddSingleton(p => new OrderApiClient(
+            new HttpClient { BaseAddress = new Uri("http://localhost") },
+            p.GetRequiredService<IConfiguration>(),
+            p.GetRequiredService<ILogger<OrderApiClient>>()));
+        services.AddSingleton(p => new UsersApiClient(
+            new HttpClient { BaseAddress = new Uri("http://localhost") },
+            p.GetRequiredService<IConfiguration>(),
+            p.GetRequiredService<ILogger<UsersApiClient>>()));
+        services.AddSingleton(p => new AffiliateApiClient(
+            "http://localhost", new HttpClient(), p.GetRequiredService<ILogger<AffiliateApiClient>>()));
+        services.AddSingleton(_ => new WalletApiClient("http://localhost"));
+        services.AddSingleton(p => new TelegramLoggerService(
+            p.GetRequiredService<IHttpClientFactory>(), "1:AA"));
+        services.AddSingleton<IVersionService, FakeVersionService>();
+
+        services.AddBotHandler();
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// The assertion that would have caught the interface switch: every dependency the
+    /// handler declares can be satisfied.
+    /// </summary>
+    [Fact]
+    public void TheBotHandler_CanBeResolved()
+    {
+        using var provider = BuildProvider();
+
+        Assert.NotNull(provider.GetRequiredService<IBotHandler>());
+    }
+
+    [Theory]
+    [InlineData(typeof(IOrderApiClient))]
+    [InlineData(typeof(IUsersApiClient))]
+    [InlineData(typeof(IAffiliateApiClient))]
+    [InlineData(typeof(IWalletApiClient))]
+    [InlineData(typeof(ITelegramLogger))]
+    [InlineData(typeof(IBotMessenger))]
+    [InlineData(typeof(IConversationStore))]
+    public void EveryAbstractionTheHandlerNeeds_IsRegistered(Type serviceType)
+    {
+        using var provider = BuildProvider();
+
+        Assert.NotNull(provider.GetRequiredService(serviceType));
+    }
+
+    /// <summary>
+    /// The interface registrations must forward to the instances already registered, not
+    /// construct second ones. A duplicate client would carry its own HttpClient, doubling
+    /// the connection pool and making any future per-client state silently diverge.
+    /// </summary>
+    [Fact]
+    public void TheInterfacesResolveToTheSameInstancesAsTheConcreteClients()
+    {
+        using var provider = BuildProvider();
+
+        Assert.Same(provider.GetRequiredService<OrderApiClient>(), provider.GetRequiredService<IOrderApiClient>());
+        Assert.Same(provider.GetRequiredService<UsersApiClient>(), provider.GetRequiredService<IUsersApiClient>());
+        Assert.Same(provider.GetRequiredService<WalletApiClient>(), provider.GetRequiredService<IWalletApiClient>());
+        Assert.Same(provider.GetRequiredService<TelegramLoggerService>(), provider.GetRequiredService<ITelegramLogger>());
+    }
+
+    /// <summary>
+    /// The conversation store must be a singleton. Scoped or transient would hand each
+    /// update its own store, so the customer's asset and side would be forgotten between
+    /// one message and the next and every order would start over.
+    /// </summary>
+    [Fact]
+    public void TheConversationStore_IsSharedAcrossScopes()
+    {
+        using var provider = BuildProvider();
+
+        using var scopeA = provider.CreateScope();
+        using var scopeB = provider.CreateScope();
+
+        Assert.Same(
+            scopeA.ServiceProvider.GetRequiredService<IConversationStore>(),
+            scopeB.ServiceProvider.GetRequiredService<IConversationStore>());
+    }
+
+    /// <summary>
+    /// Building the handler must have no side effects. It used to start a background thread
+    /// and message every user from its constructor, which ran before the rest of the
+    /// container had finished being wired — and made it impossible to construct in a test.
+    /// </summary>
+    [Fact]
+    public void ResolvingTheHandler_SendsNothingAndStartsNothing()
+    {
+        var messenger = new FakeBotMessenger();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<ITelegramBotClient>(_ => new TelegramBotClient("1:AA"));
+        services.AddSingleton<IBotMessenger>(messenger);
+        services.AddSingleton<IConversationStore, InMemoryConversationStore>();
+        services.AddSingleton<IOrderApiClient, FakeOrderApiClient>();
+        services.AddSingleton<IUsersApiClient, FakeUsersApiClient>();
+        services.AddSingleton<IAffiliateApiClient, FakeAffiliateApiClient>();
+        services.AddSingleton<IWalletApiClient, StubWalletApiClient>();
+        services.AddSingleton<ITelegramLogger, SilentTelegramLogger>();
+        services.AddSingleton<IVersionService, FakeVersionService>();
+        services.AddSingleton<IBotHandler, BotHandler>();
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IBotHandler>();
+
+        Assert.Empty(messenger.Sent);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -1,0 +1,114 @@
+﻿using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.Enums.User;
+using TallaEgg.Core.Responses.Order;
+using TallaEgg.Core.Services;
+using TallaEgg.TelegramBot.Infrastructure.Services;
+using TallaEgg.TelegramBot;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+
+namespace Wallet.Tests.Fakes;
+
+/// <summary>
+/// Records the order the bot placed, and answers with a published quote (issue #65).
+///
+/// Only the members a conversation actually reaches are implemented; the rest throw, so a
+/// test that wanders into an unconfigured call fails loudly instead of quietly passing
+/// against a default value.
+/// </summary>
+public sealed class FakeOrderApiClient : IOrderApiClient
+{
+    /// <summary>The quote returned for any symbol. Null means dealer mode is off.</summary>
+    public QuoteDto? ActiveQuote { get; set; }
+
+    public List<(Guid UserId, string Symbol, OrderSide Side, decimal Quantity)> AcceptedQuotes { get; } = [];
+    public List<OrderDto> SubmittedOrders { get; } = [];
+
+    /// <summary>What <c>AcceptQuoteAsync</c> reports back.</summary>
+    public (bool Success, string Message) AcceptResult { get; set; } = (true, "ok");
+
+    public Task<QuoteDto?> GetActiveQuoteAsync(string symbol) => Task.FromResult(ActiveQuote);
+
+    public Task<(bool success, string message)> AcceptQuoteAsync(
+        Guid userId, string symbol, OrderSide side, decimal quantity)
+    {
+        AcceptedQuotes.Add((userId, symbol, side, quantity));
+        return Task.FromResult(AcceptResult);
+    }
+
+    public Task<(bool success, string message)> SubmitOrderAsync(OrderDto order)
+    {
+        SubmittedOrders.Add(order);
+        return Task.FromResult((true, "ok"));
+    }
+
+    public Task<ApiResponse<BestPricesDto>> GetBestPricesAsync(string symbol) =>
+        Task.FromResult(ApiResponse<BestPricesDto>.Ok(new BestPricesDto(), "ok"));
+
+    public Task<ApiResponse<PagedResult<OrderHistoryDto>>> GetUserOrdersAsync(Guid userId, int pageNumber = 1, int pageSize = 10) =>
+        throw new NotSupportedException(nameof(GetUserOrdersAsync));
+    public Task<ApiResponse<PagedResult<TradeHistoryDto>>> GetUserTradesAsync(Guid userId, int pageNumber = 1, int pageSize = 10) =>
+        throw new NotSupportedException(nameof(GetUserTradesAsync));
+    public Task<ApiResponse<List<OrderHistoryDto>>> GetUserActiveOrdersAsync(Guid userId) =>
+        throw new NotSupportedException(nameof(GetUserActiveOrdersAsync));
+    public Task<ApiResponse<List<OrderHistoryDto>>> GetAllActiveOrdersAsync() =>
+        throw new NotSupportedException(nameof(GetAllActiveOrdersAsync));
+    public Task<(bool success, string message)> CancelOrderAsync(Guid orderId) =>
+        throw new NotSupportedException(nameof(CancelOrderAsync));
+    public Task<(bool success, string message)> PublishQuoteAsync(
+        string symbol, decimal buyPrice, decimal sellPrice, Guid publishedByUserId) =>
+        throw new NotSupportedException(nameof(PublishQuoteAsync));
+    public Task<(bool success, string message, int cancelledCount)> CancelAllUserActiveOrdersAsync(Guid userId, string? reason = null) =>
+        throw new NotSupportedException(nameof(CancelAllUserActiveOrdersAsync));
+    public Task<ApiResponse<bool>> NotifyMatchingEngineAsync(NotifyMatchingEngineRequest request) =>
+        throw new NotSupportedException(nameof(NotifyMatchingEngineAsync));
+}
+
+/// <summary>Answers with one known, approved customer.</summary>
+public sealed class FakeUsersApiClient : IUsersApiClient
+{
+    public UserDto? User { get; set; }
+
+    public Task<UserDto?> GetUserAsync(long telegramId) => Task.FromResult(User);
+    public Task<UserDto?> GetUserAsync(string phone) => Task.FromResult(User);
+
+    public Task<ApiResponse<PagedResult<UserDto>>> GetUsersAsync(int pageNumber = 1, int pageSize = 10, string? searchTerm = null) =>
+        throw new NotSupportedException(nameof(GetUsersAsync));
+    public Task<(bool success, string message, Guid? userId)> RegisterUserAsync(
+        long telegramId, string invitationCode, string? username, string? firstName, string? lastName) =>
+        throw new NotSupportedException(nameof(RegisterUserAsync));
+    public Task<ApiResponse<UserDto>> UpdatePhoneAsync(long telegramId, string phoneNumber) =>
+        throw new NotSupportedException(nameof(UpdatePhoneAsync));
+    public Task<ApiResponse<UserDto>> UpdateUserStatusAsync(long telegramId, UserStatus newStatus) =>
+        throw new NotSupportedException(nameof(UpdateUserStatusAsync));
+    public Task<Guid?> GetUserIdByPhoneNumberAsync(string phonenumber) =>
+        throw new NotSupportedException(nameof(GetUserIdByPhoneNumberAsync));
+}
+
+public sealed class FakeAffiliateApiClient : IAffiliateApiClient
+{
+    public Task<(bool success, string message, Guid? invitationId)> UseInvitationAsync(string invitationCode, Guid usedByUserId) =>
+        Task.FromResult((true, "ok", (Guid?)Guid.NewGuid()));
+}
+
+/// <summary>
+/// Swallows diagnostics. These calls are observational: they must never influence what the
+/// customer sees, and a test should not post to a real Telegram channel.
+/// </summary>
+public sealed class SilentTelegramLogger : ITelegramLogger
+{
+    public Task Notif(string message, string chatId = "", string parseMode = "") => Task.CompletedTask;
+    public Task Notif<T>(string message, T dto, string chatId = "", string parseMode = "") => Task.CompletedTask;
+    public Task LogAsync<T>(string message, T dto, string chatId = "", string parseMode = "") => Task.CompletedTask;
+    public Task LogAsync(string log, string chatId = "") => Task.CompletedTask;
+    public Task ErrorAsync(Exception ex, string message = "") => Task.CompletedTask;
+}
+
+public sealed class FakeVersionService : IVersionService
+{
+    public string GetCurrentVersion() => "1.0.0";
+    public string GetLastAnnouncedVersion() => "1.0.0";
+    public void SaveAnnouncedVersion(string version) { }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/FakeBotMessenger.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/FakeBotMessenger.cs
@@ -1,0 +1,69 @@
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Wallet.Tests.Fakes;
+
+/// <summary>
+/// Records what the bot said instead of saying it (issue #65).
+///
+/// This is the whole point of <see cref="IBotMessenger"/>: the real send methods are
+/// extension methods on <c>ITelegramBotClient</c> and cannot be substituted, so before the
+/// interface existed a handler test would have opened a connection to Telegram.
+///
+/// Order is preserved, because in a conversation the sequence is part of the behaviour —
+/// "your order was placed" arriving after "your trade executed" would be wrong even though
+/// both messages are correct.
+/// </summary>
+public sealed class FakeBotMessenger : IBotMessenger
+{
+    public sealed record SentMessage(long ChatId, string Text, ReplyMarkup? ReplyMarkup);
+
+    public List<SentMessage> Sent { get; } = [];
+    public List<string> AnsweredCallbackIds { get; } = [];
+    public List<(long ChatId, int MessageId)> Deleted { get; } = [];
+    public List<(long ChatId, int MessageId, string Text)> Edited { get; } = [];
+
+    /// <summary>Every message body, in the order the customer received them.</summary>
+    public IReadOnlyList<string> Texts => Sent.Select(m => m.Text).ToList();
+
+    public bool AnyTextContains(string fragment) => Sent.Any(m => m.Text.Contains(fragment));
+
+    private int _nextMessageId = 1;
+
+    public Task<int> SendAsync(
+        long chatId,
+        string text,
+        ReplyMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default)
+    {
+        Sent.Add(new SentMessage(chatId, text, replyMarkup));
+        return Task.FromResult(_nextMessageId++);
+    }
+
+    public Task EditTextAsync(
+        long chatId,
+        int messageId,
+        string text,
+        InlineKeyboardMarkup? replyMarkup = null,
+        ParseMode parseMode = ParseMode.None,
+        CancellationToken cancellationToken = default)
+    {
+        Edited.Add((chatId, messageId, text));
+        return Task.CompletedTask;
+    }
+
+    public Task AnswerCallbackAsync(
+        string callbackQueryId, string? text = null, CancellationToken cancellationToken = default)
+    {
+        AnsweredCallbackIds.Add(callbackQueryId);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(long chatId, int messageId, CancellationToken cancellationToken = default)
+    {
+        Deleted.Add((chatId, messageId));
+        return Task.CompletedTask;
+    }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/StubWalletApiClient.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/StubWalletApiClient.cs
@@ -1,0 +1,52 @@
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Requests.Wallet;
+using TallaEgg.Infrastructure.Clients;
+
+namespace Wallet.Tests.Fakes;
+
+/// <summary>
+/// A wallet client that refuses every call, for tests to override only what they exercise.
+///
+/// Each test used to spell out all of <see cref="IWalletApiClient"/>, so widening the
+/// interface broke every fake at once and buried the one method that mattered under a
+/// screenful of throws. Overriding one member states plainly what a test depends on.
+///
+/// The default is to throw rather than return a benign value on purpose: a test that
+/// silently exercises a call it never configured is testing the stub, not the code.
+/// </summary>
+public class StubWalletApiClient : IWalletApiClient
+{
+    public virtual Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade) =>
+        throw new NotSupportedException(nameof(TradeTransactionAndBalanceChangeAsync));
+
+    public virtual Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset) =>
+        throw new NotSupportedException(nameof(GetBalanceAsync));
+
+    public virtual Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(Guid userId, string asset, decimal amount) =>
+        throw new NotSupportedException(nameof(LockBalanceAsync));
+
+    public virtual Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount) =>
+        throw new NotSupportedException(nameof(UnlockBalanceAsync));
+
+    public virtual Task<(bool Success, string Message)> IncreaseBalanceAsync(Guid userId, string asset, decimal amount) =>
+        throw new NotSupportedException(nameof(IncreaseBalanceAsync));
+
+    public virtual Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(
+        Guid userId, string asset, decimal amount) =>
+        throw new NotSupportedException(nameof(ValidateBalanceAsync));
+
+    public virtual Task<(bool Success, string Message, bool HasSufficientCreditAndBalanceBase, bool HasSufficientCreditAndBalanceQuote)>
+        ValidateCreditAndBalanceAsync(Guid userId, string symbol, decimal amount, decimal price) =>
+        throw new NotSupportedException(nameof(ValidateCreditAndBalanceAsync));
+
+    public virtual Task<ApiResponse<IEnumerable<WalletDTO>>> GetUserWalletsBalanceAsync(Guid userId) =>
+        throw new NotSupportedException(nameof(GetUserWalletsBalanceAsync));
+
+    public virtual Task<ApiResponse<WalletBallanceDTO>> DepositeAsync(WalletRequest request) =>
+        throw new NotSupportedException(nameof(DepositeAsync));
+
+    public virtual Task<ApiResponse<WalletBallanceDTO>> WithdrawalAsync(WalletRequest request) =>
+        throw new NotSupportedException(nameof(WithdrawalAsync));
+}

--- a/src/Wallet/Wallet.Tests/MessageBuilderTests.cs
+++ b/src/Wallet/Wallet.Tests/MessageBuilderTests.cs
@@ -1,0 +1,249 @@
+using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.TelegramBot.Infrastructure.Messages;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The three message builders extracted from <c>BotHandler</c> and <c>BotHandlerAdmin</c>
+/// in issue #65.
+///
+/// Every defect this bot has shipped in a customer-visible message compiled cleanly and
+/// looked plausible in Telegram — a Persian date wrong by 22 days, a trade history that
+/// did not say buy or sell, times in UTC. They were found by a person reading a message,
+/// which is not a repeatable process. These tests make the text assertable without a
+/// Telegram connection.
+///
+/// The specific hazard being pinned here is the mesghal conversion. Gold prices are stored
+/// per gram and shown per mesghal, a factor of 4.3318. Getting it backwards, or applying
+/// it twice, or applying it to the total as well as the unit price, produces a number that
+/// is wrong by 4.3x and breaks nothing.
+/// </summary>
+public class MessageBuilderTests
+{
+    private const string Gold = CurrenciesConstant.MAUA_IRT; // MAUA/IRT
+    private const string Crypto = CurrenciesConstant.BTC_IRT;
+
+    /// <summary>
+    /// 80,000,000 toman per mesghal is 18,468,073.32 per gram. Used throughout so the two
+    /// units are always recognisable in an assertion.
+    /// </summary>
+    private const decimal PricePerGram = 18_468_073.32m;
+    private const decimal PricePerMesghal = 80_000_000m;
+
+    /// <summary>Digits as the customer sees them; the templates render Persian numerals.</summary>
+    private static string Fa(decimal value) => PersianFormatFor(value);
+    private static string PersianFormatFor(decimal value) =>
+        TallaEgg.Core.Utilties.PersianFormat.Number(value);
+
+    // ── TradeExecutedMessage ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A buy and a sell move money in opposite directions. The template reuses one slot for
+    /// both, so the label is the only thing telling the customer which happened — and it is
+    /// exactly the kind of detail that was already wrong once in the trade history.
+    /// </summary>
+    [Fact]
+    public void TradeExecuted_ABuyIsLabelledAsMoneyPaid()
+    {
+        var text = TradeExecutedMessage.Build(Gold, OrderSide.Buy, 2.5m, PricePerGram);
+
+        Assert.Contains("پرداختی", text);
+        Assert.DoesNotContain("دریافتی", text);
+    }
+
+    [Fact]
+    public void TradeExecuted_ASellIsLabelledAsMoneyReceived()
+    {
+        var text = TradeExecutedMessage.Build(Gold, OrderSide.Sell, 2.5m, PricePerGram);
+
+        Assert.Contains("دریافتی", text);
+        Assert.DoesNotContain("پرداختی", text);
+    }
+
+    /// <summary>
+    /// Gold is quoted per mesghal. Showing the stored per-gram number would tell the
+    /// customer they traded at 18.4 million when they traded at 80 million.
+    /// </summary>
+    [Fact]
+    public void TradeExecuted_ForGold_ShowsThePricePerMesghal()
+    {
+        var text = TradeExecutedMessage.Build(Gold, OrderSide.Buy, 2.5m, PricePerGram);
+
+        Assert.Contains("قیمت هر مثقال", text);
+        Assert.Contains(Fa(PricePerMesghal), text);
+    }
+
+    /// <summary>
+    /// The total must come from the per-gram price. Multiplying the quantity by the
+    /// displayed per-mesghal price instead overstates it by 4.3318x — and both numbers look
+    /// entirely reasonable on their own.
+    /// </summary>
+    [Fact]
+    public void TradeExecuted_TotalIsQuantityTimesThePerGramPrice_NotTheDisplayedPrice()
+    {
+        var text = TradeExecutedMessage.Build(Gold, OrderSide.Buy, 2.5m, PricePerGram);
+
+        var expected = CurrenciesConstant.RoundToCurrencyPrecision(
+            2.5m * PricePerGram, CurrenciesConstant.Toman);
+
+        Assert.Contains(Fa(expected), text);
+        Assert.DoesNotContain(Fa(2.5m * PricePerMesghal), text);
+    }
+
+    /// <summary>Non-gold pairs have no mesghal, so the price is shown as stored.</summary>
+    [Fact]
+    public void TradeExecuted_ForANonGoldPair_ShowsThePriceUnconverted()
+    {
+        var text = TradeExecutedMessage.Build(Crypto, OrderSide.Buy, 2m, 1_000m);
+
+        Assert.Contains("قیمت هر واحد", text);
+        Assert.DoesNotContain("مثقال", text);
+        Assert.Contains(Fa(1_000m), text);
+    }
+
+    // ── OrderConfirmationMessage ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The gold template takes six arguments and the non-gold one takes five. Passing the
+    /// wrong count is not a compile error: it either throws in front of the customer or
+    /// leaves a literal placeholder in the message. Asserting no brace survives covers the
+    /// whole family at once.
+    /// </summary>
+    [Theory]
+    [InlineData(Gold)]
+    [InlineData(Crypto)]
+    public void OrderConfirmation_LeavesNoUnfilledPlaceholder(string symbol)
+    {
+        var text = OrderConfirmationMessage.Build(symbol, OrderSide.Buy, 2.5m, PricePerGram);
+
+        Assert.DoesNotContain("{", text);
+        Assert.DoesNotContain("}", text);
+    }
+
+    /// <summary>
+    /// Gold shows both units. Only one of them makes the number ambiguous: read as the
+    /// wrong unit it is off by 4.3318x, which is large enough to be a different market and
+    /// small enough not to look like a bug.
+    /// </summary>
+    [Fact]
+    public void OrderConfirmation_ForGold_ShowsBothThePerMesghalAndPerGramPrice()
+    {
+        var text = OrderConfirmationMessage.Build(Gold, OrderSide.Buy, 2.5m, PricePerGram);
+
+        Assert.Contains("قیمت هر مثقال", text);
+        Assert.Contains("قیمت هر گرم", text);
+        Assert.Contains(Fa(PricePerMesghal), text);
+        Assert.Contains(Fa(PricePerGram), text);
+    }
+
+    /// <summary>
+    /// The limit path shows back the number the customer typed rather than deriving it from
+    /// the stored price. The two differ because dividing by 4.3318 and multiplying back does
+    /// not round-trip, and a confirmation quoting a slightly different figure than the one
+    /// just entered reads as the bot having mis-recorded the order.
+    /// </summary>
+    [Fact]
+    public void OrderConfirmation_ShowsTheCustomersOwnEnteredPrice_NotAReDerivedOne()
+    {
+        const decimal entered = 80_000_001m; // deliberately not a clean round-trip
+        var storedPerGram = entered / CurrenciesConstant.GramsPerMesghal;
+
+        var text = OrderConfirmationMessage.Build(
+            Gold, OrderSide.Buy, 2.5m, storedPerGram, displayPricePerMesghal: entered);
+
+        Assert.Contains(Fa(entered), text);
+    }
+
+    /// <summary>
+    /// Without an override the per-mesghal figure is derived. This is the dealer path, where
+    /// the quote is the source of the price and there is no customer input to preserve.
+    /// </summary>
+    [Fact]
+    public void OrderConfirmation_WithoutAnOverride_DerivesThePerMesghalPrice()
+    {
+        var text = OrderConfirmationMessage.Build(Gold, OrderSide.Buy, 2.5m, PricePerGram);
+
+        Assert.Contains(Fa(PricePerGram * CurrenciesConstant.GramsPerMesghal), text);
+    }
+
+    /// <summary>A non-gold pair has no second unit, so the override is meaningless and ignored.</summary>
+    [Fact]
+    public void OrderConfirmation_ForANonGoldPair_IgnoresTheMesghalOverride()
+    {
+        var text = OrderConfirmationMessage.Build(
+            Crypto, OrderSide.Buy, 2m, 1_000m, displayPricePerMesghal: 999_999m);
+
+        Assert.DoesNotContain("مثقال", text);
+        Assert.DoesNotContain(Fa(999_999m), text);
+    }
+
+    [Theory]
+    [InlineData(OrderSide.Buy, "خرید")]
+    [InlineData(OrderSide.Sell, "فروش")]
+    public void OrderConfirmation_NamesTheSide(OrderSide side, string expected)
+    {
+        var text = OrderConfirmationMessage.Build(Gold, side, 2.5m, PricePerGram);
+
+        Assert.Contains(expected, text);
+    }
+
+    // ── QuoteMessage ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The admin types prices per mesghal; quotes are stored per gram. Publishing the typed
+    /// number unconverted would price every customer trade 4.3318x too high.
+    /// </summary>
+    [Fact]
+    public void Quote_ConvertsTheAdminsMesghalPricesToPerGram()
+    {
+        var quote = QuoteMessage.Prepare(Gold, buyPricePerMesghal: 79_000_000m, sellPricePerMesghal: 80_000_000m);
+
+        Assert.Equal(
+            CurrenciesConstant.RoundOrderPrice(79_000_000m / CurrenciesConstant.GramsPerMesghal),
+            quote.BuyPricePerGram);
+        Assert.Equal(
+            CurrenciesConstant.RoundOrderPrice(80_000_000m / CurrenciesConstant.GramsPerMesghal),
+            quote.SellPricePerGram);
+    }
+
+    /// <summary>
+    /// The whole reason conversion and text are produced together: the numbers published
+    /// must be the numbers displayed. If they could drift, every customer would trade at a
+    /// price the shop owner never saw.
+    /// </summary>
+    [Fact]
+    public void Quote_PublishesExactlyThePricesItDisplays()
+    {
+        var quote = QuoteMessage.Prepare(Gold, 79_000_000m, 80_000_000m);
+
+        Assert.Contains(Fa(quote.BuyPricePerGram), quote.Text);
+        Assert.Contains(Fa(quote.SellPricePerGram), quote.Text);
+    }
+
+    /// <summary>Both units appear, so the admin can sanity-check the conversion themselves.</summary>
+    [Fact]
+    public void Quote_ShowsTheTypedMesghalPricesAlongsideThePerGramOnes()
+    {
+        var quote = QuoteMessage.Prepare(Gold, 79_000_000m, 80_000_000m);
+
+        Assert.Contains(Fa(79_000_000m), quote.Text);
+        Assert.Contains(Fa(80_000_000m), quote.Text);
+        Assert.DoesNotContain("{", quote.Text);
+    }
+
+    /// <summary>
+    /// Buy and sell must not be swapped. An inverted spread means the shop buys higher than
+    /// it sells, and a customer could cycle buy/sell indefinitely at the shop's expense.
+    /// The Orders service rejects that (QuoteTests), but the bot must not be the thing that
+    /// creates it.
+    /// </summary>
+    [Fact]
+    public void Quote_KeepsTheBuyPriceBelowTheSellPrice()
+    {
+        var quote = QuoteMessage.Prepare(Gold, buyPricePerMesghal: 79_000_000m, sellPricePerMesghal: 80_000_000m);
+
+        Assert.True(quote.BuyPricePerGram < quote.SellPricePerGram,
+            $"buy {quote.BuyPricePerGram} should be below sell {quote.SellPricePerGram}");
+    }
+}

--- a/src/Wallet/Wallet.Tests/OutboxBatchResilienceTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxBatchResilienceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,6 +8,7 @@ using Orders.Infrastructure;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Infrastructure.Clients;
+using Wallet.Tests.Fakes;
 
 namespace Wallet.Tests;
 
@@ -67,24 +68,10 @@ public class OutboxBatchResilienceTests : IDisposable
         }
     }
 
-    private sealed class AlwaysSettlesWalletClient : IWalletApiClient
+    private sealed class AlwaysSettlesWalletClient : StubWalletApiClient
     {
-        public Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade) =>
+        public override Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade) =>
             Task.FromResult((true, "settled"));
-
-        public Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message)> IncreaseBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, bool HasSufficientCreditAndBalanceBase, bool HasSufficientCreditAndBalanceQuote)>
-            ValidateCreditAndBalanceAsync(Guid userId, string symbol, decimal amount, decimal price) =>
-            throw new NotSupportedException();
     }
 
     private static string PayloadFor(Guid tradeId) =>

--- a/src/Wallet/Wallet.Tests/OutboxDueSelectionTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxDueSelectionTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,6 +8,7 @@ using Orders.Infrastructure;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Infrastructure.Clients;
+using Wallet.Tests.Fakes;
 
 namespace Wallet.Tests;
 
@@ -57,29 +58,15 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>هر تسویه را می‌پذیرد و شناسهٔ معامله‌ای که برایش صدا زده شده را نگه می‌دارد.</summary>
-    private sealed class RecordingWalletClient : IWalletApiClient
+    private sealed class RecordingWalletClient : StubWalletApiClient
     {
         public List<Guid> SettledTradeIds { get; } = [];
 
-        public Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade)
+        public override Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade)
         {
             SettledTradeIds.Add(trade.Id);
             return Task.FromResult((true, "settled"));
         }
-
-        public Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message)> IncreaseBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(Guid userId, string asset, decimal amount) =>
-            throw new NotSupportedException();
-        public Task<(bool Success, string Message, bool HasSufficientCreditAndBalanceBase, bool HasSufficientCreditAndBalanceQuote)>
-            ValidateCreditAndBalanceAsync(Guid userId, string symbol, decimal amount, decimal price) =>
-            throw new NotSupportedException();
     }
 
     private static string PayloadFor(Guid tradeId) =>


### PR DESCRIPTION
Closes #65. All four slices.

`BotHandler` was the only part of the money path with no automated coverage at all, and it could not be tested without changing its shape first. It now can be, and is.

**170 tests pass, up from 115.**

## Why it could not be tested, and what changed

| blocker | fix |
|---|---|
| `SendMessage` etc. are **extension methods** on `ITelegramBotClient` — static, unsubstitutable, so any test would open a real Telegram connection | `IBotMessenger`, an interface the project owns |
| conversation state was a `private readonly Dictionary` | injected `IConversationStore` |
| message text was built at the point of sending, inside private async methods | five pure builders returning strings |
| the constructor started a background thread and messaged every user | moved to `Start()`, called by the hosted service |
| the constructor took five concrete HTTP clients | the interfaces (two already existed; three extracted) |

## The test the issue asked for

```
"📈 بازار نقدی" → asset → 🛒 buy → "۲٫۵" → ✅ confirm
```

driven against the real handler, asserting:

- the customer is **never asked for a price** while a quote is published — the defining property of the dealer model (#48), which had no test
- a buying customer is quoted the admin's **sell** price, a selling customer the **buy** price
- `2.5` reaches the Orders service unchanged (the mesghal factor applies to prices, never quantities — applying it here would place an order 4.3× the size requested)
- the order acknowledgement arrives **before** the trade report
- the conversation is cleared on success, on failure, and on cancellation

**The no-quote case is the positive control.** Without a quote, a price *is* requested — so the dealer-mode assertion cannot pass merely because the flow silently did nothing.

## Two defects found by doing the refactor

**The DI wiring.** Moving `BotHandler` onto interfaces compiled cleanly and left every test green — but constructor parameters are matched against the container at **run time**. The bot would have died on startup with *"unable to resolve IOrderApiClient"*, and the only way to find out was to launch it. `AddBotHandler` now holds that wiring in one place and `BotHandlerRegistrationTests` exercises the same method `Program.cs` calls. Verified by deleting one registration: 3 tests fail.

**A placeholder with no argument.** `OutboxProcessorService`'s `SETTLEMENT STUCK` log had four placeholders and three arguments — the re-drive URL an operator is told to POST ended in a literal `{Id}` instead of the id. Exactly the defect family this issue documents, in the one log line that matters when money is stuck (#39).

Plus two fixed while rewiring: the conversation store is a `ConcurrentDictionary` (the old `Dictionary` was written from the message path and an hourly background loop at once), and conversations are keyed on the Telegram user id everywhere (one write used the chat id — equal in a private chat, wrong anywhere else).

## Builders

`TradeExecutedMessage`, `OrderConfirmationMessage`, `QuoteMessage`, plus the two remaining messages that contain a branch: `WalletBalanceMessage` (a negative balance is shown as a positive *debt*, since a bare minus reads as a malfunction) and `BestPricesMessage` (an empty side of the book says so rather than showing `۰ تومان`, which reads as a price of zero).

`QuoteMessage.Prepare` returns the per-gram prices **and** the confirmation text together, so "the price published is the price displayed" is true by construction — previously two calculations equal only by convention.

## Scope note

The `string.Format` calls still inline substitute a single error reason into a fixed sentence — no arithmetic, no unit, no branch. A builder for each would add indirection without pinning anything down, so the acceptance criterion is met for every message where something can actually go wrong, and deliberately not for those where nothing can.

`_botClient` survives at exactly one call site per handler: the chat-administrator lookup, which is not a messaging operation and is deliberately absent from `IBotMessenger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)