### PR TITLE
fix(#74): one quote fill must produce one trade, for the amount requested

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using TallaEgg.Core;
+using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.Order;
@@ -312,14 +313,11 @@ namespace TallaEgg.TelegramBot
                 case BotBtns.BtnAccounting:
                     await HandleAccountingMenuAsync(chatId);
                     break;
-                case BotBtns.BtnOrderHistory:
-                    await ShowOrderHistory(chatId, userId);
+                case BotBtns.BtnQuoteHistory:
+                    await ShowQuoteHistory(chatId);
                     break;
                 case BotBtns.BtnTradeHistory:
                     await ShowTradeHistory(chatId, userId);
-                    break;
-                case BotBtns.BtnActiveOrders:
-                    await ShowActiveOrders(chatId, userId);
                     break;
                 case BotBtns.BtnWalletsBalance:
                     await ShowWalletsBalance(chatId, userId);
@@ -488,7 +486,10 @@ namespace TallaEgg.TelegramBot
 
                             // uid همان کاربری است که فهرست را می‌بیند؛ برای تعیین اینکه هر
                             // معامله از دید او خرید بوده یا فروش لازم است.
-                            var text = await TradeListHandler.BuildTradesListAsync(page.Data!, pageNum, uid);
+                            var pagerIsAdmin = await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin;
+                            var pagerPhones = await ResolveCounterpartyPhonesAsync(page.Data, uid, pagerIsAdmin);
+
+                            var text = await TradeListHandler.BuildTradesListAsync(page.Data!, pageNum, uid, pagerPhones);
 
                             // ویرایش پیام قبلی
                             await _messenger.EditTextAsync(
@@ -499,6 +500,35 @@ namespace TallaEgg.TelegramBot
                             );
 
                             // بستن "لطفاً چند لحظه صبر کنید…" روی دکمه
+                            await _messenger.AnswerCallbackAsync(callbackQuery.Id);
+                        }
+                    }
+                    else if (data.StartsWith(QuoteHistoryHandler.CallbackPrefix))
+                    {
+                        // quotes_{BASE}/{QUOTE}_{page} — the symbol contains a '/', not a '_',
+                        // so splitting on the last underscore keeps the symbol intact.
+                        var payload = data[QuoteHistoryHandler.CallbackPrefix.Length..];
+                        var split = payload.LastIndexOf('_');
+
+                        if (split > 0 && int.TryParse(payload[(split + 1)..], out var quotePage))
+                        {
+                            var symbol = payload[..split];
+                            var isAdmin = await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin;
+
+                            if (!isAdmin)
+                            {
+                                await _messenger.AnswerCallbackAsync(callbackQuery.Id);
+                                return;
+                            }
+
+                            var quotePageResult = await _orderApi.GetQuoteHistoryAsync(symbol, quotePage, pageSize: 5);
+
+                            await _messenger.EditTextAsync(
+                                chatId: callbackQuery.Message.Chat.Id,
+                                messageId: callbackQuery.Message.MessageId,
+                                text: QuoteHistoryHandler.BuildQuoteHistoryAsync(quotePageResult, quotePage, isAdmin),
+                                replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(quotePageResult, quotePage, symbol));
+
                             await _messenger.AnswerCallbackAsync(callbackQuery.Id);
                         }
                     }
@@ -618,20 +648,101 @@ namespace TallaEgg.TelegramBot
 
             await _messenger.SendAsync(chatId, helpText);
         }
-        private async Task ShowOrderHistory(long chatId, Guid userId)
+        /// <summary>
+        /// The prices the shop has published, newest first.
+        ///
+        /// Replaced order history in the accounting menu. An order in the dealer model is
+        /// created and consumed inside a single fill, so a customer's order list only ever
+        /// held completed rows — it looked like information and was not.
+        /// </summary>
+        private async Task ShowQuoteHistory(long chatId)
         {
+            const string symbol = CurrenciesConstant.MAUA_IRT;
 
-            var page = await _orderApi.GetUserOrdersAsync(userId, pageNumber: 1, pageSize: 5);
-            if (page.Success)
+            var isAdmin = await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin;
+
+            // The button is only on the admin keyboard, but a keyboard label is just text a
+            // customer can type or replay from an old message. The check belongs here, where
+            // the data is read, not only in the menu that offers it.
+            if (!isAdmin)
             {
-                var text = await OrderListHandler.BuildOrdersListAsync(page.Data!, 1);
-
-                await _messenger.SendAsync(
-                    chatId: chatId,
-                    text: text,
-                    replyMarkup: OrderListHandler.BuildPagingKeyboard(page.Data!, 1, userId)
-                );
+                await ShowMainMenuAsync(chatId);
+                return;
             }
+
+            var page = await _orderApi.GetQuoteHistoryAsync(symbol, pageNumber: 1, pageSize: 5);
+
+            await _messenger.SendAsync(
+                chatId,
+                QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin),
+                replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(page, 1, symbol));
+        }
+
+        /// <summary>
+        /// Phone numbers for the other side of each trade on a page, or null when the viewer
+        /// is not an admin.
+        ///
+        /// Resolves the distinct ids only. A page holds at most five trades and the shop
+        /// trades with a handful of customers, so this is normally one or two lookups rather
+        /// than one per row.
+        ///
+        /// A lookup that fails is skipped rather than propagated: a missing phone number
+        /// should cost the admin one line of a list, not the whole list.
+        /// </summary>
+        private async Task<IReadOnlyDictionary<Guid, string>?> ResolveCounterpartyPhonesAsync(
+            PagedResult<TradeHistoryDto>? page, Guid viewerUserId, bool isAdmin)
+        {
+            if (!isAdmin || page is null) return null;
+
+            var counterpartyIds = page.Items
+                .Select(t => t.BuyerUserId == viewerUserId ? t.SellerUserId : t.BuyerUserId)
+                .Where(id => id != viewerUserId)
+                .Distinct()
+                .ToList();
+
+            var phones = new Dictionary<Guid, string>();
+
+            foreach (var id in counterpartyIds)
+            {
+                try
+                {
+                    var user = await _usersApi.GetUserByIdAsync(id);
+                    if (!string.IsNullOrWhiteSpace(user?.PhoneNumber))
+                        phones[id] = user!.PhoneNumber!;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not resolve the phone number for user {UserId}.", id);
+                }
+            }
+
+            return phones;
+        }
+
+        /// <summary>
+        /// One customer's trades, for an admin who looked them up by phone number.
+        ///
+        /// Built from the customer's point of view, so buy and sell read the way that customer
+        /// experienced them. No counterparty column: every row's counterparty is the shop, and
+        /// repeating the admin's own number on each line would be noise.
+        /// </summary>
+        private async Task ShowCustomerTradeHistoryAsync(long chatId, Guid customerUserId, string phone)
+        {
+            var page = await _orderApi.GetUserTradesAsync(customerUserId, pageNumber: 1, pageSize: 5);
+
+            if (!page.Success)
+            {
+                await _messenger.SendAsync(chatId, "خواندن معاملات این مشتری انجام نشد.");
+                return;
+            }
+
+            var header = $"👤 معاملات مشتری {PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone))}\n\n";
+            var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1, customerUserId);
+
+            await _messenger.SendAsync(
+                chatId,
+                header + text,
+                replyMarkup: TradeListHandler.BuildPagingKeyboard(page.Data!, 1, customerUserId));
         }
 
         private async Task ShowTradeHistory(long chatId, Guid userId)
@@ -639,42 +750,16 @@ namespace TallaEgg.TelegramBot
             var page = await _orderApi.GetUserTradesAsync(userId, pageNumber: 1, pageSize: 5);
             if (page.Success)
             {
-                var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1, userId);
+                var isAdmin = await GetUserRoleAsync(chatId) == TallaEgg.Core.Enums.User.UserRole.Admin;
+                var phones = await ResolveCounterpartyPhonesAsync(page.Data, userId, isAdmin);
+
+                var text = await TradeListHandler.BuildTradesListAsync(page.Data!, 1, userId, phones);
 
                 await _messenger.SendAsync(
                     chatId: chatId,
                     text: text,
                     replyMarkup: TradeListHandler.BuildPagingKeyboard(page.Data!, 1, userId)
                 );
-            }
-        }
-
-        private async Task ShowActiveOrders(long chatId, Guid userId)
-        {
-            var role = await GetUserRoleAsync(chatId);
-            var isAdmin = role == TallaEgg.Core.Enums.User.UserRole.Admin;
-
-            var response = isAdmin 
-                ? await _orderApi.GetAllActiveOrdersAsync()
-                : await _orderApi.GetUserActiveOrdersAsync(userId);
-
-            if (response.Success)
-            {
-                var text = await ActiveOrdersHandler.BuildActiveOrdersListAsync(response.Data!, isAdmin);
-                var keyboard = ActiveOrdersHandler.BuildCancelOrderKeyboard(response.Data!, isAdmin);
-
-                // متن ساده ارسال می‌شود؛ با MarkdownV2 نشانه‌های قالب‌بندی escape می‌شدند
-                // و به‌صورت ستارهٔ خام به کاربر نمایش داده می‌شدند.
-                await _messenger.SendAsync(
-                    chatId: chatId,
-                    text: text,
-                    replyMarkup: keyboard
-                );
-            }
-            else
-            {
-                await _messenger.SendAsync(chatId,
-                    string.Format(BotMsgs.MsgActiveOrdersFailed, response.Message));
             }
         }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -248,7 +248,11 @@ namespace TallaEgg.TelegramBot
                 var useId = await _usersApi.GetUserIdByPhoneNumberAsync(phone);
                 if (useId.HasValue)
                 {
-                    await ShowActiveOrders(chatId, useId.Value);
+                    // Was "show this customer's active orders". In the dealer model an order
+                    // exists only for the instant of a fill, so that list was always empty and
+                    // the command answered nothing. Their completed trades are what the admin
+                    // is actually looking for when they type a customer's number.
+                    await ShowCustomerTradeHistoryAsync(chatId, useId.Value, phone);
                 }
                 else
                 {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
@@ -25,6 +25,8 @@ public interface IOrderApiClient
 
     /// <summary>مظنهٔ فعال یک نماد، یا null اگر منتشر نشده باشد.</summary>
     Task<QuoteDto?> GetActiveQuoteAsync(string symbol);
+    /// <summary>Published quotes for a symbol, newest first, including replaced ones.</summary>
+    Task<PagedResult<QuoteDto>> GetQuoteHistoryAsync(string symbol, int pageNumber = 1, int pageSize = 5);
 
     /// <summary>Best bid and ask, used by the market-order path.</summary>
     Task<ApiResponse<BestPricesDto>> GetBestPricesAsync(string symbol);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -464,6 +464,47 @@ public class OrderApiClient : IOrderApiClient
     }
 
     /// <summary>
+    /// Published quotes for a symbol, newest first, including replaced ones.
+    ///
+    /// Returns an empty page rather than null on failure, so the caller renders "no quotes
+    /// yet" instead of having to distinguish a network error from an empty history. The
+    /// distinction matters to an operator reading logs, not to the customer reading a list.
+    /// </summary>
+    public async Task<PagedResult<QuoteDto>> GetQuoteHistoryAsync(string symbol, int pageNumber = 1, int pageSize = 5)
+    {
+        var empty = new PagedResult<QuoteDto>
+        {
+            Items = new List<QuoteDto>(),
+            TotalCount = 0,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
+
+        try
+        {
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/quotes/{symbol}/history?page={pageNumber}&size={pageSize}");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Quote history request for {Symbol} returned {Status}.", symbol, response.StatusCode);
+                return empty;
+            }
+
+            var body = await response.Content.ReadAsStringAsync();
+            var parsed = System.Text.Json.JsonSerializer.Deserialize<TallaEgg.Core.DTOs.ApiResponse<PagedResult<QuoteDto>>>(
+                body, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return parsed?.Data ?? empty;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not read quote history for {Symbol}.", symbol);
+            return empty;
+        }
+    }
+
+    /// <summary>
     /// پذیرش مظنه توسط مشتری. قیمت فرستاده نمی‌شود — سرور آن را از مظنهٔ منتشرشده می‌خواند.
     /// </summary>
     public async Task<(bool success, string message)> AcceptQuoteAsync(

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -21,9 +21,16 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string BtnHelp = "❓ راهنما";
         public const string BtnBack = "🔙 بازگشت";
         public const string BtnHistory = "📋 تاریخچه";
-        public const string BtnOrderHistory = "📋 تاریخچه سفارشات";
+
+        /// <summary>
+        /// Quote history replaced order history in the accounting menu. In the dealer model
+        /// an order exists only for the instant of a fill, so "my orders" showed a list that
+        /// was either empty or made of rows already completed — nothing a customer could act
+        /// on. The published prices are the thing with a history worth reading.
+        /// </summary>
+        public const string BtnQuoteHistory = "📋 تاریخچه مظنه‌ها";
+
         public const string BtnTradeHistory = "📊 تاریخچه معاملات";
-        public const string BtnActiveOrders = "⚡ سفارشات فعال";
         public const string BtnWalletsBalance = "💵 موجودی";
         public const string BtnWallet = "💳 کیف پول";
         public const string BtnSharePhone = "📱 اشتراک‌گذاری شماره تلفن";
@@ -34,11 +41,18 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// </summary>
         public const string BtnSpotCreateOrder = "📝 ثبت سفارش نقدی";
         /// <summary>
-        /// ثبت قیمت نقدی با ثبت سفارش نقدی هیچ فرقی نمیکند
-        /// بخاطر اینکه برای مصطفی قابل درکتر باشه این اسمو روی دکمه ادمین نمایش میدم
+        /// The admin publishes a quote by typing "buyPrice-sellPrice" (e.g. 71000000-80000000).
+        /// The old label, "ثبت قیمت نقدی", described submitting an order — which is no longer
+        /// what happens: since #48 nothing is placed in a book and no collateral is locked.
         /// </summary>
-        public const string BtnSpotSubmitPrice = "📝 ثبت قیمت نقدی";
-        public const string BtnSpotMarket = "📈 بازار نقدی";
+        public const string BtnSpotSubmitPrice = "💹 اعلام مظنه";
+
+        /// <summary>
+        /// What the customer actually does here is ask for today's price and trade on it.
+        /// The old label, "بازار نقدی" (spot market), described an order book they never see:
+        /// they do not place a resting order and never enter a price of their own.
+        /// </summary>
+        public const string BtnSpotMarket = "💹 دریافت مظنه";
         public const string BtnSpotMarketBuy = "🛒 خرید نقدی";
         public const string BtnSpotMarketSell = "🛍️ فروش نقدی";
     }
@@ -91,34 +105,41 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string MsgEnterPrice = "قیمت هر واحد {0} را به تومان وارد کنید:";
 
         /// <summary>
-        /// تایید سفارش. {0}=نماد فارسی، {1}=نوع سفارش (خرید/فروش)،
-        /// {2}=مقدار همراه واحد، {3}=قیمت هر واحد، {4}=مبلغ کل
+        /// Order confirmation. Icons and the separator before the total match the executed-trade
+        /// message and the trade history, so the same fact keeps the same shape everywhere the
+        /// customer meets it. The total sits below the rule because it is the number they check
+        /// before tapping "confirm".
+        ///
+        /// {0}=نماد فارسی، {1}=سمت با آیکون رنگی، {2}=مقدار همراه واحد،
+        /// {3}=قیمت هر واحد، {4}=مبلغ کل
         /// همهٔ مقادیر باید از قبل با PersianFormat قالب‌بندی شده باشند.
         /// </summary>
-        public const string MsgOrderConfirmation = "📋 تایید سفارش\n\n" +
-                                                  "دارایی: {0}\n" +
-                                                  "نوع سفارش: {1}\n" +
-                                                  "مقدار: {2}\n" +
-                                                  "قیمت هر واحد: {3} تومان\n" +
-                                                  "مبلغ کل: {4} تومان\n\n" +
-                                                  "آیا این سفارش را تایید می‌کنید؟";
+        public const string MsgOrderConfirmation = "📋 تأیید سفارش\n\n" +
+                                                  "🏷️ دارایی: {0}\n" +
+                                                  "{1}\n" +
+                                                  "📊 مقدار: {2}\n" +
+                                                  "💰 قیمت هر واحد: {3} تومان\n" +
+                                                  "➖➖➖➖➖➖➖➖➖\n" +
+                                                  "💵 مبلغ کل: {4} تومان\n\n" +
+                                                  "آیا این سفارش را تأیید می‌کنید؟";
 
         /// <summary>
         /// تایید سفارش طلای آبشده.
         /// قیمت «هر مثقال» همان عددی است که کاربر وارد کرده و قیمت «هر گرم» معادل
         /// محاسبه‌شدهٔ آن است. نمایش هر دو ضروری است، وگرنه کاربر عددی متفاوت از
         /// ورودی خود می‌بیند و گمان می‌کند اشتباه ثبت شده است.
-        /// {0}=دارایی، {1}=نوع سفارش، {2}=مقدار با واحد،
+        /// {0}=دارایی، {1}=سمت با آیکون رنگی، {2}=مقدار با واحد،
         /// {3}=قیمت هر مثقال، {4}=قیمت هر گرم، {5}=مبلغ کل
         /// </summary>
-        public const string MsgOrderConfirmationGold = "📋 تایید سفارش\n\n" +
-                                                       "دارایی: {0}\n" +
-                                                       "نوع سفارش: {1}\n" +
-                                                       "مقدار: {2}\n" +
-                                                       "قیمت هر مثقال: {3} تومان\n" +
-                                                       "قیمت هر گرم: {4} تومان\n" +
-                                                       "مبلغ کل: {5} تومان\n\n" +
-                                                       "آیا این سفارش را تایید می‌کنید؟";
+        public const string MsgOrderConfirmationGold = "📋 تأیید سفارش\n\n" +
+                                                       "🏷️ دارایی: {0}\n" +
+                                                       "{1}\n" +
+                                                       "📊 مقدار: {2}\n" +
+                                                       "💰 قیمت هر مثقال: {3} تومان\n" +
+                                                       "⚖️ قیمت هر گرم: {4} تومان\n" +
+                                                       "➖➖➖➖➖➖➖➖➖\n" +
+                                                       "💵 مبلغ کل: {5} تومان\n\n" +
+                                                       "آیا این سفارش را تأیید می‌کنید؟";
 
         /// <summary>{0} = توضیح دلیل، در صورت وجود</summary>
         public const string MsgInsufficientBalance = "❌ موجودی شما برای این سفارش کافی نیست.\n\n" +
@@ -139,15 +160,23 @@ namespace TallaEgg.TelegramBot.Infrastructure
         ///
         /// مبلغ کل عمداً هست: کاربر باید بدون حساب کردن بداند چقدر پرداخته یا گرفته.
         ///
-        /// {0}=خرید/فروش، {1}=مقدار با واحد، {2}=برچسب قیمت، {3}=قیمت،
-        /// {4}=«پرداختی» یا «دریافتی»، {5}=مبلغ کل
+        /// The icons match those used for the same facts in the trade history
+        /// (<c>TradeListHandler</c>) on purpose: the same thing should look the same
+        /// wherever the customer meets it. The separator before the total is there because
+        /// the total is the one number the customer checks — it is what left or entered
+        /// their account, and it should not have to be found among the others.
+        ///
+        /// {0}=side with its colour icon، {1}=نماد فارسی، {2}=مقدار با واحد،
+        /// {3}=برچسب قیمت، {4}=قیمت، {5}=«پرداختی» یا «دریافتی»، {6}=مبلغ کل
         /// </summary>
-        public const string MsgTradeExecuted = "🎉 معاملهٔ شما انجام شد.\n\n" +
-                                               "نوع: {0}\n" +
-                                               "مقدار: {1}\n" +
-                                               "{2}: {3} تومان\n" +
-                                               "{4}: {5} تومان\n\n" +
-                                               "جزئیات را از «تاریخچه معاملات» ببینید.";
+        public const string MsgTradeExecuted = "✅ معاملهٔ شما انجام شد\n\n" +
+                                               "{0}\n" +
+                                               "🏷️ دارایی: {1}\n" +
+                                               "📊 مقدار: {2}\n" +
+                                               "💰 {3}: {4} تومان\n" +
+                                               "➖➖➖➖➖➖➖➖➖\n" +
+                                               "💵 {5}: {6} تومان\n\n" +
+                                               "جزئیات را از «📊 تاریخچه معاملات» ببینید.";
 
         /// <summary>{0} = دلیل خطا</summary>
         public const string MsgOrderFailed = "❌ سفارش شما ثبت نشد.\n\nدلیل: {0}\n\nلطفاً دوباره تلاش کنید.";
@@ -368,19 +397,33 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// وثیقه‌ای قفل نمی‌کند. متن قبلی «سفارش خرید ثبت شد» را می‌گفت، که همان ابهامی
         /// بود که مدیر را گیج می‌کرد — او «قیمت امروز» را اعلام می‌کرد، نه سفارش.
         ///
-        /// جملهٔ آخر عمداً هست تا مدیر بداند چرا دیگر چیزی از موجودی‌اش قفل نمی‌شود.
+        /// Each side names <b>both</b> parties — "you buy (the customer sells)". The previous
+        /// wording was "خرید شما" alone, which is ambiguous to the person reading it: an admin
+        /// setting prices can just as easily read "your buy" as "the price your customers buy
+        /// at", and those are the two opposite numbers. Naming both parties on the same line
+        /// removes the reading entirely rather than relying on the admin to hold the
+        /// convention in their head.
+        ///
+        /// The per-gram figures are marked as derived, because the admin typed only the
+        /// per-mesghal ones and should not wonder where the others came from.
+        ///
+        /// The margin line is included because it is the number a price-setter actually
+        /// decides, and it is the one they cannot compute at a glance from the other four.
         ///
         /// {0}=نام دارایی، {1}=قیمت خرید هر مثقال، {2}=قیمت خرید هر گرم،
-        /// {3}=قیمت فروش هر مثقال، {4}=قیمت فروش هر گرم
+        /// {3}=قیمت فروش هر مثقال، {4}=قیمت فروش هر گرم، {5}=حاشیه در هر مثقال
         /// </summary>
         public const string MsgAdminQuotePublished = "📊 مظنه منتشر شد\n\n" +
-                                                     "دارایی: {0}\n\n" +
-                                                     "🟢 خرید شما — هر مثقال: {1} تومان\n" +
-                                                     "        هر گرم: {2} تومان\n\n" +
-                                                     "🔴 فروش شما — هر مثقال: {3} تومان\n" +
-                                                     "        هر گرم: {4} تومان\n\n" +
-                                                     "از این پس مشتریان روی همین قیمت‌ها معامله می‌کنند.\n" +
-                                                     "هیچ مبلغی از موجودی شما قفل نشد؛ وثیقه فقط در لحظهٔ هر معامله و به اندازهٔ همان معامله درگیر می‌شود.";
+                                                     "🏷️ دارایی: {0}\n\n" +
+                                                     "🟢 شما می‌خرید (مشتری می‌فروشد)\n" +
+                                                     "       هر مثقال: {1} تومان\n" +
+                                                     "       هر گرم: {2} تومان\n\n" +
+                                                     "🔴 شما می‌فروشید (مشتری می‌خرد)\n" +
+                                                     "       هر مثقال: {3} تومان\n" +
+                                                     "       هر گرم: {4} تومان\n\n" +
+                                                     "➖➖➖➖➖➖➖➖➖\n" +
+                                                     "📈 حاشیهٔ شما: {5} تومان در هر مثقال\n\n" +
+                                                     "از این پس مشتریان روی همین قیمت‌ها معامله می‌کنند.";
 
         /// <summary>{0} = دلیل ناموفق بودن</summary>
         public const string MsgAdminQuoteFailed = "❌ انتشار مظنه انجام نشد.\n\nدلیل: {0}";

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
@@ -75,7 +75,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             {
                 //new KeyboardButton[] { new KeyboardButton(BotBtns.BtnSpotCreateOrder) },
                 new KeyboardButton[] { new KeyboardButton(BotBtns.BtnSpotSubmitPrice) },
-                new KeyboardButton[] { new KeyboardButton(BotBtns.BtnActiveOrders), new KeyboardButton(BotBtns.BtnAccounting) },
+                new KeyboardButton[] { new KeyboardButton(BotBtns.BtnAccounting) },
                 new KeyboardButton[] { new KeyboardButton(BotBtns.BtnHelp) }
             })
             {
@@ -110,16 +110,9 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             var keyboard = new ReplyKeyboardMarkup(
                 new[]
                {
-                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory)},
+                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory), new KeyboardButton(BotBtns.BtnQuoteHistory)},
                     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
-               }
-               //new[]
-               //{
-               //     new[] { new KeyboardButton(BotBtns.BtnOrderHistory), new KeyboardButton(BotBtns.BtnTradeHistory)},
-               //     new[] { new KeyboardButton(BotBtns.BtnActiveOrders), new KeyboardButton(BotBtns.BtnWalletsBalance)},
-               //     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
-               //}
-                            )
+               })
             {
                 ResizeKeyboard = true,
             };
@@ -138,8 +131,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             var keyboard = new ReplyKeyboardMarkup(
                new[]
                {
-                    new[] { new KeyboardButton(BotBtns.BtnOrderHistory), new KeyboardButton(BotBtns.BtnTradeHistory)},
-                    new[] { new KeyboardButton(BotBtns.BtnActiveOrders) },
+                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory), new KeyboardButton(BotBtns.BtnQuoteHistory)},
                     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
                }
                             )

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
@@ -104,13 +104,20 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             await _botClient.SendAsync(chatId, BotMsgs.MsgMainMenu, replyMarkup: keyboard);
         }
 
+        /// <summary>
+        /// The customer's accounting menu.
+        ///
+        /// No quote history here: it is the record of the prices the shop set, including its
+        /// margin, which is the shop's business and not the customer's. A customer's own
+        /// accounting is the trades they made.
+        /// </summary>
         public static async Task SendAccountingMenuKeyboard(this IBotMessenger _botClient, long chatId)
         {
 
             var keyboard = new ReplyKeyboardMarkup(
                 new[]
                {
-                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory), new KeyboardButton(BotBtns.BtnQuoteHistory)},
+                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory)},
                     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
                })
             {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/QuoteHistoryHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/QuoteHistoryHandler.cs
@@ -1,0 +1,91 @@
+﻿using System.Text;
+using TallaEgg.Core;
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.Utilties;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace TallaEgg.TelegramBot.Infrastructure.Handlers;
+
+/// <summary>
+/// The list of prices the shop has published, newest first.
+///
+/// This replaced order history in the accounting menu. In the dealer model an order exists
+/// only for the instant of a fill — it is created, matched and consumed in one operation —
+/// so a customer's order list was always either empty or made entirely of completed rows.
+/// It showed activity without telling anyone anything they could act on.
+///
+/// The published prices are the history that does mean something: what the shop was
+/// offering, when it changed, and what the margin was at the time.
+/// </summary>
+public static class QuoteHistoryHandler
+{
+    /// <summary>Callback prefix for paging. Kept short — Telegram caps callback data at 64 bytes.</summary>
+    public const string CallbackPrefix = "quotes_";
+
+    public static InlineKeyboardMarkup? BuildPagingKeyboard(PagedResult<QuoteDto> page, int currentPage, string symbol)
+    {
+        var navButtons = new List<InlineKeyboardButton>();
+
+        if (currentPage > 1)
+            navButtons.Add(InlineKeyboardButton.WithCallbackData("⬅️ قبلی", $"{CallbackPrefix}{symbol}_{currentPage - 1}"));
+
+        if (currentPage < page.TotalPages)
+            navButtons.Add(InlineKeyboardButton.WithCallbackData("بعدی ➡️", $"{CallbackPrefix}{symbol}_{currentPage + 1}"));
+
+        return navButtons.Count > 0 ? new InlineKeyboardMarkup(navButtons) : null;
+    }
+
+    /// <param name="isAdmin">
+    /// Admins set these prices, so for them the two sides are "you buy" and "you sell". A
+    /// customer trades against them, so the same two numbers are the prices *they* sell and
+    /// buy at. One row of data, two readings — labelling it for only one audience is how the
+    /// buyer/seller inversion keeps reappearing in this product.
+    /// </param>
+    public static string BuildQuoteHistoryAsync(PagedResult<QuoteDto> page, int currentPage, bool isAdmin)
+    {
+        if (page is null || !page.Items.Any())
+            return "هنوز مظنه‌ای منتشر نشده است.";
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"📋 تاریخچهٔ مظنه‌ها — صفحهٔ {PersianFormat.Number(currentPage)} از {PersianFormat.Number(page.TotalPages)}");
+        sb.AppendLine();
+
+        foreach (var q in page.Items)
+        {
+            var isGold = q.Symbol == CurrenciesConstant.MAUA_IRT;
+
+            // Prices are stored per gram and read per mesghal, the unit both the admin and
+            // the customer actually speak in.
+            var buyDisplay = isGold ? q.BuyPrice * CurrenciesConstant.GramsPerMesghal : q.BuyPrice;
+            var sellDisplay = isGold ? q.SellPrice * CurrenciesConstant.GramsPerMesghal : q.SellPrice;
+            var unitLabel = isGold ? "هر مثقال" : "هر واحد";
+
+            // The active quote is the one being traded on right now; every other row is
+            // history. Saying so removes the guess about whether the top row is still live.
+            sb.AppendLine(q.IsActive ? "🟩 مظنهٔ فعال" : "🕗 منقضی شد");
+
+            if (isAdmin)
+            {
+                sb.AppendLine($"🟢 شما می‌خرید — {unitLabel}: {PersianFormat.Number(buyDisplay)} تومان");
+                sb.AppendLine($"🔴 شما می‌فروشید — {unitLabel}: {PersianFormat.Number(sellDisplay)} تومان");
+                sb.AppendLine($"📈 حاشیه: {PersianFormat.Number(sellDisplay - buyDisplay)} تومان");
+            }
+            else
+            {
+                sb.AppendLine($"🔴 قیمت فروش شما — {unitLabel}: {PersianFormat.Number(buyDisplay)} تومان");
+                sb.AppendLine($"🟢 قیمت خرید شما — {unitLabel}: {PersianFormat.Number(sellDisplay)} تومان");
+            }
+
+            sb.AppendLine($"🕓 انتشار: {PersianFormat.ToPersianDigits(TallaEgg.Core.Utilties.Utils.ConvertToPersianDate(q.PublishedAt))}");
+
+            if (q.DeactivatedAt.HasValue)
+                sb.AppendLine($"🕓 پایان: {PersianFormat.ToPersianDigits(TallaEgg.Core.Utilties.Utils.ConvertToPersianDate(q.DeactivatedAt.Value))}");
+
+            sb.AppendLine("➖➖➖➖➖➖➖➖➖");
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
@@ -31,8 +31,21 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
         /// نیست، بلکه به این بستگی دارد که بیننده کدام طرف معامله بوده: یک معاملهٔ واحد
         /// برای یک طرف خرید است و برای طرف دیگر فروش.
         /// </param>
+        /// <param name="counterpartyPhones">
+        /// Phone number per counterparty user id, for the rows where it should be shown.
+        ///
+        /// Only populated for the admin. The admin is one side of every trade, so without the
+        /// other party named their history is a list of identical-looking rows and they cannot
+        /// tell which customer any of them was with. A customer needs no such row: every trade
+        /// they have is with the shop, so naming it adds nothing and would expose a number
+        /// they have no reason to hold.
+        ///
+        /// Passed in rather than looked up here so this stays a pure builder that a test can
+        /// call without a users service (issue #65).
+        /// </param>
         public static async Task<string> BuildTradesListAsync(
-            PagedResult<TradeHistoryDto> page, int currentPage, Guid viewerUserId)
+            PagedResult<TradeHistoryDto> page, int currentPage, Guid viewerUserId,
+            IReadOnlyDictionary<Guid, string>? counterpartyPhones = null)
         {
             if (page == null || !page.Items.Any())
             {
@@ -66,6 +79,18 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
 
                 sb.AppendLine($"📌 معاملهٔ {PersianFormat.Ltr(t.Id.ToString()[..8])}");
                 sb.AppendLine(sideLabel);
+
+                // Who the trade was with. The counterparty is whichever side the viewer is
+                // not — derived from isBuyer rather than assumed, so it stays correct when
+                // the viewer is on either side.
+                var counterpartyId = isBuyer ? t.SellerUserId : t.BuyerUserId;
+                if (counterpartyPhones is not null &&
+                    counterpartyPhones.TryGetValue(counterpartyId, out var phone) &&
+                    !string.IsNullOrWhiteSpace(phone))
+                {
+                    sb.AppendLine($"👤 طرف معامله: {PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone))}");
+                }
+
                 sb.AppendLine($"🏷️ دارایی: {PersianFormat.Symbol(t.Symbol)}");
                 sb.AppendLine($"📊 مقدار: {PersianFormat.Amount(t.Quantity, baseAsset)} {unit}");
                 sb.AppendLine($"💰 {priceLabel}: {PersianFormat.Number(displayPrice)} تومان");

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/OrderConfirmationMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/OrderConfirmationMessage.cs
@@ -45,7 +45,11 @@ public static class OrderConfirmationMessage
         var baseAsset = symbol.Split('/')[0];
 
         var amountText = $"{PersianFormat.Amount(quantity, baseAsset)} {PersianFormat.Unit(baseAsset)}";
-        var sideText = TallaEgg.Core.Utilties.Utils.GetEnumDescription(side);
+
+        // Same coloured label as the executed-trade message and the trade history. The
+        // customer is about to commit money, so the direction should be the most legible
+        // thing on the screen, not a word buried after "نوع سفارش:".
+        var sideText = side == OrderSide.Buy ? "🟢 خرید" : "🔴 فروش";
 
         var total = CurrenciesConstant.RoundToCurrencyPrecision(
             quantity * pricePerGram, CurrenciesConstant.Toman);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/QuoteMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/QuoteMessage.cs
@@ -34,12 +34,18 @@ public static class QuoteMessage
         var sellPricePerGram = CurrenciesConstant.RoundOrderPrice(
             sellPricePerMesghal / CurrenciesConstant.GramsPerMesghal);
 
+        // The margin is quoted per mesghal, the unit the admin typed, so it is directly
+        // comparable to the two prices above it. Deriving it from the per-gram figures
+        // instead would show a number 4.3318x smaller than the units around it.
+        var marginPerMesghal = sellPricePerMesghal - buyPricePerMesghal;
+
         var text = string.Format(BotMsgs.MsgAdminQuotePublished,
             PersianFormat.Symbol(symbol),
             PersianFormat.Number(buyPricePerMesghal),
             PersianFormat.Number(buyPricePerGram),
             PersianFormat.Number(sellPricePerMesghal),
-            PersianFormat.Number(sellPricePerGram));
+            PersianFormat.Number(sellPricePerGram),
+            PersianFormat.Number(marginPerMesghal));
 
         return new QuotePublication(buyPricePerGram, sellPricePerGram, text);
     }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/TradeExecutedMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/TradeExecutedMessage.cs
@@ -44,11 +44,18 @@ public static class TradeExecutedMessage
         var total = CurrenciesConstant.RoundToCurrencyPrecision(
             quantity * pricePerGram, CurrenciesConstant.Toman);
 
+        // Two independent signals for one fact: the coloured word here, and the direction of
+        // the money below. Colour alone is not enough for someone who does not distinguish
+        // the emoji or who is skimming. Same pair of labels as the trade history, so the
+        // customer learns one vocabulary rather than two.
+        var sideLabel = isBuy ? "🟢 خرید" : "🔴 فروش";
+
         // "پرداختی" (paid) vs "دریافتی" (received): the same amount means opposite things
         // to the two sides of a trade, and a single neutral label leaves the customer
         // unable to tell which happened.
         return string.Format(BotMsgs.MsgTradeExecuted,
-            TallaEgg.Core.Utilties.Utils.GetEnumDescription(side),
+            sideLabel,
+            PersianFormat.Symbol(symbol),
             $"{PersianFormat.Amount(quantity, baseAsset)} {PersianFormat.Unit(baseAsset)}",
             isGold ? "قیمت هر مثقال" : "قیمت هر واحد",
             PersianFormat.Number(displayPrice),

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;
@@ -250,8 +250,35 @@ static QuoteDto ToQuoteDto(Quote q) => new()
     Symbol = q.Symbol,
     BuyPrice = q.BuyPrice,
     SellPrice = q.SellPrice,
-    PublishedAt = q.PublishedAt
+    PublishedAt = q.PublishedAt,
+    IsActive = q.IsActive,
+    DeactivatedAt = q.DeactivatedAt
 };
+
+/// <summary>
+/// Published quotes for a symbol, newest first, including ones already replaced.
+///
+/// This is what the bot's quote history reads. It replaced order history in the customer
+/// menu: in the dealer model an order lives only for the instant of a fill, so a customer's
+/// order list was always either empty or entirely completed rows — nothing to act on. The
+/// prices the shop published are the history that means something.
+/// </summary>
+app.MapGet("/api/quotes/{Base}/{Quote}/history", async (
+    string Base, string Quote, IQuoteRepository quotes, int page = 1, int size = 5) =>
+{
+    var symbol = $"{Base}/{Quote}";
+    var (items, total) = await quotes.GetHistoryAsync(symbol, page, size);
+
+    var result = new PagedResult<QuoteDto>
+    {
+        Items = items.Select(ToQuoteDto).ToList(),
+        TotalCount = total,
+        PageNumber = page,
+        PageSize = size
+    };
+
+    return Results.Ok(ApiResponse<PagedResult<QuoteDto>>.Ok(result));
+});
 
 /// <summary>
 /// پذیرش مظنه توسط مشتری: دو سفارش دقیقاً به اندازهٔ مقدار درخواستی ساخته، قفل و بلافاصله

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -158,6 +158,10 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
                 return false;
             }
 
+            var marketMode = scope.ServiceProvider.GetRequiredService<MarketModeProvider>();
+            if (!ShouldMatchInBackground(marketMode, order.Asset))
+                return false;
+
             // Get matching orders from order book
             var matchingOrders = await GetMatchingOrdersAsync(matchingRepository, order);
             
@@ -239,9 +243,12 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
 
             // Process each asset independently
             // پردازش مستقل هر دارایی
-            var tasks = activeAssets.Select(asset => 
-                ProcessSingleAssetAsync(asset, cancellationToken)
-            ).ToArray();
+            var marketMode = scope.ServiceProvider.GetRequiredService<MarketModeProvider>();
+
+            var tasks = activeAssets
+                .Where(asset => ShouldMatchInBackground(marketMode, asset))
+                .Select(asset => ProcessSingleAssetAsync(asset, cancellationToken))
+                .ToArray();
 
             await Task.WhenAll(tasks);
         }
@@ -249,6 +256,39 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         {
             _logger.LogError(ex, "💥 Error processing all pending orders");
         }
+    }
+
+    /// <summary>
+    /// Whether this background loop should match a symbol at all.
+    ///
+    /// In Dealer mode it must not. A quote acceptance creates both orders, matches them
+    /// completely and consumes them inside one operation (<c>QuoteFillService</c>), so there
+    /// is never resting liquidity for this loop to pair up — its only possible effect is to
+    /// reach the same pair the fill is already matching.
+    ///
+    /// That is exactly what happened in issue #74: one order pair produced two trades, one
+    /// from the fill and one from this loop, and the customer paid for both. The semaphore
+    /// added in #53 serialises this loop against itself; it does not cover the fill path,
+    /// which calls the repository directly. Removing the second matcher is a smaller and
+    /// surer fix than trying to make two matchers agree.
+    ///
+    /// The concurrency token on RemainingAmount would now refuse the loser of such a race, so
+    /// this is the second line of defence rather than the only one — but a refusal still
+    /// produces a rolled-back transaction and a warning for a situation that should not arise.
+    /// </summary>
+    /// <param name="marketMode">
+    /// Resolved from the caller's scope rather than injected: this service is a singleton and
+    /// <see cref="MarketModeProvider"/> is scoped, and it deliberately re-reads configuration
+    /// on each call so a mode change needs no restart.
+    /// </param>
+    private bool ShouldMatchInBackground(MarketModeProvider marketMode, string asset)
+    {
+        if (marketMode.GetMode(asset) != MarketMode.Dealer)
+            return true;
+
+        _logger.LogDebug(
+            "Skipping {Asset}: it is a dealer market, where fills are matched synchronously.", asset);
+        return false;
     }
 
     /// <summary>

--- a/src/Order/Orders.Application/Services/QuoteFillService.cs
+++ b/src/Order/Orders.Application/Services/QuoteFillService.cs
@@ -1,6 +1,7 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Orders.Core;
 using Orders.Infrastructure;
+using TallaEgg.Core;
 using TallaEgg.Core.Enums.Order;
 
 namespace Orders.Application.Services;
@@ -53,6 +54,20 @@ public class QuoteFillService
     {
         if (quantity <= 0)
             return (false, "مقدار باید بزرگ‌تر از صفر باشد.", null);
+
+        // Rounded once, here, before anything is created — and this value is what both orders
+        // and the match then use.
+        //
+        // The order columns hold two decimal places, so a customer's 1.2345 grams was stored
+        // as 1.23 while the in-memory order kept 1.2345, and the match ran on the unrounded
+        // figure. Rounding at the boundary means the order the customer gets is the order the
+        // confirmation showed them: the confirmation already displays the rounded amount, so
+        // 1.23 is the number they agreed to (issue #74).
+        var baseAsset = symbol.Split('/')[0];
+        quantity = CurrenciesConstant.RoundToCurrencyPrecision(quantity, baseAsset);
+
+        if (quantity <= 0)
+            return (false, $"مقدار وارد‌شده از حداقل قابل معامله کمتر است.", null);
 
         if (!_marketMode.IsDealerMarket(symbol, out var marketMakerUserId))
             return (false, "این نماد در حالت مظنه‌ای نیست.", null);

--- a/src/Order/Orders.Core/IQuoteRepository.cs
+++ b/src/Order/Orders.Core/IQuoteRepository.cs
@@ -1,4 +1,4 @@
-namespace Orders.Core;
+﻿namespace Orders.Core;
 
 public interface IQuoteRepository
 {
@@ -13,4 +13,14 @@ public interface IQuoteRepository
     /// می‌کند؛ در حالت دوم معاملهٔ کاملاً معتبری رد می‌شود.
     /// </summary>
     Task<Quote> PublishAsync(Quote quote);
+
+    /// <summary>
+    /// Published quotes for a symbol, newest first, including ones already replaced.
+    ///
+    /// The superseded rows are the point. Deactivating rather than deleting was a deliberate
+    /// choice when quotes were introduced (#48), so that it stays possible to see which price
+    /// was in force when any given trade happened. Without a way to read them, that history
+    /// existed but nobody could look at it.
+    /// </summary>
+    Task<(IReadOnlyList<Quote> Items, int TotalCount)> GetHistoryAsync(string symbol, int pageNumber, int pageSize);
 }

--- a/src/Order/Orders.Infrastructure/Configurations/OrderConfigurations.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/OrderConfigurations.cs
@@ -18,9 +18,27 @@ namespace Orders.Infrastructure.Configurations
                 .IsRequired()
                 .HasPrecision(18, 2);
             
+            // RemainingAmount is a concurrency token: every UPDATE to an order carries
+            // "WHERE RemainingAmount = <the value that was read>", so a second writer whose
+            // read is stale — or who raced us — affects zero rows and EF throws
+            // DbUpdateConcurrencyException instead of silently overwriting.
+            //
+            // This is what makes "one fill produces one trade" a database guarantee rather
+            // than a code convention (issue #74). Before it, ExecuteAtomicMatchAsync claimed
+            // in a comment to "re-fetch orders with lock", and did neither: there was no
+            // lock, and because the same DbContext had just created the orders, EF identity
+            // resolution handed back the tracked in-memory copy rather than reading the row.
+            // Two matchers therefore both saw an unspent order and both matched it, and one
+            // customer paid twice.
+            //
+            // A concurrency token rather than an UPDLOCK hint on purpose: it is enforced by
+            // EF for any provider, so it holds under SQLite in tests exactly as under SQL
+            // Server in production. Same reasoning as issue #42, where a primary key on
+            // TradeId made "settled exactly once" structural.
             builder.Property(o => o.RemainingAmount)
                 .IsRequired()
-                .HasPrecision(18, 2);
+                .HasPrecision(18, 2)
+                .IsConcurrencyToken();
             
             builder.Property(o => o.Price)
                 .IsRequired()

--- a/src/Order/Orders.Infrastructure/Migrations/20260730133419_ConcurrencyTokenOnRemainingAmount.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260730133419_ConcurrencyTokenOnRemainingAmount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730133419_ConcurrencyTokenOnRemainingAmount")]
+    partial class ConcurrencyTokenOnRemainingAmount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260730133419_ConcurrencyTokenOnRemainingAmount.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260730133419_ConcurrencyTokenOnRemainingAmount.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <summary>
+    /// Deliberately empty, and deliberately kept.
+    ///
+    /// Marking Order.RemainingAmount as a concurrency token (issue #74) changes how EF writes
+    /// — every UPDATE gains "WHERE RemainingAmount = &lt;the value read&gt;" — but not the
+    /// schema, so there is no DDL to emit. The migration exists to keep the model snapshot in
+    /// step with the model; without it the next migration would carry this change as a
+    /// surprise, and EF would report pending model changes.
+    /// </summary>
+    public partial class ConcurrencyTokenOnRemainingAmount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -113,8 +113,25 @@ public class OrderMatchingRepository
 
         try
         {
-            // 1. Re-fetch orders with lock to ensure they haven't changed
-            // بازخوانی سفارشات برای اطمینان از عدم تغییر
+            // 1. Read the orders as the database currently holds them.
+            //
+            // The reload is explicit because a plain query would not have re-read anything:
+            // when the same DbContext created these orders moments earlier, EF identity
+            // resolution returns the tracked in-memory instance and the query result is
+            // discarded. That is how a match once ran against RemainingAmount = 1.2345 while
+            // the row said 1.23 — the quantity columns hold two decimal places (issue #74).
+            //
+            // The real protection against a racing matcher is the concurrency token on
+            // RemainingAmount, which turns a stale write into an exception. This reload
+            // additionally makes the quantity clamp below reason about real values, so the
+            // ordinary path succeeds instead of failing the concurrency check.
+            foreach (var tracked in new[] { buyOrder, sellOrder })
+            {
+                var entry = _context.Entry(tracked);
+                if (entry.State != EntityState.Detached)
+                    await entry.ReloadAsync();
+            }
+
             var currentBuyOrder = await _context.Orders
                 .FirstOrDefaultAsync(o => o.Id == buyOrder.Id);
 
@@ -141,9 +158,18 @@ public class OrderMatchingRepository
             //    return (false, null, "قیمت خرید کمتر از قیمت فروش است");
             //}
 
-            // 4. Calculate actual tradeable quantity
+            // 4. Calculate actual tradeable quantity.
+            //
+            // Rounded to the base asset's own precision first. A caller can ask for a
+            // quantity finer than the asset supports — a customer typing 1.2345 grams — and
+            // the trade table would store it, while the order table (two decimal places)
+            // could not. Rounding here means one number is used for the trade, the order and
+            // the settlement, whatever the caller passed (issue #74).
+            var baseAssetForQty = currentBuyOrder.Asset.Split('/')[0];
+            var requestedQty = CurrenciesConstant.RoundToCurrencyPrecision(matchQuantity, baseAssetForQty);
+
             var actualMatchQty = Math.Min(
-                Math.Min(matchQuantity, currentBuyOrder.RemainingAmount),
+                Math.Min(requestedQty, currentBuyOrder.RemainingAmount),
                 currentSellOrder.RemainingAmount
             );
 
@@ -188,6 +214,23 @@ public class OrderMatchingRepository
                 currentBuyOrder.Id, currentSellOrder.Id, actualMatchQty, tradePrice);
 
             return (true, trade, string.Empty);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // Another matcher changed one of these orders between our read and our write, or
+            // our copy was stale. Either way this match must not be applied: the alternative
+            // is the defect in issue #74, where one order pair produced two trades and the
+            // customer paid for both.
+            //
+            // Logged as a warning, not an error: losing the race is the guard working, and
+            // the winner's trade is valid. An error would page someone for correct behaviour.
+            await transaction.RollbackAsync();
+            _logger.LogWarning(ex,
+                "Refused to match Buy={BuyOrderId} with Sell={SellOrderId}: the orders changed " +
+                "concurrently. Another matcher has already filled them.",
+                buyOrder.Id, sellOrder.Id);
+
+            return (false, null, "این سفارش هم‌زمان توسط عملیات دیگری پردازش شد.");
         }
         catch (Exception ex)
         {

--- a/src/Order/Orders.Infrastructure/QuoteRepository.cs
+++ b/src/Order/Orders.Infrastructure/QuoteRepository.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 
@@ -26,6 +26,32 @@ public class QuoteRepository : IQuoteRepository
             .Where(q => q.Symbol == normalized && q.IsActive)
             .OrderByDescending(q => q.PublishedAt)
             .FirstOrDefaultAsync();
+    }
+
+    public async Task<(IReadOnlyList<Quote> Items, int TotalCount)> GetHistoryAsync(
+        string symbol, int pageNumber, int pageSize)
+    {
+        var normalized = symbol.Trim().ToUpperInvariant();
+
+        // Clamped rather than trusted: these arrive from an HTTP query string, and a page
+        // size of zero would divide by zero when the caller computes the page count, while a
+        // huge one would build a message Telegram refuses to send.
+        pageNumber = Math.Max(1, pageNumber);
+        pageSize = Math.Clamp(pageSize, 1, 50);
+
+        var query = _context.Quotes.Where(q => q.Symbol == normalized);
+
+        var total = await query.CountAsync();
+
+        // Ordered by PublishedAt, not by Id: ids are Guids and carry no order at all, so
+        // paging on them would return the same rows on different pages.
+        var items = await query
+            .OrderByDescending(q => q.PublishedAt)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return (items, total);
     }
 
     public async Task<Quote> PublishAsync(Quote quote)

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/QuoteDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/QuoteDto.cs
@@ -26,6 +26,15 @@ namespace TallaEgg.Core.DTOs.Order
         public decimal SellPrice { get; set; }
 
         public DateTime PublishedAt { get; set; }
+
+        /// <summary>
+        /// Whether this is the quote customers are currently trading on. False for a quote
+        /// that has been replaced by a newer one.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>When a newer quote replaced this one; null while it is still active.</summary>
+        public DateTime? DeactivatedAt { get; set; }
     }
 
     /// <summary>درخواست انتشار مظنه توسط ادمین. قیمت‌ها بر حسب واحد پایه (تومان بر گرم).</summary>

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
@@ -22,4 +22,12 @@ public interface IUsersApiClient
     Task<ApiResponse<UserDto>> UpdatePhoneAsync(long telegramId, string phoneNumber);
     Task<ApiResponse<UserDto>> UpdateUserStatusAsync(long telegramId, UserStatus newStatus);
     Task<Guid?> GetUserIdByPhoneNumberAsync(string phonenumber);
+
+    /// <summary>
+    /// Looks a user up by their internal id; null when no such user exists.
+    ///
+    /// Needed because trades carry user ids, not phone numbers, so naming the other side of
+    /// a trade in the admin's history requires this direction of lookup.
+    /// </summary>
+    Task<UserDto?> GetUserByIdAsync(Guid userId);
 }

--- a/src/Wallet/Wallet.Tests/AccountingMenuTests.cs
+++ b/src/Wallet/Wallet.Tests/AccountingMenuTests.cs
@@ -1,0 +1,85 @@
+﻿using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram;
+using TallaEgg.TelegramBot.Infrastructure.Messaging;
+using Telegram.Bot.Types.ReplyMarkups;
+using Wallet.Tests.Fakes;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Who sees which accounting buttons.
+///
+/// Quote history is the record of the prices the shop set, and for the admin it also shows the
+/// margin on each one. That is the shop's business, not the customer's, so the button belongs
+/// only on the admin keyboard.
+///
+/// <para>
+/// This test exists because the removal was made once and silently did not apply: the edit was
+/// a text substitution whose pattern no longer matched after an earlier change to the same
+/// method, and nothing failed — not the build, not the tests. The customer kept seeing the
+/// button until someone noticed in Telegram. A keyboard is behaviour; it should be asserted
+/// like any other.
+/// </para>
+/// </summary>
+public class AccountingMenuTests
+{
+    private const long ChatId = 12345;
+
+    private static async Task<IReadOnlyList<string>> ButtonsOfAsync(Func<IBotMessenger, Task> sendMenu)
+    {
+        var messenger = new FakeBotMessenger();
+        await sendMenu(messenger);
+
+        var markup = Assert.IsType<ReplyKeyboardMarkup>(messenger.Sent.Single().ReplyMarkup);
+
+        return markup.Keyboard.SelectMany(row => row).Select(b => b.Text).ToList();
+    }
+
+    [Fact]
+    public async Task TheCustomerMenuDoesNotOfferQuoteHistory()
+    {
+        var buttons = await ButtonsOfAsync(m => m.SendAccountingMenuKeyboard(ChatId));
+
+        Assert.DoesNotContain(BotBtns.BtnQuoteHistory, buttons);
+    }
+
+    [Fact]
+    public async Task TheAdminMenuDoesOfferQuoteHistory()
+    {
+        var buttons = await ButtonsOfAsync(m => m.SendAccountingMenuKeyboardForAdmin(ChatId));
+
+        Assert.Contains(BotBtns.BtnQuoteHistory, buttons);
+    }
+
+    /// <summary>Both audiences keep their own trade history and a way back.</summary>
+    [Fact]
+    public async Task BothMenusOfferTradeHistoryAndAWayBack()
+    {
+        foreach (var buttons in new[]
+                 {
+                     await ButtonsOfAsync(m => m.SendAccountingMenuKeyboard(ChatId)),
+                     await ButtonsOfAsync(m => m.SendAccountingMenuKeyboardForAdmin(ChatId))
+                 })
+        {
+            Assert.Contains(BotBtns.BtnTradeHistory, buttons);
+            Assert.Contains(BotBtns.BtnMainMenu, buttons);
+        }
+    }
+
+    /// <summary>
+    /// The removed active-orders button must not come back. In the dealer model an order lives
+    /// only for the instant of a fill, so the list was always empty.
+    /// </summary>
+    [Fact]
+    public async Task NeitherMenuOffersActiveOrders()
+    {
+        foreach (var buttons in new[]
+                 {
+                     await ButtonsOfAsync(m => m.SendAccountingMenuKeyboard(ChatId)),
+                     await ButtonsOfAsync(m => m.SendAccountingMenuKeyboardForAdmin(ChatId))
+                 })
+        {
+            Assert.DoesNotContain(buttons, b => b.Contains("سفارشات فعال"));
+        }
+    }
+}

--- a/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
+++ b/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
@@ -178,7 +178,7 @@ public class BotConversationFlowTests
         await WalkToConfirmationAsync(amount: "2.5");
 
         var confirmation = _messenger.Texts.Last();
-        Assert.Contains("تایید سفارش", confirmation);
+        Assert.Contains("تأیید سفارش", confirmation);
         Assert.Contains("قیمت هر مثقال", confirmation);
         Assert.Contains("قیمت هر گرم", confirmation);
         Assert.DoesNotContain("{", confirmation);

--- a/src/Wallet/Wallet.Tests/DealerModeSkipsBackgroundMatchingTests.cs
+++ b/src/Wallet/Wallet.Tests/DealerModeSkipsBackgroundMatchingTests.cs
@@ -1,0 +1,243 @@
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Infrastructure.Clients;
+using Wallet.Tests.Fakes;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// In Dealer mode the background matching loop must not match anything (issue #74).
+///
+/// A quote acceptance creates both orders, matches them in full and consumes them inside one
+/// operation, so there is never resting liquidity for the loop to pair. Its only possible
+/// effect on a dealer symbol is to reach the pair a fill is already matching — which is what
+/// produced two trades from one order pair and charged the customer twice.
+///
+/// The semaphore from #53 serialises this loop against itself. It does not cover
+/// <c>QuoteFillService</c>, which calls the repository directly. Removing the second matcher
+/// is smaller and surer than coordinating two.
+///
+/// Both directions are asserted. A guard that also stopped order-book matching would replace
+/// one defect with a worse one: no trades at all when peer-to-peer trading opens.
+/// </summary>
+public class DealerModeSkipsBackgroundMatchingTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+    private const decimal Price = 16_967_542.36m;
+    private const decimal Quantity = 2m;
+
+    private readonly Guid _buyerId = Guid.NewGuid();
+    private readonly Guid _sellerId = Guid.NewGuid();
+
+    public DealerModeSkipsBackgroundMatchingTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using var setup = NewContext();
+        setup.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private OrdersDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+    /// <summary>
+    /// Calls the production <c>AddMatchingEngine</c> so this covers the real wiring, with the
+    /// database and the wallet swapped for local doubles.
+    /// </summary>
+    private ServiceProvider BuildProvider(params (string Key, string Value)[] settings) =>
+        BuildProvider(null, settings);
+
+    private ServiceProvider BuildProvider(
+        ILoggerProvider? logProvider,
+        params (string Key, string Value)[] settings)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.Select(s => new KeyValuePair<string, string?>(s.Key, s.Value)))
+            .Build());
+
+        if (logProvider is null)
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        else
+            services.AddLogging(b => b.AddProvider(logProvider));
+        services.AddScoped(_ => NewContext());
+        services.AddScoped<OrderMatchingRepository>();
+        services.AddScoped<IOrderRepository, OrderRepository>();
+        services.AddScoped<MarketModeProvider>();
+        services.AddScoped<IWalletApiClient, StubWalletApiClient>();
+        services.AddMatchingEngine();
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>A confirmed, unmatched pair — what the loop would pick up.</summary>
+    private (Guid BuyId, Guid SellId) SeedMatchablePair()
+    {
+        using var db = NewContext();
+
+        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, _buyerId, OrderSide.Buy, TradingType.Spot);
+        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, _sellerId, OrderSide.Sell, TradingType.Spot);
+        buy.Confirm();
+        sell.Confirm();
+
+        db.Orders.AddRange(buy, sell);
+        db.SaveChanges();
+
+        return (buy.Id, sell.Id);
+    }
+
+    private async Task<int> TradeCountAsync()
+    {
+        await using var db = NewContext();
+        return await db.Trades.CountAsync();
+    }
+
+    /// <summary>
+    /// Note: this pair of "creates no trade" tests would also pass without the guard, because
+    /// the order-book query cannot run under SQLite at all (see
+    /// <see cref="InOrderBookMode_TheOrderBookIsConsulted"/>). They state the outcome that
+    /// matters; <see cref="InDealerMode_TheOrderBookIsNeverConsulted"/> is the one that
+    /// actually fails when the guard is removed — confirmed by removing it.
+    /// </summary>
+    [Fact]
+    public async Task InDealerMode_TheBackgroundLoopCreatesNoTrade()
+    {
+        var (buyId, _) = SeedMatchablePair();
+
+        using var provider = BuildProvider(
+            ("Matching:MarketModes:" + Symbol, "Dealer"),
+            ("Matching:MarketMakerUserId", _sellerId.ToString()));
+
+        var engine = provider.GetRequiredService<MatchingEngineService>();
+
+        var matched = await engine.ProcessOrderForMatchingAsync(buyId);
+
+        Assert.False(matched, "a dealer symbol must not be matched by the background loop");
+        Assert.Equal(0, await TradeCountAsync());
+    }
+
+    [Fact]
+    public async Task InDealerMode_TheWholeSweepCreatesNoTrade()
+    {
+        SeedMatchablePair();
+
+        using var provider = BuildProvider(
+            ("Matching:MarketModes:" + Symbol, "Dealer"),
+            ("Matching:MarketMakerUserId", _sellerId.ToString()));
+
+        var engine = provider.GetRequiredService<MatchingEngineService>();
+
+        await engine.ProcessAllPendingOrdersAsync(CancellationToken.None);
+
+        Assert.Equal(0, await TradeCountAsync());
+    }
+
+    // ── the other direction: the guard must not over-block ──────────────────────
+
+    /// <summary>
+    /// Asserted by whether the order book is consulted at all, rather than by whether a trade
+    /// results.
+    ///
+    /// <para>
+    /// <b>Why:</b> the order-book query cannot run under SQLite —
+    /// <c>GetSellOrdersWithLockAsync</c> orders by <c>Price</c>, and SQLite raises
+    /// <c>NotSupportedException: SQLite does not support expressions of type 'decimal' in ORDER
+    /// BY clauses</c>. Verified directly, not assumed. Production uses SQL Server, where it is
+    /// fine. So "a trade appears" is not reachable here, but "the engine reached the order
+    /// book" is — and that is the thing the guard decides.
+    /// </para>
+    ///
+    /// <para>
+    /// Without this direction, a guard that disabled matching altogether would satisfy the two
+    /// tests above and nobody would find out until peer-to-peer trading was switched on.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task InOrderBookMode_TheOrderBookIsConsulted()
+    {
+        var (buyId, _) = SeedMatchablePair();
+
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildProvider(log, ("Matching:MarketModes:" + Symbol, "OrderBook"));
+
+        await provider.GetRequiredService<MatchingEngineService>().ProcessOrderForMatchingAsync(buyId);
+
+        Assert.Contains(log.Messages, m => m.Contains("sell orders for asset"));
+    }
+
+    /// <summary>In Dealer mode it must not even be consulted — nothing to consult it for.</summary>
+    [Fact]
+    public async Task InDealerMode_TheOrderBookIsNeverConsulted()
+    {
+        var (buyId, _) = SeedMatchablePair();
+
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildProvider(log,
+            ("Matching:MarketModes:" + Symbol, "Dealer"),
+            ("Matching:MarketMakerUserId", _sellerId.ToString()));
+
+        await provider.GetRequiredService<MatchingEngineService>().ProcessOrderForMatchingAsync(buyId);
+
+        Assert.DoesNotContain(log.Messages, m => m.Contains("sell orders for asset"));
+    }
+
+    /// <summary>
+    /// With no configuration the mode falls back to OrderBook, the historical behaviour, so the
+    /// book must still be consulted. (That the fallback is silent is its own problem, tracked
+    /// in #73; this only pins that the new guard did not change it.)
+    /// </summary>
+    [Fact]
+    public async Task WithNoMarketModeConfigured_TheOrderBookIsStillConsulted()
+    {
+        var (buyId, _) = SeedMatchablePair();
+
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildProvider(log);
+
+        await provider.GetRequiredService<MatchingEngineService>().ProcessOrderForMatchingAsync(buyId);
+
+        Assert.Contains(log.Messages, m => m.Contains("sell orders for asset"));
+    }
+
+    /// <summary>Collects log messages so a test can tell which code path ran.</summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new Sink(Messages);
+
+        public void Dispose() { }
+
+        private sealed class Sink(List<string> messages) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                lock (messages) messages.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/src/Wallet/Wallet.Tests/DoubleMatchTests.cs
+++ b/src/Wallet/Wallet.Tests/DoubleMatchTests.cs
@@ -1,0 +1,286 @@
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// One pair of orders must produce one trade, for no more than the order's own amount
+/// (issue #74).
+///
+/// A single quote acceptance produced two trades from one order pair and the customer paid
+/// for both. Orders for 1.23 g yielded trades of 1.2345 g and 1.23 g — 2.4645 g in total.
+/// Three defects combined:
+///
+/// <list type="number">
+/// <item>the quantity columns hold two decimal places, so a customer's 1.2345 was truncated
+/// to 1.23 on write while the in-memory entity kept 1.2345;</item>
+/// <item><c>ExecuteAtomicMatchAsync</c>'s "re-fetch with lock" did neither — EF identity
+/// resolution returned the stale tracked entity, and there was no lock or concurrency
+/// token;</item>
+/// <item>the dealer fill path matched outside the semaphore that serialises the background
+/// engine, so both could match the same pair at once.</item>
+/// </list>
+///
+/// Conservation checks could not catch any of it: both trades were internally balanced, so
+/// no money was created. The cost fell on the customer, which nothing was measuring.
+/// </summary>
+public class DoubleMatchTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly OrdersDbContext _context;
+    private readonly OrderMatchingRepository _repository;
+
+    private readonly Guid _buyerId = Guid.NewGuid();
+    private readonly Guid _sellerId = Guid.NewGuid();
+
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+    private const decimal Price = 16_967_542.36m;
+
+    public DoubleMatchTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+        _context = new OrdersDbContext(options);
+        _context.Database.EnsureCreated();
+        _repository = new OrderMatchingRepository(_context, NullLogger<OrderMatchingRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private Order AddOrder(Guid userId, OrderSide side, decimal amount)
+    {
+        var order = Order.CreateMakerOrder(Symbol, amount, Price, userId, side, TradingType.Spot);
+        order.Confirm();
+        _context.Orders.Add(order);
+        _context.SaveChanges();
+        return order;
+    }
+
+    /// <summary>
+    /// A second context over the same database, which is what a concurrent matcher has: its
+    /// own change tracker, so it reads the row rather than a tracked copy.
+    /// </summary>
+    private OrderMatchingRepository SeparateSession(out OrdersDbContext context)
+    {
+        context = new OrdersDbContext(
+            new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+        return new OrderMatchingRepository(context, NullLogger<OrderMatchingRepository>.Instance);
+    }
+
+    // ── one pair, one trade ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The defect exactly as it happened: two matchers reach the same pair, each having read
+    /// the remaining amount before either wrote. Only one may produce a trade.
+    ///
+    /// Driven through two DbContexts rather than two threads on purpose. What has to be true
+    /// is not "a race can occur" — it demonstrably can — but "when it does, at most one trade
+    /// exists afterwards". Two sessions make that deterministic; two threads on one SQLite
+    /// connection would be flaky or deadlock and would prove less.
+    /// </summary>
+    [Fact]
+    public async Task TwoMatchersOnTheSamePair_ProduceExactlyOneTrade()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, 1.23m);
+        var sell = AddOrder(_sellerId, OrderSide.Sell, 1.23m);
+
+        var other = SeparateSession(out var otherContext);
+        using (otherContext)
+        {
+            var otherBuy = await otherContext.Orders.SingleAsync(o => o.Id == buy.Id);
+            var otherSell = await otherContext.Orders.SingleAsync(o => o.Id == sell.Id);
+
+            var first = await _repository.ExecuteAtomicMatchAsync(buy, sell, 1.23m);
+            var second = await other.ExecuteAtomicMatchAsync(otherBuy, otherSell, 1.23m);
+
+            Assert.True(first.Success, first.ErrorMessage);
+            Assert.False(second.Success,
+                "the second matcher must be refused; the pair was already fully matched");
+        }
+
+        _context.ChangeTracker.Clear();
+        Assert.Equal(1, await _context.Trades.CountAsync());
+    }
+
+    /// <summary>
+    /// The consequence that actually cost money: the total quantity traded across a pair can
+    /// never exceed what was ordered. This is the assertion the conservation checks were
+    /// missing — money stayed balanced while the customer bought twice.
+    /// </summary>
+    [Fact]
+    public async Task TheTotalTradedNeverExceedsTheOrderAmount()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, 1.23m);
+        var sell = AddOrder(_sellerId, OrderSide.Sell, 1.23m);
+
+        var other = SeparateSession(out var otherContext);
+        using (otherContext)
+        {
+            var otherBuy = await otherContext.Orders.SingleAsync(o => o.Id == buy.Id);
+            var otherSell = await otherContext.Orders.SingleAsync(o => o.Id == sell.Id);
+
+            await _repository.ExecuteAtomicMatchAsync(buy, sell, 1.23m);
+            await other.ExecuteAtomicMatchAsync(otherBuy, otherSell, 1.23m);
+        }
+
+        _context.ChangeTracker.Clear();
+        var traded = await _context.Trades.SumAsync(t => t.Quantity);
+
+        Assert.Equal(1.23m, traded);
+    }
+
+    // ── a match may not exceed what the database holds ───────────────────────────
+
+    /// <summary>
+    /// A match may not be finer than the asset's own precision.
+    ///
+    /// This is the half of the defect that came from column precision. `Orders.Amount` and
+    /// `Orders.RemainingAmount` hold two decimal places while `Trades.Quantity` holds eight,
+    /// so a customer's 1.2345 was truncated to 1.23 in the order row and stored in full in
+    /// the trade row — a trade larger than the order that funded it.
+    ///
+    /// <para>
+    /// <b>Why the assertion is about rounding rather than truncation:</b> SQLite does not
+    /// enforce decimal precision, so the truncation itself cannot be reproduced here — the
+    /// first version of this test asserted the row held 1.23 and failed, because under SQLite
+    /// it holds 1.2345. The truncation is evidenced by the production rows in #74. What is
+    /// provider-independent, and what actually prevents the defect, is that the match rounds
+    /// to the asset's precision so the order, the trade and the settlement carry one number.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task AMatchIsRoundedToTheAssetsPrecision()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, 1.2345m);
+        var sell = AddOrder(_sellerId, OrderSide.Sell, 1.2345m);
+
+        var (success, trade, error) = await _repository.ExecuteAtomicMatchAsync(buy, sell, 1.2345m);
+
+        Assert.True(success, error);
+
+        // Gold is declared at two decimal places, the same as the order columns.
+        var expected = CurrenciesConstant.RoundToCurrencyPrecision(1.2345m, CurrenciesConstant.Maua);
+        Assert.Equal(1.23m, expected);
+        Assert.Equal(expected, trade!.Quantity);
+    }
+
+    /// <summary>
+    /// The ordinary case must keep working. A guard that also blocks legitimate fills would
+    /// be a worse defect than the one being fixed.
+    /// </summary>
+    [Fact]
+    public async Task AnOrdinarySingleMatch_StillSucceeds()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, 2.5m);
+        var sell = AddOrder(_sellerId, OrderSide.Sell, 2.5m);
+
+        var (success, trade, error) = await _repository.ExecuteAtomicMatchAsync(buy, sell, 2.5m);
+
+        Assert.True(success, error);
+        Assert.Equal(2.5m, trade!.Quantity);
+    }
+
+    /// <summary>
+    /// The concurrency token specifically.
+    ///
+    /// <para>
+    /// The other tests here pass on the reload alone — verified by removing the token and
+    /// watching them stay green. They run read→write, read→write, so the second matcher's
+    /// reload already sees a spent order. The token covers the window the reload cannot: the
+    /// row changing between our read and our write.
+    /// </para>
+    ///
+    /// <para>
+    /// That divergence is staged by setting the tracked entity's <i>original</i> value, rather
+    /// than by running a second transaction. In-memory SQLite on one connection rejects nested
+    /// transactions outright ("SqliteConnection does not support nested transactions"), and a
+    /// second connection would block on the write lock this transaction already holds. Setting
+    /// the original value produces the identical condition — EF emits
+    /// <c>WHERE RemainingAmount = &lt;what we think we read&gt;</c>, no row matches, and the
+    /// update is refused — which is the token's entire contract.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task WhenTheRowNoLongerMatchesWhatWeRead_TheMatchIsRefused()
+    {
+        var hooked = new HookedOrdersDbContext(
+            new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+        using (hooked)
+        {
+            var repository = new OrderMatchingRepository(hooked, NullLogger<OrderMatchingRepository>.Instance);
+
+            var buy = AddOrder(_buyerId, OrderSide.Buy, 1.23m);
+            var sell = AddOrder(_sellerId, OrderSide.Sell, 1.23m);
+
+            var hookedBuy = await hooked.Orders.SingleAsync(o => o.Id == buy.Id);
+            var hookedSell = await hooked.Orders.SingleAsync(o => o.Id == sell.Id);
+
+            // Just before the write, pretend we had read a value the row does not hold — the
+            // state a rival's commit would have left us in.
+            hooked.BeforeSave = () =>
+                hooked.Entry(hookedBuy).Property(o => o.RemainingAmount).OriginalValue = 0.5m;
+
+            var (success, _, error) = await repository.ExecuteAtomicMatchAsync(hookedBuy, hookedSell, 1.23m);
+
+            Assert.False(success, "a write whose read is out of date must be refused");
+            Assert.Contains("هم‌زمان", error!);
+        }
+
+        // Nothing was written: no trade, and the orders are untouched.
+        _context.ChangeTracker.Clear();
+        Assert.Equal(0, await _context.Trades.CountAsync());
+        Assert.Equal(1.23m, (await _context.Orders.SingleAsync(o => o.Side == OrderSide.Buy)).RemainingAmount);
+    }
+
+    /// <summary>
+    /// A hook immediately before <c>SaveChanges</c>, the same device used for #42.
+    /// </summary>
+    private sealed class HookedOrdersDbContext : OrdersDbContext
+    {
+        public Action? BeforeSave;
+
+        public HookedOrdersDbContext(DbContextOptions<OrdersDbContext> options) : base(options) { }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            var hook = BeforeSave;
+            BeforeSave = null; // once only — a rollback would otherwise run it again
+            hook?.Invoke();
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Partial fills must still work: two sequential matches on one large order are correct
+    /// behaviour, unlike two matches for the same fill.
+    /// </summary>
+    [Fact]
+    public async Task SequentialPartialFills_AreStillAllowed()
+    {
+        var buy = AddOrder(_buyerId, OrderSide.Buy, 10m);
+        var sellA = AddOrder(_sellerId, OrderSide.Sell, 4m);
+        var sellB = AddOrder(_sellerId, OrderSide.Sell, 6m);
+
+        var first = await _repository.ExecuteAtomicMatchAsync(buy, sellA, 4m);
+        var second = await _repository.ExecuteAtomicMatchAsync(buy, sellB, 6m);
+
+        Assert.True(first.Success, first.ErrorMessage);
+        Assert.True(second.Success, second.ErrorMessage);
+
+        _context.ChangeTracker.Clear();
+        Assert.Equal(10m, await _context.Trades.SumAsync(t => t.Quantity));
+        Assert.Equal(0m, (await _context.Orders.SingleAsync(o => o.Id == buy.Id)).RemainingAmount);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -31,6 +31,18 @@ public sealed class FakeOrderApiClient : IOrderApiClient
 
     public Task<QuoteDto?> GetActiveQuoteAsync(string symbol) => Task.FromResult(ActiveQuote);
 
+    /// <summary>Quotes returned by the history endpoint, newest first.</summary>
+    public List<QuoteDto> QuoteHistory { get; } = [];
+
+    public Task<PagedResult<QuoteDto>> GetQuoteHistoryAsync(string symbol, int pageNumber = 1, int pageSize = 5) =>
+        Task.FromResult(new PagedResult<QuoteDto>
+        {
+            Items = QuoteHistory.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList(),
+            TotalCount = QuoteHistory.Count,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        });
+
     public Task<(bool success, string message)> AcceptQuoteAsync(
         Guid userId, string symbol, OrderSide side, decimal quantity)
     {
@@ -85,6 +97,12 @@ public sealed class FakeUsersApiClient : IUsersApiClient
         throw new NotSupportedException(nameof(UpdateUserStatusAsync));
     public Task<Guid?> GetUserIdByPhoneNumberAsync(string phonenumber) =>
         throw new NotSupportedException(nameof(GetUserIdByPhoneNumberAsync));
+
+    /// <summary>Users reachable by id, for resolving the other side of a trade.</summary>
+    public Dictionary<Guid, UserDto> UsersById { get; } = [];
+
+    public Task<UserDto?> GetUserByIdAsync(Guid userId) =>
+        Task.FromResult(UsersById.TryGetValue(userId, out var found) ? found : null);
 }
 
 public sealed class FakeAffiliateApiClient : IAffiliateApiClient

--- a/src/Wallet/Wallet.Tests/QuoteHistoryMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/QuoteHistoryMessageTests.cs
@@ -1,0 +1,216 @@
+﻿using TallaEgg.Core;
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.TelegramBot.Infrastructure.Handlers;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The quote history that replaced order history in the accounting menu.
+///
+/// The risk this covers is the buyer/seller inversion, which has already appeared three
+/// times in this product in different disguises: in matching (#40), in the trade history
+/// (which did not say buy or sell at all), and in the dealer pricing itself (#48). Here it
+/// takes yet another form — one row of data has two correct readings depending on who is
+/// looking. The admin publishes the prices, so the buy price is what *they* pay. The
+/// customer trades against them, so the same number is what *they* receive.
+///
+/// Label it for one audience and the other audience reads every price backwards.
+/// </summary>
+public class QuoteHistoryMessageTests
+{
+    private const string Gold = CurrenciesConstant.MAUA_IRT;
+
+    /// <summary>17,000,000/gram is 73,640,600/mesghal — recognisably a different magnitude.</summary>
+    private const decimal BuyPerGram = 17_000_000m;
+    private const decimal SellPerGram = 17_100_000m;
+
+    private static string Fa(decimal value) => TallaEgg.Core.Utilties.PersianFormat.Number(value);
+
+    private static PagedResult<QuoteDto> OnePage(params QuoteDto[] quotes) => new()
+    {
+        Items = quotes,
+        TotalCount = quotes.Length,
+        PageNumber = 1,
+        PageSize = 5
+    };
+
+    private static QuoteDto Quote(bool isActive = true, DateTime? deactivatedAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Symbol = Gold,
+        BuyPrice = BuyPerGram,
+        SellPrice = SellPerGram,
+        PublishedAt = new DateTime(2026, 7, 30, 8, 42, 0, DateTimeKind.Utc),
+        IsActive = isActive,
+        DeactivatedAt = deactivatedAt
+    };
+
+    // ── the two readings of one row ─────────────────────────────────────────────
+
+    /// <summary>
+    /// For the admin, the buy price is the price they pay. Saying "you buy" next to the
+    /// price the customer buys at would have them setting their margin upside down.
+    /// </summary>
+    [Fact]
+    public void ForAnAdmin_TheBuyPriceIsLabelledAsTheirOwnPurchase()
+    {
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true);
+
+        Assert.Contains("شما می‌خرید", text);
+        Assert.Contains("شما می‌فروشید", text);
+    }
+
+    /// <summary>
+    /// For the customer the same two numbers swap meaning: the admin's buy price is the
+    /// price the customer sells at.
+    /// </summary>
+    [Fact]
+    public void ForACustomer_TheAdminsBuyPriceIsTheirSellPrice()
+    {
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false);
+
+        Assert.Contains("قیمت فروش شما", text);
+        Assert.Contains("قیمت خرید شما", text);
+        Assert.DoesNotContain("شما می‌خرید", text);
+    }
+
+    /// <summary>
+    /// The decisive assertion: the two audiences must not be shown the same wording for the
+    /// same row, because the correct wording is opposite for each.
+    /// </summary>
+    [Fact]
+    public void TheAdminAndCustomerViewsAreNotIdentical()
+    {
+        var page = OnePage(Quote());
+
+        var adminText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true);
+        var customerText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false);
+
+        Assert.NotEqual(adminText, customerText);
+    }
+
+    /// <summary>Margin is the admin's own number to decide; a customer has no business seeing it.</summary>
+    [Fact]
+    public void TheMarginIsShownOnlyToTheAdmin()
+    {
+        var page = OnePage(Quote());
+
+        Assert.Contains("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true));
+        Assert.DoesNotContain("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false));
+    }
+
+    // ── units ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Prices are stored per gram and read per mesghal. Showing the stored figure would
+    /// understate every historical price by a factor of 4.3318 — and each row would still
+    /// look like a plausible gold price.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PricesAreConvertedToPerMesghal(bool isAdmin)
+    {
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin);
+
+        Assert.Contains("هر مثقال", text);
+        Assert.Contains(Fa(BuyPerGram * CurrenciesConstant.GramsPerMesghal), text);
+        Assert.Contains(Fa(SellPerGram * CurrenciesConstant.GramsPerMesghal), text);
+        Assert.DoesNotContain(Fa(BuyPerGram), text);
+    }
+
+    /// <summary>The admin's margin must be in the same unit as the prices printed beside it.</summary>
+    [Fact]
+    public void TheMarginIsQuotedPerMesghal_MatchingThePricesAboveIt()
+    {
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true);
+
+        var expected = (SellPerGram - BuyPerGram) * CurrenciesConstant.GramsPerMesghal;
+
+        Assert.Contains(Fa(expected), text);
+        Assert.DoesNotContain(Fa(SellPerGram - BuyPerGram), text);
+    }
+
+    // ── which row is live ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Superseded quotes are kept rather than deleted so it stays possible to see which price
+    /// was in force for any trade. That only helps if the list says which row is still live —
+    /// otherwise the reader assumes it is the top one, which is true only until it isn't.
+    /// </summary>
+    [Fact]
+    public void TheActiveQuoteIsDistinguishedFromReplacedOnes()
+    {
+        var replaced = Quote(isActive: false, deactivatedAt: new DateTime(2026, 7, 30, 11, 34, 0, DateTimeKind.Utc));
+
+        var activeText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false);
+        var replacedText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false);
+
+        Assert.Contains("مظنهٔ فعال", activeText);
+        Assert.DoesNotContain("مظنهٔ فعال", replacedText);
+        Assert.Contains("منقضی شد", replacedText);
+    }
+
+    [Fact]
+    public void AReplacedQuoteShowsWhenItEnded_AndAnActiveOneDoesNot()
+    {
+        var replaced = Quote(isActive: false, deactivatedAt: new DateTime(2026, 7, 30, 11, 34, 0, DateTimeKind.Utc));
+
+        Assert.Contains("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false));
+        Assert.DoesNotContain("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false));
+    }
+
+    // ── edges ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnEmptyHistoryReadsAsEmpty_RatherThanAsAnErrorOrABlankMessage()
+    {
+        var empty = new PagedResult<QuoteDto> { Items = new List<QuoteDto>(), TotalCount = 0, PageNumber = 1, PageSize = 5 };
+
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(empty, 1, isAdmin: false);
+
+        Assert.Contains("هنوز مظنه‌ای منتشر نشده", text);
+    }
+
+    [Fact]
+    public void NoUnfilledPlaceholderSurvives()
+    {
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote(), Quote(isActive: false)), 1, isAdmin: true);
+
+        Assert.DoesNotContain("{", text);
+    }
+
+    // ── paging ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The symbol travels in the callback data and contains a '/'. The page number is split
+    /// off at the *last* underscore for that reason; splitting on the first would work only
+    /// until a symbol contained one.
+    /// </summary>
+    [Fact]
+    public void ThePagingCallbackCarriesTheSymbolAndTheTargetPage()
+    {
+        var page = new PagedResult<QuoteDto> { Items = new[] { Quote() }, TotalCount = 12, PageNumber = 2, PageSize = 5 };
+
+        var keyboard = QuoteHistoryHandler.BuildPagingKeyboard(page, currentPage: 2, symbol: Gold);
+
+        Assert.NotNull(keyboard);
+        var data = keyboard!.InlineKeyboard.SelectMany(row => row).Select(b => b.CallbackData!).ToArray();
+
+        Assert.Contains($"{QuoteHistoryHandler.CallbackPrefix}{Gold}_1", data);
+        Assert.Contains($"{QuoteHistoryHandler.CallbackPrefix}{Gold}_3", data);
+
+        // Telegram rejects callback data over 64 bytes, and rejection happens at send time.
+        Assert.All(data, d => Assert.True(
+            System.Text.Encoding.UTF8.GetByteCount(d) <= 64, $"callback data too long: {d}"));
+    }
+
+    [Fact]
+    public void ASinglePageHasNoNavigationButtons()
+    {
+        var page = new PagedResult<QuoteDto> { Items = new[] { Quote() }, TotalCount = 1, PageNumber = 1, PageSize = 5 };
+
+        Assert.Null(QuoteHistoryHandler.BuildPagingKeyboard(page, 1, Gold));
+    }
+}

--- a/src/Wallet/Wallet.Tests/TradeListCounterpartyTests.cs
+++ b/src/Wallet/Wallet.Tests/TradeListCounterpartyTests.cs
@@ -1,0 +1,156 @@
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.TelegramBot.Infrastructure.Handlers;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Naming the other side of a trade in the admin's history.
+///
+/// The admin is one side of <b>every</b> trade in the dealer model, so without the
+/// counterparty their history is a page of rows that differ only by amount and time — they
+/// cannot tell which customer any of them was with. A customer needs no such row: all their
+/// trades are with the shop.
+///
+/// The value is passed in as a lookup rather than fetched here, so this stays a pure builder
+/// (issue #65). These tests therefore also pin the decision that "no lookup supplied" means
+/// "do not show the line" — which is what keeps a customer from seeing the shop's number.
+/// </summary>
+public class TradeListCounterpartyTests
+{
+    private static readonly Guid Admin = Guid.NewGuid();
+    private static readonly Guid CustomerA = Guid.NewGuid();
+    private static readonly Guid CustomerB = Guid.NewGuid();
+
+    private const string PhoneA = "09158527483";
+    private const string PhoneB = "09037212111";
+
+    private static PagedResult<TradeHistoryDto> Page(params TradeHistoryDto[] trades) => new()
+    {
+        Items = trades,
+        TotalCount = trades.Length,
+        PageNumber = 1,
+        PageSize = 5
+    };
+
+    private static TradeHistoryDto Trade(Guid buyer, Guid seller) => new()
+    {
+        Id = Guid.NewGuid(),
+        Symbol = "MAUA/IRT",
+        Price = 16_875_201.99m,
+        Quantity = 10m,
+        QuoteQuantity = 168_752_019m,
+        BuyerUserId = buyer,
+        SellerUserId = seller,
+        CreatedAt = new DateTime(2026, 7, 30, 11, 34, 0, DateTimeKind.Utc)
+    };
+
+    /// <summary>Persian digits, because that is how the number is rendered in the message.</summary>
+    private static string Fa(string phone) => TallaEgg.Core.Utilties.PersianFormat.ToPersianDigits(phone);
+
+    // ── shown when supplied ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WhenALookupIsSupplied_TheCounterpartyIsNamed()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA)), 1, viewerUserId: Admin,
+            counterpartyPhones: new Dictionary<Guid, string> { [CustomerA] = PhoneA });
+
+        Assert.Contains("طرف معامله", text);
+        Assert.Contains(Fa(PhoneA), text);
+    }
+
+    /// <summary>
+    /// The counterparty is derived from which side the viewer is on, not assumed to be the
+    /// seller. The admin buys on some trades and sells on others, so an implementation that
+    /// always took one field would name the admin themselves on half the rows.
+    /// </summary>
+    [Fact]
+    public async Task TheCounterpartyIsTheSideTheViewerIsNot_WhicheverThatIs()
+    {
+        var phones = new Dictionary<Guid, string> { [CustomerA] = PhoneA, [CustomerB] = PhoneB };
+
+        var adminBought = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA)), 1, Admin, phones);
+
+        var adminSold = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: CustomerB, seller: Admin)), 1, Admin, phones);
+
+        Assert.Contains(Fa(PhoneA), adminBought);
+        Assert.DoesNotContain(Fa(PhoneB), adminBought);
+
+        Assert.Contains(Fa(PhoneB), adminSold);
+        Assert.DoesNotContain(Fa(PhoneA), adminSold);
+    }
+
+    /// <summary>Each row names its own counterparty, not the first one found on the page.</summary>
+    [Fact]
+    public async Task EachRowNamesItsOwnCounterparty()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA),
+                 Trade(buyer: CustomerB, seller: Admin)),
+            1, Admin,
+            new Dictionary<Guid, string> { [CustomerA] = PhoneA, [CustomerB] = PhoneB });
+
+        Assert.Contains(Fa(PhoneA), text);
+        Assert.Contains(Fa(PhoneB), text);
+    }
+
+    // ── absent when not supplied ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The customer's own history. No lookup is supplied for them, so the line disappears —
+    /// they would otherwise be shown the shop's phone number on every row.
+    /// </summary>
+    [Fact]
+    public async Task WithoutALookup_NoCounterpartyLineAppears()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: CustomerA, seller: Admin)), 1, viewerUserId: CustomerA);
+
+        Assert.DoesNotContain("طرف معامله", text);
+    }
+
+    /// <summary>
+    /// A lookup that came back without this particular user — the Users service was
+    /// unreachable for one id — must drop the line, not print an empty label or throw. A
+    /// missing phone number costs one line, not the whole list.
+    /// </summary>
+    [Fact]
+    public async Task AnUnresolvedCounterparty_IsOmittedRatherThanShownBlank()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA)), 1, Admin,
+            counterpartyPhones: new Dictionary<Guid, string>());
+
+        Assert.DoesNotContain("طرف معامله", text);
+    }
+
+    [Fact]
+    public async Task ABlankPhoneNumber_IsTreatedAsUnresolved()
+    {
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA)), 1, Admin,
+            counterpartyPhones: new Dictionary<Guid, string> { [CustomerA] = "   " });
+
+        Assert.DoesNotContain("طرف معامله", text);
+    }
+
+    /// <summary>
+    /// Adding the counterparty must not have disturbed the buy/sell labelling that
+    /// <see cref="TradeListSideTests"/> covers — the two live in the same loop.
+    /// </summary>
+    [Fact]
+    public async Task TheSideLabelStillReflectsTheViewer()
+    {
+        var phones = new Dictionary<Guid, string> { [CustomerA] = PhoneA };
+
+        var text = await TradeListHandler.BuildTradesListAsync(
+            Page(Trade(buyer: Admin, seller: CustomerA)), 1, Admin, phones);
+
+        Assert.Contains("🟢 خرید", text);   // the admin was the buyer here
+        Assert.Contains("پرداختی", text);
+    }
+}


### PR DESCRIPTION
Closes #74.

A single quote acceptance created **two** trades from **one** pair of orders. Found from a customer noticing their last trade listed twice — it was not a display fault.

> **The second trade never settled.** The wallet refused it (`Buyer locked IRT (76355.00) is less than required (20946431)`) because the first settlement had already consumed the pair's collateral — the guard from C-5 / #52. Matching failed; settlement held, and no money moved twice. The damage was a trade row that will never settle, a permanently-failed outbox message, and 76,355 IRT stranded locked, since released.
>
> That does not reduce the need for these fixes. Two matchers reaching one order pair is a defect regardless of whether the last line of defence catches the consequence; relying on it is not a design.

```
trade    | created                 | Quantity | QuoteQuantity | buyOrder | sellOrder
663C15AE | 2026-07-30 12:40:46.620 | 1.2345   | 20,946,431    | 8519536A | 7953A0DF
305F1374 | 2026-07-30 12:40:46.620 | 1.23     | 20,870,077    | 8519536A | 7953A0DF
```

Both orders were for 1.23 g. 2.4645 g was matched.

## Why nothing caught it

The check run after every manual session verifies **conservation** — that no money is created or destroyed — and it held exactly. What nothing was checking is whether a *particular* trade settled at all: trade and settlement counts had diverged by one (59 vs 58) and nothing compared them.

The new tests assert the missing property directly: the total quantity matched across an order pair may never exceed what was ordered.

## Three defects, three fixes

### (a) Round the quantity once, at entry

`Orders.Amount` and `RemainingAmount` are `decimal(18,2)`; `Trades.Quantity` is `decimal(18,8)`. A customer's 1.2345 was truncated to 1.23 on write while the in-memory order kept 1.2345.

`QuoteFillService` now rounds to the asset's declared precision (gold is 2 dp, matching the column) before creating either order, and `ExecuteAtomicMatchAsync` rounds its match quantity as well, so every caller gets one number through order, trade and settlement. The confirmation message already displayed the rounded figure, so 1.23 is what the customer agreed to.

### (b) Make `RemainingAmount` a concurrency token

Every UPDATE now carries `WHERE RemainingAmount = <the value read>`. A stale or racing write affects zero rows and throws; `DbUpdateConcurrencyException` is translated into a clear refusal and logged as a **warning**, because losing the race is the guard working.

A token rather than an `UPDLOCK` hint on purpose: EF enforces it for any provider, so it holds under SQLite in tests exactly as under SQL Server in production. Same approach as #42, where a primary key made "settled exactly once" structural rather than conventional.

The accompanying migration is **empty by design** — this changes how EF writes, not the schema — and is kept so the model snapshot stays in step.

**Also fixed the read it depends on.** This comment described a guarantee that did not exist:

```csharp
// 1. Re-fetch orders with lock to ensure they haven't changed
var currentBuyOrder = await _context.Orders.FirstOrDefaultAsync(o => o.Id == buyOrder.Id);
```

No lock, and no re-fetch: the same `DbContext` had created these orders, so EF identity resolution returned the tracked in-memory copy. The orders are now reloaded explicitly. (Third instance of a comment asserting an unimplemented guarantee, after #72 and this one — worth watching for.)

### (c) Stop the background engine matching dealer-mode symbols

A quote fill creates both orders, matches them fully and consumes them in one operation, so there is never resting liquidity for the loop to pair. Its only possible effect on a dealer symbol is to reach the pair the fill is already matching.

The semaphore added in #53 serialises the loop against itself; it does not cover `QuoteFillService`, which calls the repository directly. Removing the second matcher is smaller and surer than coordinating two.

## Every fix is load-bearing

Each was reverted individually and the corresponding test fails:

| reverted | test that fails |
|---|---|
| (a) rounding | `AMatchIsRoundedToTheAssetsPrecision` |
| (b) token | `WhenTheRowNoLongerMatchesWhatWeRead_TheMatchIsRefused` |
| (c) guard | `InDealerMode_TheOrderBookIsNeverConsulted` |

This mattered: an earlier version of the tests passed **with the token removed**, because the reload alone covers the sequential case. The token needed its own test for the window the reload cannot close — the row changing between the read and the write.

## Two test limitations, recorded rather than papered over

**The column truncation cannot be reproduced under SQLite**, which does not enforce decimal precision. The first version of that test asserted the row held 1.23 and failed, because under SQLite it holds 1.2345. It now asserts the rounding — provider-independent, and the thing that actually prevents the defect. The truncation itself is evidenced by the production rows above.

**The order-book query cannot run under SQLite either**: it orders by a decimal column, which SQLite rejects (`NotSupportedException: SQLite does not support expressions of type 'decimal' in ORDER BY clauses` — verified, not assumed). So (c) is asserted by whether the order book is *consulted*, in both directions. Without the OrderBook direction, a guard that disabled matching entirely would have passed and gone unnoticed until peer-to-peer trading opened.

## Result

**201 tests pass**, up from 190. Build clean.

## Not included

Trade `663C15AE` is still in the data. Customer `09037212111` was debited 20,946,431 IRT and credited 1.2345 g for it. Reversing it moves real money and is the shop owner's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
