### PR TITLE
docs+ci: correct the config claim from #80, and add the CI workflow (#71)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,72 @@
+# Builds and tests every pull request (issue #71).
+#
+# Until this existed nothing ran the test suite except a developer choosing to, so a pull
+# request that broke it merged green. That matters more here than usual: merges to main go
+# through `gh pr merge --admin`, which bypasses the required review, so this check is the
+# only gate left.
+#
+# Release, not Debug. Release is what a server runs and nothing was building it. `#if DEBUG`
+# blocks compile differently there — the TLS bypasses in #31 are exactly that shape — and a
+# Release build would have caught the Affiliate.Api startup crash (#72) class of problem
+# before it reached a running service.
+#
+# Deliberately not here: deployment. One server and two developers is better served by
+# `git pull` and a restart than by a pipeline, and a half-working deploy pipeline three weeks
+# before the science-park review would be a pure loss. Revisit after it.
+
+name: build-and-test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push supersedes the previous run on the same branch. Without this, a branch pushed
+# three times queues three full builds and the first two are already irrelevant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      # Restore is separate so a package-resolution failure is reported as its own step
+      # rather than buried in build output.
+      - name: Restore
+        run: dotnet restore TallaEgg.sln
+
+      - name: Build (Release)
+        run: dotnet build TallaEgg.sln --configuration Release --no-restore
+
+      # --no-build so this runs the assemblies the step above produced. Without it `dotnet
+      # test` would rebuild, and a Debug rebuild here would quietly defeat the point of
+      # building in Release.
+      #
+      # The suite needs no database and no configuration file: it runs against SQLite in
+      # memory and builds any configuration it needs in memory too. Verified, not assumed —
+      # the runner has no `config/appsettings.global.json`, so a test that read one would
+      # fail here rather than on someone's machine.
+      - name: Test (Release)
+        run: >
+          dotnet test src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+          --configuration Release
+          --no-build
+          --logger "trx;LogFileName=test-results.trx"
+          --results-directory ${{ github.workspace }}/test-results
+
+      - name: Upload test results
+        # Results are most useful precisely when the step above failed.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://private-user-images.githubusercontent.com/45781438/530709883-c2a1096b-5c
 | `src/TallaEgg` | Shared core/application/infrastructure libraries plus a legacy orchestration API |
 | `src/Wallet/Wallet.Tests` | The test suite for the whole platform (see [Testing](#testing)) |
 | `TelegramBot` | Telegram bot host, handlers, and typed API clients |
-| `config/appsettings.global.json` | Shared configuration consumed by every service — **never committed** |
+| `config/appsettings.global.json` | Shared configuration consumed by every service — currently tracked, and it should not be ([#33](https://github.com/MohKardan/TallaEgg/issues/33)) |
 | `docs/` | Architecture, operations, process, OKRs, and the business proposal |
 | `governance/` | Charter, bylaws, meeting notes, and `P-XXXX` proposals |
 | `scripts/`, `publishes/` | Helper scripts and deployment artefacts |
@@ -71,7 +71,13 @@ The platform supports two market modes per symbol, set in configuration:
 
 Every service loads `config/appsettings.global.json`, then flattens the section under `Services:` matching its own assembly name. There is no per-service `appsettings.json` to maintain.
 
-**This file is never committed** — it holds a live bot token. Create it from the template below.
+> ⚠️ **This file is currently tracked in git and contains a live bot token.** That is a known
+> defect, not the intended design — see [#33](https://github.com/MohKardan/TallaEgg/issues/33),
+> which covers rotating the token and moving the file out of source control before deployment.
+> Until that lands, treat the committed values as compromised: the repository is public, so
+> anyone can read them. Do not add further secrets to this file.
+
+Create your own copy from the template below.
 
 ```json
 {


### PR DESCRIPTION
﻿Correcting a claim I merged in #80 ten minutes earlier, and adding the CI workflow #71 asks for.

## The correction

#80 stated that `config/appsettings.global.json` is never committed. **It is committed.**

```
git ls-files config/appsettings.global.json   →  tracked
git check-ignore …                            →  not ignored
git show HEAD:… | grep TelegramBotToken       →  a real token
```

Sending that token to `getMe` returns **`@TallaEggLocalBot`** — it is the live token, not a placeholder. It has been in history since `80f952a`, across four commits, in a **public** repository.

I wrote that line from the project's stated rule rather than from the repository. It is exactly the failure the README pass was meant to remove — a document asserting a guarantee that nothing implements — and worse than the errors it replaced, because "never committed" reads as reassurance and would stop a reader from checking.

The section now says what is true, points at #33, and still tells a new developer to create their own copy. **No secret is added or removed here**; rotation is yours to do through BotFather and is deliberately deferred until just before deployment.

## The CI workflow (#71)

`.github/workflows/build-and-test.yml` — restore, build, test, upload results.

**Release, not Debug.** Release is what a server runs and nobody was building it. `#if DEBUG` blocks compile differently there — the TLS bypasses in #31 are that shape — and a Release build would have caught the Affiliate.Api Production startup crash (#72) class of problem before it reached a running service.

**Why it matters more here than usual:** merges to `main` go through `gh pr merge --admin`, which bypasses the required review. With review bypassed, this check is the only gate left.

The suite is worth guarding: 25 tests → **336**, much of it pinning defects that were expensive to find the first time (#42, #52, #74, #77). Several of those tests exist because the bug reached a live session first.

### The two things the issue said to check rather than assume

| Check | Result |
|---|---|
| No test reads `config/appsettings.global.json` | ✅ The only reference under `Wallet.Tests` is a *comment*; the test beside it builds config with `AddInMemoryCollection`. The runner has no such file, so a test that read one would fail in CI rather than on someone's machine. |
| Release build and Release test pass | ✅ Run locally exactly as the workflow runs them — **336 passed, 0 failed**. |

`--no-build` on the test step is load-bearing: without it `dotnet test` rebuilds, and a Debug rebuild would quietly undo the Release build above.

### Out of scope, deliberately

**Deployment.** One server and two developers is better served by `git pull` and a restart than by a pipeline, and a half-working deploy pipeline three weeks before the review would be a pure loss.

## Remaining for #71

Two acceptance criteria need action outside this PR:

- [ ] Verify a deliberately failing test fails the check — worth doing once this PR shows a green run.
- [ ] **Make the check required on `main`** in branch protection, so `--admin` cannot bypass it silently. That is a repository setting only you can change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
