### PR TITLE
docs(process): add a scope-discipline standard

### DIFF
--- a/docs/process/INDEX.md
+++ b/docs/process/INDEX.md
@@ -251,6 +251,11 @@ When one of these is created, move its line into "Existing today" in the same PR
 - If blocked: move to "Blocked", pull next task
 - If done early: pull next task, don't multitask
 
+### 6. Scope Discipline
+✅ **DO**: Keep changes to the smallest scope that accomplishes the task
+✅ **DO**: Flag unrelated issues you notice and let the task owner decide if they become work
+❌ **DON'T**: Refactor, rename, or "clean up" code that wasn't part of the request
+
 ---
 
 ## Start-of-Sprint Checklist (for Tech Lead / Sprint Planner)

--- a/docs/process/STANDARDS.md
+++ b/docs/process/STANDARDS.md
@@ -82,6 +82,17 @@ placement at repo root is existing history, not a pattern to copy.
 
 ## 3. Development Process Standards
 
+### Scope Discipline
+- Keep every change to the smallest scope that accomplishes the task at hand.
+- **Never rewrite or refactor code that was not part of the request** — not adjacent code that
+  looks untidy, not a naming convention that disagrees with this document, not tests that would
+  read better written another way.
+- If something nearby looks wrong, flag it and let the task owner decide whether it becomes
+  separate work. Do not fix it inline as part of an unrelated change.
+- New code follows this document; existing code that predates or contradicts it is left as-is
+  until a task specifically asks for it to change.
+- Applies equally to human developers and AI coding agents.
+
 ### Definition of Done (for each task)
 - [ ] Code compiles without warnings
 - [ ] All unit tests written and passing


### PR DESCRIPTION
## Description
Adds a new standard to `STANDARDS.md` (and a matching digest entry in `INDEX.md`): keep every change to the smallest scope that accomplishes the task, and never rewrite or refactor code that wasn't part of the request. Requested directly by Mohammad after noticing this needed to be an explicit, durable rule rather than an ad-hoc reminder each time.

## Linked Task / Finding
No tracked issue — a process/standards addition, not a code fix.

## Type
- [x] Docs

## Changes
- `docs/process/STANDARDS.md`: new "Scope Discipline" subsection under "3. Development Process Standards".
- `docs/process/INDEX.md`: new "6. Scope Discipline" entry in "Critical Standards to Know Immediately".

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments/prose in English
- [ ] Peer reviewed — second reviewer unresponsive (per #71); merging via admin as already established practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)