### PR TITLE
[Fix][High] manual-test-run never parsed: GitHub expressions have no arithmetic

### DIFF
--- a/.github/workflows/manual-test-run.yml
+++ b/.github/workflows/manual-test-run.yml
@@ -31,7 +31,12 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(inputs.duration_minutes) + 20 }}
+    # A constant, not derived from duration_minutes: GitHub's expression language has no
+    # arithmetic operators, so `fromJSON(inputs.duration_minutes) + 20` fails to parse and
+    # takes the whole file down with it. 320 = the 300-minute input cap plus headroom for
+    # build and startup. A shorter run simply ends when its keep-alive loop finishes; this
+    # value only caps a job that hangs.
+    timeout-minutes: 320
 
     services:
       sqlserver:


### PR DESCRIPTION
**Branch Name**: `fix/manual-test-run-invalid-timeout-expression`
**Linked Issue**: follow-up to #87

---

## Description

`manual-test-run.yml` could never run. `timeout-minutes` was written as `${{ fromJSON(inputs.duration_minutes) + 20 }}`, and GitHub's expression language has no arithmetic operators — comparison and logical operators only. A workflow file that fails to parse fails entirely, so dispatching it returned HTTP 422 and every push recorded a 0-second failed run.

---

## Type of Change

- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

- `timeout-minutes` is now the constant `320` — the 300-minute input cap plus headroom for build and startup
- A comment records why it is a constant, so nobody reintroduces the expression

Nothing is lost by fixing it this way. A shorter run ends when its keep-alive loop finishes; `timeout-minutes` only caps a job that hangs.

Every other `${{ }}` in the file was re-checked: all of them use property access or `||`, both supported.

---

## Testing Completed

- [x] Dispatched from this branch with `duration_minutes=5` — accepted, where the same call against `main` returned HTTP 422
- [x] Run observed to completion (see the run linked in the PR conversation)

### How this got past review

The file was validated by parsing it as YAML, and it *is* valid YAML. The defect is in GitHub's expression language, which a YAML parser does not evaluate — the string `${{ ... + ... }}` is just a scalar to it. Parsing YAML is not the same as validating a workflow; the only checks that would have caught this are `actionlint` or an actual dispatch.

---

## Security Checklist

- [x] No hardcoded secrets
- [x] No sensitive data in logs
- [x] Code compiles without warnings

---

## Breaking Changes?

- [x] No breaking changes — the workflow never successfully ran, so there is no prior behaviour to break

---

## Deployment Notes

None. Workflow-only change.

**Rollback Plan**: revert the commit; the workflow returns to being unrunnable.

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description clearly explains "why" and "what"
- [x] All tests pass locally and on CI
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data in code
- [x] Commit messages are clear
- [x] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
