### PR TITLE
DO NOT MERGE - verifying CI catches a failing test (#71)

### DIFF
--- a/src/Wallet/Wallet.Tests/UserHelpMatchesTheMenuTests.cs
+++ b/src/Wallet/Wallet.Tests/UserHelpMatchesTheMenuTests.cs
@@ -1,4 +1,4 @@
-using TallaEgg.TelegramBot.Infrastructure;
+﻿using TallaEgg.TelegramBot.Infrastructure;
 
 namespace Wallet.Tests;
 
@@ -33,7 +33,7 @@ public class UserHelpMatchesTheMenuTests
     [Fact]
     public void TheHelpNamesTheQuoteButton()
     {
-        Assert.True(Mentions(BotMsgs.MsgUserHelp, BotBtns.BtnSpotMarket),
+        Assert.True(Mentions(BotMsgs.MsgUserHelp, "DELIBERATE-CI-VERIFICATION-FAILURE"),
             $"help must name the quote button ({BotBtns.BtnSpotMarket})");
     }
 


### PR DESCRIPTION
Temporary. One assertion in `UserHelpMatchesTheMenuTests` is deliberately broken to confirm the `test` check turns red and blocks merge, which is the last unverified acceptance criterion on #71. Will be closed and the branch deleted once observed.