### PR TITLE
[Fix][High] Fail fast on missing connection strings - #68

### DIFF
--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -44,8 +44,7 @@ if (urls is { Length: > 0 })
 
 // تنظیم اتصال به دیتابیس SQL Server
 builder.Services.AddDbContext<AffiliateDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("AffiliateDb") ??
-        "Server=localhost;Database=TallaEggAffiliate;Trusted_Connection=True;TrustServerCertificate=True;",
+    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "AffiliateDb"),
         b => b.MigrationsAssembly("Affiliate.Api")));
 
 // فقط در production محافظت فعال شود

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -56,8 +56,7 @@ if (urls is { Length: > 0 })
 
 // تنظیم اتصال به دیتابیس SQL Server
 builder.Services.AddDbContext<OrdersDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("OrdersDb") ??
-        "Server=localhost;Database=TallaEggOrders;Trusted_Connection=True;TrustServerCertificate=True;",
+    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
         b => b.MigrationsAssembly("Orders.Infrastructure"))
     .LogTo(Console.WriteLine, LogLevel.None)); // Disable all EF Core logging
 

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -7,6 +7,7 @@ using Orders.Application;
 using Orders.Core;
 using Orders.Infrastructure;
 using System.Text.Json;
+using TallaEgg.Core;
 using TallaEgg.Core.Models;
 using Users.Application;
 using Users.Core;
@@ -47,8 +48,7 @@ if (urls is { Length: > 0 })
 
 // تنظیم اتصال به دیتابیس SQL Server (در appsettings.json هم می‌توان قرار داد)
 builder.Services.AddDbContext<OrdersDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("OrdersDb") ??
-        "Server=localhost;Database=TallaEggOrders;Trusted_Connection=True;TrustServerCertificate=True;",
+    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
         b => b.MigrationsAssembly("TallaEgg.Api")));
 
 // تنظیم اتصال به دیتابیس اصلی TallaEgg

--- a/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
+++ b/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Configuration;
+
+namespace TallaEgg.Core;
+
+/// <summary>
+/// Reads configuration values that a service cannot start without, and fails loudly when one
+/// is missing.
+/// </summary>
+public static class ConfigurationGuard
+{
+    /// <summary>The file every service reads its settings from, named in the failure message.</summary>
+    private const string SHARED_CONFIG_FILE_NAME = "appsettings.global.json";
+
+    /// <summary>
+    /// Returns the named connection string, or throws naming what is missing and where it belongs.
+    /// </summary>
+    /// <remarks>
+    /// Each service previously fell back to a hardcoded literal:
+    /// <code>
+    /// GetConnectionString("OrdersDb") ?? "Server=localhost;Database=TallaEggOrders;..."
+    /// </code>
+    /// That turns a configuration mistake into a connectivity error. A missing key, a renamed
+    /// key, or a config file the host cannot locate all surfaced as
+    /// <c>"A network-related or instance-specific error has occurred... Server is not found"</c>,
+    /// which points at the database rather than at the setting that is actually absent — the
+    /// exact confusion recorded in issue #68.
+    ///
+    /// On a host that <i>does</i> answer at <c>localhost</c> it is worse than confusing: the
+    /// service starts, migrates, and reads and writes a different database than intended, with
+    /// nothing in the logs to say so.
+    ///
+    /// Throwing at startup keeps a misconfigured service from ever reaching a request.
+    /// </remarks>
+    /// <param name="configuration">Configuration the service was built with.</param>
+    /// <param name="name">Connection string name, e.g. <c>OrdersDb</c>.</param>
+    /// <exception cref="InvalidOperationException">The value is absent, empty, or whitespace.</exception>
+    public static string RequireConnectionString(IConfiguration configuration, string name)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var value = configuration.GetConnectionString(name);
+
+        // Whitespace counts as missing. A key present but blank is a half-finished edit, and
+        // letting it through only moves the failure to the first query.
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"Connection string '{name}' is missing. Add it under \"ConnectionStrings\" in " +
+                $"{SHARED_CONFIG_FILE_NAME}. The service will not start without it.");
+        }
+
+        return value;
+    }
+}

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -54,8 +54,7 @@ if (urls is { Length: > 0 })
 
 // تنظیم اتصال به دیتابیس SQL Server
 builder.Services.AddDbContext<UsersDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("UsersDb") ??
-        "Server=localhost;Database=TallaEggUsers;Trusted_Connection=True;TrustServerCertificate=True;",
+    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "UsersDb"),
         b => b.MigrationsAssembly("Users.Api")));
 
 // فقط در production محافظت فعال شود

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -59,8 +59,7 @@ builder.Host.UseSerilog();
 
 // تنظیم اتصال به دیتابیس SQL Server
 builder.Services.AddDbContext<WalletDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("WalletDb") ??
-        "Server=localhost;Database=TallaEggWallet;Trusted_Connection=True;TrustServerCertificate=True;",
+    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "WalletDb"),
         b => b.MigrationsAssembly("Wallet.Api")));
 
 

--- a/src/Wallet/Wallet.Tests/ConfigurationGuardTests.cs
+++ b/src/Wallet/Wallet.Tests/ConfigurationGuardTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Configuration;
+using TallaEgg.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Connection strings must be present, not defaulted (issue #68).
+///
+/// <para>
+/// All five services used to read the connection string with
+/// <c>GetConnectionString("…") ?? "Server=localhost;…"</c>. On a server where the shared
+/// configuration file was missing the key, every service silently started against a local
+/// SQL Server instead of refusing to run — so the failure surfaced far from its cause,
+/// as an empty or wrong database rather than as a configuration error.
+/// </para>
+///
+/// <para>
+/// These tests pin the replacement: a missing or blank value stops startup with a message
+/// that names both the key and the file to edit.
+/// </para>
+/// </summary>
+public class ConfigurationGuardTests
+{
+    private static IConfiguration Configuration(params (string Key, string? Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(s => s.Key, s => s.Value))
+            .Build();
+
+    /// <summary>The behaviour when configuration is correct is unchanged: the value comes back as-is.</summary>
+    [Fact]
+    public void RequireConnectionString_WhenTheKeyIsPresent_ReturnsTheValue()
+    {
+        var configuration = Configuration(("ConnectionStrings:OrdersDb", "Server=db;Database=X;"));
+
+        var value = ConfigurationGuard.RequireConnectionString(configuration, "OrdersDb");
+
+        Assert.Equal("Server=db;Database=X;", value);
+    }
+
+    /// <summary>The case that used to fall back to localhost.</summary>
+    [Fact]
+    public void RequireConnectionString_WhenTheKeyIsAbsent_Throws()
+    {
+        var configuration = Configuration(("ConnectionStrings:WalletDb", "Server=db;Database=X;"));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireConnectionString(configuration, "OrdersDb"));
+    }
+
+    /// <summary>
+    /// A present-but-blank key is a half-finished edit, not a configured value. Letting it
+    /// through would only move the failure to the first query.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RequireConnectionString_WhenTheValueIsBlank_Throws(string value)
+    {
+        var configuration = Configuration(("ConnectionStrings:OrdersDb", value));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireConnectionString(configuration, "OrdersDb"));
+    }
+
+    /// <summary>
+    /// The message has to be actionable on a server with no debugger attached: which key,
+    /// and which file it belongs in.
+    /// </summary>
+    [Fact]
+    public void RequireConnectionString_WhenTheKeyIsAbsent_TheMessageNamesTheKeyAndTheFile()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireConnectionString(Configuration(), "OrdersDb"));
+
+        Assert.Contains("OrdersDb", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("appsettings.global.json", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
**Branch Name**: `fix/fail-fast-on-missing-connection-strings`
**Linked Issue**: #68 (partial — the part that needs no target server)

---

## Description

All five services fell back to a hardcoded `Server=localhost;…` connection string when the shared configuration file did not supply one. A deployment missing the key therefore started successfully against a local SQL Server rather than failing, and the mistake surfaced later as an empty or wrong database. This replaces the fallback with a startup check that names the missing key and the file to fix.

---

## Type of Change

- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

- Added `TallaEgg.Core.ConfigurationGuard.RequireConnectionString(IConfiguration, string)` — returns the value, or throws `InvalidOperationException` naming the key and `appsettings.global.json`
- Replaced the `?? "Server=localhost;…"` fallback at all five call sites, one line each:
  - `src/User/Users.Api/Program.cs` (`UsersDb`)
  - `src/Wallet/Wallet.Api/Program.cs` (`WalletDb`)
  - `src/Order/Orders.Api/Program.cs` (`OrdersDb`)
  - `src/Affiliate/Affiliate.Api/Program.cs` (`AffiliateDb`)
  - `src/TallaEgg/TallaEgg.Api/Program.cs` (`OrdersDb`)
- Added `src/Wallet/Wallet.Tests/ConfigurationGuardTests.cs`

Whitespace counts as missing. A key present but blank is a half-finished edit, and letting it through only moves the failure to the first query.

### What does not change

No connection string, no configuration value, no business logic, and no behaviour when configuration is correct. `Trusted_Connection` is untouched. The only commented-out fallback that remains (`TallaEgg.Api/Program.cs`, the disabled `TallaEggDb` context) was already dead code and is left alone.

---

## Testing Completed

### Unit Tests

- [x] New unit tests written
- [x] All unit tests pass (`dotnet test`)

```
Passed!  - Failed: 0, Passed: 342, Skipped: 0, Total: 342 - Wallet.Tests.dll (net9.0)
```

Five new cases in `ConfigurationGuardTests`:

- key present → the value is returned unchanged
- key absent → throws
- value `""` and value `"   "` → throws
- message names both the key and `appsettings.global.json`

### Environment

- [x] Tested locally on Windows
- [ ] Tested on staging environment — no staging environment exists yet

`Orders.Api` reaches `TallaEgg.Core` only transitively (via `Orders.Application`). Verified by building the solution rather than assumed; `dotnet build TallaEgg.sln` succeeds.

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages — the exception names the key, never its value, so a connection string with credentials cannot reach a log through this path
- [x] `.gitignore` blocks sensitive files — unchanged by this PR; note that `config/appsettings.global.json` is still tracked, which is #33's scope, not this one
- [x] Code compiles without new warnings

---

## Code Quality

- [x] Code follows naming conventions (`STANDARDS.md`) — `SHARED_CONFIG_FILE_NAME` in `UPPER_SNAKE_CASE`, new tests named `Method_Scenario_ExpectedResult`
- [x] Comments are in English and explain the "why", not the "what"
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added

---

## Breaking Changes?

- [ ] No breaking changes
- [x] Breaking changes (see details below)

Breaking only for a deployment that was relying on the silent localhost fallback — which is the defect. Such a service now refuses to start instead of writing to the wrong database. Every developer machine that already has the keys in `config/appsettings.global.json` is unaffected.

---

## Deployment Notes

**Pre-Deployment**: no migrations, no new environment variables. Confirm `ConnectionStrings:UsersDb`, `WalletDb`, `OrdersDb`, and `AffiliateDb` exist and are non-blank in `config/appsettings.global.json`.

**Post-Deployment Verification**: each service starts. If one does not, the startup exception names the missing key.

**Rollback Plan**: revert the commit. The previous behaviour (silent localhost fallback) returns.

---

## Related Issues

- Partial fix for #68. The remaining part — pointing the services at a real database host — needs a target server and stays open there.

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description clearly explains "why" and "what"
- [x] All tests pass locally and on CI
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data in code
- [x] Commit messages are clear
- [x] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
