### PR TITLE
[Feature][Medium] Manual test-run workflow: stand up the whole stack on Actions

### DIFF
--- a/.github/workflows/manual-test-run.yml
+++ b/.github/workflows/manual-test-run.yml
@@ -1,0 +1,192 @@
+# Stands up the whole platform (Users/Wallet/Orders APIs + the Telegram bot) on a
+# GitHub-hosted runner so a human can manually test it over real Telegram.
+#
+# Why this exists: the usual sandboxed dev container this repo is often built in has no
+# outbound access to api.telegram.org and no SQL Server, so the bot can never actually be
+# tested there. A GitHub-hosted runner has neither restriction and this repo is public, so
+# the run is free. It is a temporary test session, not a deployment: the database lives in
+# an ephemeral service container and everything stops when the job ends.
+#
+# Requires two repository secrets (Settings > Secrets and variables > Actions):
+#   TELEGRAM_BOT_TOKEN  - a bot token from @BotFather
+#   OWNER_TELEGRAM_ID   - your numeric Telegram user id (ask @userinfobot), so you're
+#                          auto-approved as Admin on /start
+# Optional secret:
+#   MSSQL_SA_PASSWORD   - falls back to a fixed dev-only password if unset
+
+name: manual-test-run
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: 'How long to keep the services running (minutes, max 300)'
+        required: false
+        default: '180'
+
+concurrency:
+  group: manual-test-run
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(inputs.duration_minutes) + 20 }}
+
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          MSSQL_SA_PASSWORD: ${{ secrets.MSSQL_SA_PASSWORD || 'DevOnly!Passw0rd' }}
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "sqlcmd -C -S localhost -U sa -P $MSSQL_SA_PASSWORD -Q 'SELECT 1' || /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P $MSSQL_SA_PASSWORD -Q 'SELECT 1' || /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -Q 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 15
+
+    steps:
+      - name: Guard duration input
+        env:
+          DURATION_MINUTES: ${{ inputs.duration_minutes }}
+        run: |
+          if [ "$DURATION_MINUTES" -gt 300 ]; then
+            echo "duration_minutes must be <= 300 (leaves headroom under GitHub's job time limit)."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Write config/appsettings.global.json
+        env:
+          SA_PASSWORD: ${{ secrets.MSSQL_SA_PASSWORD || 'DevOnly!Passw0rd' }}
+          BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          OWNER_ID: ${{ secrets.OWNER_TELEGRAM_ID }}
+        run: |
+          if [ -z "$BOT_TOKEN" ] || [ -z "$OWNER_ID" ]; then
+            echo "Missing TELEGRAM_BOT_TOKEN and/or OWNER_TELEGRAM_ID repository secrets."
+            exit 1
+          fi
+          cat > config/appsettings.global.json <<EOF
+          {
+            "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } },
+            "AllowedHosts": "*",
+            "ConnectionStrings": {
+              "UsersDb": "Server=localhost,1433;Database=TallaEggUsers;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True;",
+              "WalletDb": "Server=localhost,1433;Database=TallaEggWallet;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True;",
+              "OrdersDb": "Server=localhost,1433;Database=TallaEggOrders;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True;",
+              "AffiliateDb": "Server=localhost,1433;Database=TallaEggAffiliate;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True;"
+            },
+            "Services": {
+              "Users.Api": {
+                "Urls": [ "http://localhost:5136" ],
+                "WalletApiUrl": "http://localhost:60933/"
+              },
+              "Wallet.Api": {
+                "Urls": [ "http://localhost:60933" ]
+              },
+              "Orders.Api": {
+                "Urls": [ "http://localhost:5140" ],
+                "WalletApiUrl": "http://localhost:60933/api",
+                "Matching": {
+                  "RequireMarketMakerCounterparty": true,
+                  "MarketModes": { "MAUA/IRT": "Dealer" }
+                }
+              },
+              "TallaEgg.TelegramBot.Infrastructure": {
+                "Urls": [ "http://localhost:57546" ],
+                "OrderApiUrl": "http://localhost:5140/api",
+                "UsersApiUrl": "http://localhost:5136/api",
+                "AffiliateApiUrl": "http://localhost:60812/api",
+                "PricesApiUrl": "http://localhost:5140/api",
+                "WalletApiUrl": "http://localhost:60933/api",
+                "BotSettings": {
+                  "RequireReferralCode": false,
+                  "DefaultReferralCode": "admin",
+                  "OwnerTelegramIds": [ ${OWNER_ID} ]
+                },
+                "TelegramBotToken": "${BOT_TOKEN}"
+              }
+            },
+            "FeatureFlags": { "QuarantineStubEndpoints": true }
+          }
+          EOF
+
+      - name: Build (Release)
+        run: dotnet build TallaEgg.sln --configuration Release
+
+      - name: Start services
+        run: |
+          mkdir -p run-logs
+          start() {
+            name=$1; project=$2
+            nohup dotnet run --no-build --configuration Release --project "$project" \
+              > "run-logs/$name.log" 2>&1 &
+            echo $! > "run-logs/$name.pid"
+          }
+          start users src/User/Users.Api/Users.Api.csproj
+          start wallet src/Wallet/Wallet.Api/Wallet.Api.csproj
+          start orders src/Order/Orders.Api/Orders.Api.csproj
+          sleep 5
+          start bot TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+
+      - name: Wait for services to come up
+        run: |
+          check() {
+            name=$1; url=$2
+            for i in $(seq 1 30); do
+              if curl -sf "$url" -o /dev/null; then
+                echo "$name is up"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "$name did not come up in time"
+            echo "---- $name log (tail) ----"
+            tail -n 100 "run-logs/$name.log" || true
+            return 1
+          }
+          check users   http://localhost:5136/api-docs/index.html
+          check wallet  http://localhost:60933/api-docs/index.html
+          check orders  http://localhost:5140/api-docs/index.html
+          sleep 5
+          echo "---- bot log (tail, first check) ----"
+          tail -n 50 run-logs/bot.log || true
+
+      - name: Ready — ping your bot on Telegram now
+        env:
+          DURATION_MINUTES: ${{ inputs.duration_minutes }}
+        run: |
+          echo "All services are up. Swagger UIs (only reachable from inside this runner, not from your browser):"
+          echo "  Users:  http://localhost:5136/api-docs"
+          echo "  Wallet: http://localhost:60933/api-docs"
+          echo "  Orders: http://localhost:5140/api-docs"
+          echo ""
+          echo "Open Telegram and send /start to your bot now."
+          echo "Services will keep running for ${DURATION_MINUTES} more minutes."
+
+      - name: Keep alive for manual testing
+        env:
+          DURATION_MINUTES: ${{ inputs.duration_minutes }}
+        run: |
+          minutes=$DURATION_MINUTES
+          end=$((SECONDS + minutes * 60))
+          while [ $SECONDS -lt $end ]; do
+            sleep 60
+            remaining=$(( (end - SECONDS) / 60 ))
+            echo "[$(date -u +%H:%M:%S)] still running, ~${remaining}m left"
+          done
+
+      - name: Final logs
+        if: always()
+        run: |
+          for f in run-logs/*.log; do
+            echo "==== $f (last 80 lines) ===="
+            tail -n 80 "$f" || true
+          done

--- a/.github/workflows/manual-test-run.yml
+++ b/.github/workflows/manual-test-run.yml
@@ -155,9 +155,33 @@ jobs:
           check users   http://localhost:5136/api-docs/index.html
           check wallet  http://localhost:60933/api-docs/index.html
           check orders  http://localhost:5140/api-docs/index.html
-          sleep 5
-          echo "---- bot log (tail, first check) ----"
-          tail -n 50 run-logs/bot.log || true
+
+          # The bot has no HTTP endpoint worth polling, so wait on the log line it prints once
+          # long polling has started. Without this the job would sit idle for the full duration
+          # with a dead bot, and the person testing would only find out by getting no reply.
+          #
+          # It is slower to come up than the APIs: it runs a series of connectivity probes and
+          # a getMe call against api.telegram.org first, so allow several minutes.
+          for i in $(seq 1 90); do
+            if grep -q "listening for messages" run-logs/bot.log; then
+              echo "bot is up"
+              break
+            fi
+            # A wrong token or an unreachable Telegram fails in a way that never produces the
+            # ready line, so stop on those rather than waiting out the whole loop.
+            if grep -qE "Bot is valid: False|Unhandled exception|Application startup exception" run-logs/bot.log; then
+              echo "bot failed to start"
+              tail -n 100 run-logs/bot.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+          if ! grep -q "listening for messages" run-logs/bot.log; then
+            echo "bot did not come up in time"
+            tail -n 100 run-logs/bot.log
+            exit 1
+          fi
 
       - name: Ready — ping your bot on Telegram now
         env:


### PR DESCRIPTION
**Branch Name**: `feat/manual-test-run-workflow`
**Linked Issue**: none — supports the deployment work (#68, #69, #70) by making the stack runnable somewhere other than one laptop

---

## Description

Adds a manually-triggered workflow that stands up the whole platform — Users, Wallet, and Orders APIs plus the Telegram bot — on a GitHub-hosted runner, against a throwaway SQL Server, and keeps it alive for a configurable window so a human can test against the real bot on Telegram.

Today the only place the stack runs is a single developer machine, and the services do not survive the session that started them. This gives a second place to run it that needs no server and no local SQL Server.

The first commit here (`562fb26`) was written in an earlier session and left on an unnamed branch without a PR; it is brought in unchanged. The second commit is the fix described below.

---

## Type of Change

- [ ] Hotfix (urgent bug fix)
- [x] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

New file `.github/workflows/manual-test-run.yml`:

- `workflow_dispatch` only — never runs on push or PR
- takes `duration_minutes` (default 180, capped at 300)
- runs SQL Server 2022 as a service container; the databases are created by the migrations each service already runs at startup
- writes `config/appsettings.global.json` from repository secrets rather than using the file in the repo, so the runner never uses local connection strings
- starts the three APIs and the bot, waits for all four, then idles for the requested window
- prints the tail of every log at the end, including on failure

**The fix in this PR** (`cb62c6b`): the original waited on each API until it answered, but for the bot it only tailed the log and moved on. A bot that failed to start looked exactly like one that started — the job idled for the full duration, and the tester would have found out by sending a message and getting no reply. It now waits for the line the bot prints once long polling begins, and stops early on a rejected token or an unhandled startup exception, since neither ever produces that line.

---

## Testing Completed

- [x] YAML parses (`yaml.safe_load`)
- [x] The shell of the modified step passes `bash -n`
- [ ] The workflow has not been executed — it cannot run until the two secrets below exist

Three things that would have broken the workflow were checked against the code rather than assumed:

| Check | Result |
|---|---|
| Do the services create their own schema? | Yes — all four call `MigrateAsync()` at startup, so an empty SQL Server is fine |
| Would Production auth block the health check? | No — every `launchSettings.json` sets `Development`, and `dotnet run` applies it |
| Does `/api-docs` exist? | Yes — `RoutePrefix = "api-docs"` in all three APIs |

---

## Required before this can run

Two repository secrets (`Settings → Secrets and variables → Actions`):

- `TELEGRAM_BOT_TOKEN`
- `OWNER_TELEGRAM_ID` — the numeric Telegram user id that gets auto-approved as Admin

Optional: `MSSQL_SA_PASSWORD`, which otherwise falls back to a fixed value used only inside the ephemeral container.

Without them the workflow stops at the first step with a clear message rather than starting anything.

---

## Security Checklist

- [x] No hardcoded secrets — the token and owner id come from repository secrets, and GitHub masks them in the public logs
- [x] No sensitive data in logs — the config file is written with a heredoc, never echoed
- [x] `workflow_dispatch` only, so only someone with write access can start a run

Worth stating plainly: putting the bot token in a repository secret does not make it secret while the same token sits in `config/appsettings.global.json` in this public repo. That is #33, not this PR, and this workflow does not make it worse — but it does not fix it either.

---

## Code Quality

- [x] Comments are in English and explain the "why", not the "what"
- [x] No unnecessary dependencies added

---

## Breaking Changes?

- [x] No breaking changes

Nothing existing runs this workflow. `build-and-test.yml` is untouched and remains the required check.

---

## Deployment Notes

Not a deployment. The database lives in a service container and everything stops when the job ends. No state survives a run.

**Rollback Plan**: delete the workflow file.

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description clearly explains "why" and "what"
- [x] All tests pass locally and on CI
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data in code
- [x] Commit messages are clear
- [x] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
