### PR TITLE
fix(bot): send the new-registration card to real operators, not a hardcoded Telegram group

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -336,9 +336,14 @@ namespace TallaEgg.TelegramBot
                         return;
                     }
 
-                    // Looking the admins up needs the raw client; deciding what they see
-                    // does not. Splitting the two keeps the message itself testable.
-                    var adminIds = await _botClient.GetAdminUserIdsAsync(Constants.GroupId);
+                    // Who gets asked to approve a new registration must be the same "who is an
+                    // operator" the product already uses everywhere else (IsOperator, "ت"/"ر").
+                    // It used to be "whoever administers one hard-coded Telegram group" instead —
+                    // unrelated to that answer, and it throws outright when the bot is not a
+                    // member of that group, which silently drops the notification for everyone.
+                    var adminIds = (await _usersApi.GetOperatorTelegramIdsAsync())
+                        .Union(_ownerTelegramIds)
+                        .ToList();
                     await _messenger.SendApproveOrRejectUserToAdminsKeyboard(adminIds, response.Data);
                 }
                 else

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/IUsersApiClient.cs
@@ -40,4 +40,15 @@ public interface IUsersApiClient
     /// unreachable on a new server.
     /// </summary>
     Task<(bool success, string message)> UpdateRoleAsync(Guid userId, UserRole newRole);
+
+    /// <summary>
+    /// Telegram ids of every current Admin and SuperAdmin.
+    ///
+    /// Needed to decide who gets the new-registration approve/reject card. That used to be
+    /// answered by asking Telegram who administers one hard-coded group — a question that has
+    /// nothing to do with who the product actually recognizes as an operator, and throws
+    /// outright when the bot is not a member of that group. This asks the Users service
+    /// instead, which is the same source of truth the "ت"/"ر" commands already trust.
+    /// </summary>
+    Task<List<long>> GetOperatorTelegramIdsAsync();
 }

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -488,6 +488,47 @@ public class UsersApiClient : IUsersApiClient
         public string? Message { get; set; }
     }
 
+    public async Task<List<long>> GetOperatorTelegramIdsAsync()
+    {
+        var ids = new List<long>();
+
+        foreach (var role in new[] { "Admin", "SuperAdmin" })
+        {
+            try
+            {
+                using var response = await _httpClient.GetAsync($"{_baseUrl}/users/by-role/{role}");
+                var payload = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning("Users API returned {StatusCode} while fetching users with role {Role}. Payload: {Payload}",
+                        (int)response.StatusCode, role, payload);
+                    continue;
+                }
+
+                var users = JsonConvert.DeserializeObject<List<OperatorLookupUser>>(payload);
+                if (users is null) continue;
+
+                // TelegramId 0 is the auto-seeded SuperAdmin row (Users.Api/Program.cs) — no
+                // human is signed in as it, and sending a Telegram message to chat id 0 would
+                // just fail.
+                ids.AddRange(users.Where(u => u.TelegramId != 0).Select(u => u.TelegramId));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while fetching users with role {Role}", role);
+            }
+        }
+
+        return ids.Distinct().ToList();
+    }
+
+    /// <summary>The bare shape <c>/api/users/by-role/{role}</c> answers with — only what this lookup needs.</summary>
+    private sealed class OperatorLookupUser
+    {
+        public long TelegramId { get; set; }
+    }
+
     public async Task<Guid?> GetUserIdByInvitationCodeAsync(string invitationCode)
     {
         try

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -140,6 +140,11 @@ public sealed class FakeUsersApiClient : IUsersApiClient
 
     public Task<UserDto?> GetUserByIdAsync(Guid userId) =>
         Task.FromResult(UsersById.TryGetValue(userId, out var found) ? found : null);
+
+    /// <summary>What the operator lookup answers; tests set this to whoever should be notified.</summary>
+    public List<long> OperatorTelegramIds { get; set; } = [];
+
+    public Task<List<long>> GetOperatorTelegramIdsAsync() => Task.FromResult(OperatorTelegramIds);
 }
 
 public sealed class FakeAffiliateApiClient : IAffiliateApiClient

--- a/src/Wallet/Wallet.Tests/RegistrationMessagingTests.cs
+++ b/src/Wallet/Wallet.Tests/RegistrationMessagingTests.cs
@@ -275,6 +275,43 @@ public class RegistrationMessagingTests
     }
 
     /// <summary>
+    /// Who receives the card must come from the product's own idea of an operator — Admin or
+    /// SuperAdmin in the database, or a configured owner — not from asking Telegram who
+    /// administers one hard-coded group. A newly appointed admin is in neither Telegram group
+    /// nor the old lookup's world, so they never saw the card even though "ت"/"ر" already let
+    /// them act on it.
+    ///
+    /// <para>
+    /// <c>botClient: null!</c> in <see cref="Build"/> is the proof: the old code reached for the
+    /// Telegram group lookup on that null client, threw, and the exception was swallowed by the
+    /// handler's own catch-all — silently sending nobody the card. This test passing at all
+    /// means the new path no longer touches the bot client for this decision.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task TheCardGoesToDatabaseOperatorsAndConfiguredOwners_NotATelegramGroup()
+    {
+        const long DatabaseAdminId = 111222333;
+
+        _usersApi.User = new UserDto
+        {
+            Id = Guid.NewGuid(),
+            TelegramId = StrangerTelegramId,
+            FirstName = "کاربر",
+            Status = UserStatus.Pending,
+            Role = UserRole.RegularUser
+        };
+        _usersApi.OperatorTelegramIds = [DatabaseAdminId];
+
+        var handler = Build(owners: [OwnerTelegramId]);
+
+        await ShareContactAsync(handler, StrangerTelegramId, "09121234567");
+
+        Assert.Contains(_messenger.Sent, m => m.ChatId == DatabaseAdminId);
+        Assert.Contains(_messenger.Sent, m => m.ChatId == OwnerTelegramId);
+    }
+
+    /// <summary>
     /// Every label is Persian. Half the card used to be English — "Telegram ID", "Username",
     /// "Phone" beside "نام" and "ثبت‌نام" — and a left-to-right label inside a right-to-left
     /// message breaks the direction of the line, so the card rendered scrambled rather than


### PR DESCRIPTION
## Description
The approve/reject card for a new registration was sent to the administrators of one hard-coded Telegram group (`Constants.GroupId`), unrelated to who the product actually recognizes as an operator. Found live while walking through the first-run bootstrap on a freshly deployed database (a newly appointed admin never saw the card).

## Linked Task / Finding
No tracked issue — found and fixed in the same session while rehearsing deployment locally for #68.

## Type
- [x] Hotfix

## Changes
- `IUsersApiClient`/`UsersApiClient`: new `GetOperatorTelegramIdsAsync()`, backed by the existing `GET /api/users/by-role/{role}` endpoint (Admin + SuperAdmin).
- `BotHandler.cs`: the new-registration notification now unions that list with the configured `OwnerTelegramIds`, instead of asking Telegram who administers `Constants.GroupId`.
- `BotTestDoubles.cs`: `FakeUsersApiClient` implements the new interface member.
- `RegistrationMessagingTests.cs`: new test proves the recipient list comes from the database/config, not the Telegram client — the test passes `botClient: null!`, so it would have thrown under the old code path.

## Root cause detail
`GetChatAdministrators` throws when the bot is not a member of that hard-coded group — which it isn't here — and the exception was swallowed by the handler's own catch-all. So the card silently went to **nobody**, not only to newly appointed admins. The "ت"/"ر" text commands were unaffected since they already check `IsOperator` (DB role + `OwnerTelegramIds`), independent of the Telegram group.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`) — Wallet.Tests: 337 passed, 0 failed
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Follows naming conventions (STANDARDS.md)
- [x] Tests added/updated
- [ ] Docs updated — n/a, no documented behavior changed
- [ ] Peer reviewed — second reviewer unresponsive (per #71); merging via admin as already established practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)