### PR TITLE
feat(orders): automated quote publishing with a fallback price chain

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -281,6 +281,18 @@ namespace TallaEgg.TelegramBot
                 return true;
             }
 
+            if (msgText.StartsWith("اسپرد "))
+            {
+                await HandleAutoQuoteSpreadCommandAsync(chatId, msgText, user);
+                return true;
+            }
+
+            if (msgText.StartsWith("اتومات "))
+            {
+                await HandleAutoQuoteToggleCommandAsync(chatId, msgText, user);
+                return true;
+            }
+
             //دستور ثبت قیمت جفتی برای ادمین
             // Handle price pair format: buyPrice-sellPrice (e.g., 8523690-8529630)
             var pricePairRegex = new Regex(@"^(\d+)-(\d+)$", RegexOptions.Compiled);
@@ -557,6 +569,58 @@ namespace TallaEgg.TelegramBot
             await _messenger.SendAsync(telegramUserId, BotMsgs.MsgUserRejected);
             await _telegramLogger.Notif<Message>($"کاربر رد شد \n userId : {telegramUserId} adminId : {adminTgId}", originalMsg);
 
+        }
+
+        /// <summary>
+        /// <c>اسپرد [درصد]</c> — sets the spread the automatic quote publisher applies around
+        /// the fetched gold price for MAUA/IRT (issue #90). Does not itself turn auto-quote on;
+        /// see <see cref="HandleAutoQuoteToggleCommandAsync"/>.
+        /// </summary>
+        private async Task HandleAutoQuoteSpreadCommandAsync(long chatId, string msgText, UserDto actor)
+        {
+            var match = Regex.Match(msgText.Trim(), @"^اسپرد\s+(?<percent>[\d.]+)$", RegexOptions.Compiled);
+
+            if (!match.Success || !decimal.TryParse(match.Groups["percent"].Value, out var spreadPercent))
+            {
+                await _messenger.SendAsync(chatId, BotMsgs.MsgAutoQuoteSpreadFormatError);
+                return;
+            }
+
+            var (success, message) = await _orderApi.UpdateAutoQuoteSpreadAsync(
+                CurrenciesConstant.MAUA_IRT, spreadPercent, actor.Id);
+
+            await _messenger.SendAsync(chatId, success
+                ? string.Format(BotMsgs.MsgAutoQuoteSpreadUpdated, PersianFormat.Number(spreadPercent, decimals: 2))
+                : string.Format(BotMsgs.MsgAutoQuoteSpreadFailed, message));
+        }
+
+        /// <summary>
+        /// <c>اتومات روشن</c> / <c>اتومات خاموش</c> — turns automatic quote publishing on or
+        /// off for MAUA/IRT (issue #90). A manually published quote (<c>buyPrice-sellPrice</c>)
+        /// always overrides the automatic one regardless of this setting.
+        /// </summary>
+        private async Task HandleAutoQuoteToggleCommandAsync(long chatId, string msgText, UserDto actor)
+        {
+            var trimmed = msgText.Trim();
+            bool? enable = trimmed switch
+            {
+                "اتومات روشن" => true,
+                "اتومات خاموش" => false,
+                _ => null
+            };
+
+            if (enable is null)
+            {
+                await _messenger.SendAsync(chatId, BotMsgs.MsgAutoQuoteToggleFormatError);
+                return;
+            }
+
+            var (success, message) = await _orderApi.SetAutoQuoteEnabledAsync(
+                CurrenciesConstant.MAUA_IRT, enable.Value, actor.Id);
+
+            await _messenger.SendAsync(chatId, success
+                ? (enable.Value ? BotMsgs.MsgAutoQuoteEnabled : BotMsgs.MsgAutoQuoteDisabled)
+                : string.Format(BotMsgs.MsgAutoQuoteToggleFailed, message));
         }
 
         /// <summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
@@ -44,4 +44,15 @@ public interface IOrderApiClient
     Task<(bool success, string message, int cancelledCount)> CancelAllUserActiveOrdersAsync(Guid userId, string? reason = null);
     
     Task<ApiResponse<bool>> NotifyMatchingEngineAsync(NotifyMatchingEngineRequest request);
-} 
+
+    // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────────
+
+    /// <summary>تنظیمات فعلی مظنهٔ اتومات یک نماد.</summary>
+    Task<AutoQuoteSettingsDto?> GetAutoQuoteSettingsAsync(string symbol);
+
+    /// <summary>تغییر اسپرد مظنهٔ اتومات یک نماد.</summary>
+    Task<(bool success, string message)> UpdateAutoQuoteSpreadAsync(string symbol, decimal spreadPercent, Guid updatedByUserId);
+
+    /// <summary>روشن/خاموش کردن مظنهٔ اتومات یک نماد.</summary>
+    Task<(bool success, string message)> SetAutoQuoteEnabledAsync(string symbol, bool isEnabled, Guid updatedByUserId);
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -443,6 +443,71 @@ public class OrderApiClient : IOrderApiClient
         }
     }
 
+    // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────────
+
+    public async Task<AutoQuoteSettingsDto?> GetAutoQuoteSettingsAsync(string symbol)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{_baseUrl}/autoquote-settings/{symbol}");
+            if (!response.IsSuccessStatusCode) return null;
+
+            var body = await response.Content.ReadAsStringAsync();
+            var parsed = System.Text.Json.JsonSerializer.Deserialize<TallaEgg.Core.DTOs.ApiResponse<AutoQuoteSettingsDto>>(
+                body, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return parsed?.Data;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<(bool success, string message)> UpdateAutoQuoteSpreadAsync(string symbol, decimal spreadPercent, Guid updatedByUserId)
+    {
+        try
+        {
+            var payload = new { spreadPercent, updatedByUserId };
+            var content = new StringContent(
+                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync($"{_baseUrl}/autoquote-settings/{symbol}/spread", content);
+            var body = await response.Content.ReadAsStringAsync();
+            var message = TryReadMessage(body);
+
+            return response.IsSuccessStatusCode
+                ? (true, message ?? "اسپرد به‌روزرسانی شد.")
+                : (false, message ?? $"خطا در به‌روزرسانی اسپرد (کد {(int)response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+        }
+    }
+
+    public async Task<(bool success, string message)> SetAutoQuoteEnabledAsync(string symbol, bool isEnabled, Guid updatedByUserId)
+    {
+        try
+        {
+            var payload = new { isEnabled, updatedByUserId };
+            var content = new StringContent(
+                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync($"{_baseUrl}/autoquote-settings/{symbol}/enabled", content);
+            var body = await response.Content.ReadAsStringAsync();
+            var message = TryReadMessage(body);
+
+            return response.IsSuccessStatusCode
+                ? (true, message ?? "انجام شد.")
+                : (false, message ?? $"خطا (کد {(int)response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+        }
+    }
+
     /// <summary>مظنهٔ فعال یک نماد، یا null اگر منتشر نشده باشد.</summary>
     public async Task<QuoteDto?> GetActiveQuoteAsync(string symbol)
     {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -555,6 +555,31 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// <summary>{0} = دلیل خطا</summary>
         public const string MsgAdminPriceSubmitError = "❌ ثبت قیمت‌ها انجام نشد.\n\nدلیل: {0}";
 
+        // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────
+
+        public const string MsgAutoQuoteSpreadFormatError = "❌ قالب دستور درست نیست.\n\n" +
+                                                             "قالب صحیح:\n" +
+                                                             "اسپرد [درصد]\n\n" +
+                                                             "نمونه: اسپرد 0.5";
+
+        /// <summary>{0} = درصد اسپرد جدید</summary>
+        public const string MsgAutoQuoteSpreadUpdated = "✅ اسپرد مظنهٔ اتومات روی {0}٪ تنظیم شد.";
+
+        /// <summary>{0} = دلیل خطا</summary>
+        public const string MsgAutoQuoteSpreadFailed = "❌ تنظیم اسپرد انجام نشد.\n\nدلیل: {0}";
+
+        public const string MsgAutoQuoteToggleFormatError = "❌ قالب دستور درست نیست.\n\n" +
+                                                             "قالب صحیح:\n" +
+                                                             "اتومات روشن\n" +
+                                                             "اتومات خاموش";
+
+        public const string MsgAutoQuoteEnabled = "✅ مظنهٔ اتومات روشن شد.";
+
+        public const string MsgAutoQuoteDisabled = "⏸️ مظنهٔ اتومات خاموش شد.";
+
+        /// <summary>{0} = دلیل خطا</summary>
+        public const string MsgAutoQuoteToggleFailed = "❌ انجام نشد.\n\nدلیل: {0}";
+
         /// <summary>
         /// وقتی ربات بدون تغییر نسخه دوباره اجرا می‌شود (ری‌استارت معمولی).
         /// {0} = نسخه فعلی

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -123,6 +123,32 @@ builder.Services.AddScoped<Orders.Application.Services.QuoteFillService>();
 // Outbox processor: reliably delivers trade settlements to the Wallet service.
 builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();
 
+// Automated quote publishing (issue #90): fetches a live gold price and publishes a quote the
+// same way an admin does by hand. Off for a symbol until an admin turns it on via the bot.
+// A named HttpClient per provider rather than AddHttpClient<TInterface,TImplementation>: two
+// implementations share IGoldPriceProvider, and each needs its own API token/key, which is a
+// plain configuration string DI cannot inject as a constructor parameter on its own.
+builder.Services.AddHttpClient("NerkhGoldPriceProvider");
+builder.Services.AddHttpClient("BrsApiGoldPriceProvider");
+
+var nerkhApiToken = builder.Configuration["AutoQuote:NerkhApiToken"];
+var brsApiKey = builder.Configuration["AutoQuote:BrsApiKey"];
+
+builder.Services.AddScoped<Orders.Core.IAutoQuoteSettingsRepository, Orders.Infrastructure.AutoQuoteSettingsRepository>();
+
+builder.Services.AddScoped<Orders.Core.IGoldPriceProvider>(sp => new Orders.Infrastructure.Clients.NerkhGoldPriceProvider(
+    sp.GetRequiredService<IHttpClientFactory>().CreateClient("NerkhGoldPriceProvider"),
+    sp.GetRequiredService<ILogger<Orders.Infrastructure.Clients.NerkhGoldPriceProvider>>(),
+    nerkhApiToken));
+
+builder.Services.AddScoped<Orders.Core.IGoldPriceProvider>(sp => new Orders.Infrastructure.Clients.BrsApiGoldPriceProvider(
+    sp.GetRequiredService<IHttpClientFactory>().CreateClient("BrsApiGoldPriceProvider"),
+    sp.GetRequiredService<ILogger<Orders.Infrastructure.Clients.BrsApiGoldPriceProvider>>(),
+    brsApiKey));
+
+builder.Services.AddScoped<Orders.Application.Services.GoldPriceProviderChain>();
+builder.Services.AddHostedService<Orders.Application.Services.AutoQuotePublisherService>();
+
 // Configure JSON serialization
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -240,6 +266,59 @@ app.MapGet("/api/quotes/{Base}/{Quote}", async (string Base, string Quote, IQuot
         ? Results.NotFound(ApiResponse<QuoteDto>.Fail("مظنه‌ای منتشر نشده است."))
         : Results.Ok(ApiResponse<QuoteDto>.Ok(ToQuoteDto(quote)));
 });
+
+// ─────────────────────── مظنهٔ اتومات (issue #90) ───────────────────────
+
+/// <summary>تنظیمات فعلی مظنهٔ اتومات یک نماد.</summary>
+app.MapGet("/api/autoquote-settings/{Base}/{Quote}", async (string Base, string Quote, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
+{
+    var symbol = $"{Base}/{Quote}";
+    var settings = await settingsRepo.GetOrCreateAsync(symbol);
+
+    return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings)));
+});
+
+/// <summary>تغییر اسپرد مظنهٔ اتومات یک نماد.</summary>
+app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
+    string Base, string Quote, UpdateAutoQuoteSpreadRequest request, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
+{
+    var symbol = $"{Base}/{Quote}";
+
+    try
+    {
+        var settings = await settingsRepo.GetOrCreateAsync(symbol);
+        settings.UpdateSpread(request.SpreadPercent, request.UpdatedByUserId);
+        await settingsRepo.SaveAsync(settings);
+
+        return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings), "اسپرد به‌روزرسانی شد."));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ApiResponse<AutoQuoteSettingsDto>.Fail(ex.Message));
+    }
+});
+
+/// <summary>روشن/خاموش کردن مظنهٔ اتومات یک نماد.</summary>
+app.MapPost("/api/autoquote-settings/{Base}/{Quote}/enabled", async (
+    string Base, string Quote, SetAutoQuoteEnabledRequest request, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
+{
+    var symbol = $"{Base}/{Quote}";
+
+    var settings = await settingsRepo.GetOrCreateAsync(symbol);
+    settings.SetEnabled(request.IsEnabled, request.UpdatedByUserId);
+    await settingsRepo.SaveAsync(settings);
+
+    return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings),
+        request.IsEnabled ? "مظنهٔ اتومات روشن شد." : "مظنهٔ اتومات خاموش شد."));
+});
+
+static AutoQuoteSettingsDto ToAutoQuoteSettingsDto(Orders.Core.AutoQuoteSettings s) => new()
+{
+    Symbol = s.Symbol,
+    SpreadPercent = s.SpreadPercent,
+    IsEnabled = s.IsEnabled,
+    UpdatedAt = s.UpdatedAt
+};
 
 // نگاشت اینجاست و نه روی خود DTO: TallaEgg.Core به Orders.Core ارجاع ندارد و نباید
 // داشته باشد — DTO مشترک بین سرویس‌هاست و نباید به مدل دامنهٔ یکی از آن‌ها وابسته شود.

--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+using TallaEgg.Core;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// Periodically publishes a quote for MAUA/IRT from a live gold price, the same way an admin
+/// does by hand with the <c>buyPrice-sellPrice</c> command — this calls the same
+/// <see cref="Quote.Publish"/>, nothing about publishing itself changes (issue #90).
+///
+/// Only runs when an admin has explicitly turned it on: see <see cref="AutoQuoteSettings"/>.
+/// A manually published quote always overrides the automatic one on the next customer action,
+/// since only one quote per symbol is ever active — this service does not need to know or care
+/// whether the previous quote was manual or automatic.
+/// </summary>
+public class AutoQuotePublisherService : BackgroundService
+{
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(2);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AutoQuotePublisherService> _logger;
+
+    public AutoQuotePublisherService(IServiceScopeFactory scopeFactory, ILogger<AutoQuotePublisherService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AutoQuotePublisherService started (poll every {Minutes}m).", PollInterval.TotalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await PublishIfDueAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // A misconfiguration or a bug here must never take the rest of the shop down —
+                // manual quotes and trading are unrelated to this loop (same rule already
+                // established for #73).
+                _logger.LogError(ex, "Unexpected error in the auto-quote publishing loop.");
+            }
+
+            try
+            {
+                await Task.Delay(PollInterval, stoppingToken);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("AutoQuotePublisherService stopped.");
+    }
+
+    /// <summary>internal so the tick logic can be tested directly, without waiting on the poll loop.</summary>
+    internal async Task PublishIfDueAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var settingsRepo = scope.ServiceProvider.GetRequiredService<IAutoQuoteSettingsRepository>();
+
+        var settings = await settingsRepo.GetOrCreateAsync(Symbol);
+        if (!settings.IsEnabled) return;
+
+        var chain = scope.ServiceProvider.GetRequiredService<GoldPriceProviderChain>();
+        var mesghalPrice = await chain.GetMesghalPriceAsync(ct);
+
+        if (mesghalPrice is null)
+        {
+            _logger.LogWarning("Auto-quote for {Symbol} skipped this tick: no price source answered.", Symbol);
+            return;
+        }
+
+        // Quotes are stored per gram (Quote.cs), while the fetched price and the admin's manual
+        // command are both per mesghal — the same conversion the manual path already applies.
+        var perGram = mesghalPrice.Value / CurrenciesConstant.GramsPerMesghal;
+
+        var halfSpread = settings.SpreadPercent / 100m / 2m;
+        var buyPrice = decimal.Round(perGram * (1 - halfSpread), 2);
+        var sellPrice = decimal.Round(perGram * (1 + halfSpread), 2);
+
+        var quoteRepo = scope.ServiceProvider.GetRequiredService<IQuoteRepository>();
+
+        try
+        {
+            var quote = Quote.Publish(Symbol, buyPrice, sellPrice, settings.UpdatedByUserId);
+            await quoteRepo.PublishAsync(quote);
+
+            _logger.LogInformation(
+                "Auto-published quote for {Symbol}: buy {BuyPrice}, sell {SellPrice} (mesghal {Mesghal}, spread {Spread}%).",
+                Symbol, buyPrice, sellPrice, mesghalPrice, settings.SpreadPercent);
+        }
+        catch (ArgumentException ex)
+        {
+            // Quote.Publish's own validation (e.g. a zero/negative price from a source
+            // returning garbage) rejects the quote. Logged and skipped, not thrown further —
+            // the previous quote stays active until the next tick gets a sane price.
+            _logger.LogWarning(ex, "Auto-quote for {Symbol} rejected by Quote.Publish; keeping the previous quote.", Symbol);
+        }
+    }
+}

--- a/src/Order/Orders.Application/Services/GoldPriceProviderChain.cs
+++ b/src/Order/Orders.Application/Services/GoldPriceProviderChain.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// Tries each configured <see cref="IGoldPriceProvider"/> in order and returns the first price
+/// that answers. Adding a third or fourth source is registering one more provider in DI, in the
+/// order it should be tried — nothing here changes.
+/// </summary>
+public class GoldPriceProviderChain
+{
+    private readonly IReadOnlyList<IGoldPriceProvider> _providers;
+    private readonly ILogger<GoldPriceProviderChain> _logger;
+
+    public GoldPriceProviderChain(IEnumerable<IGoldPriceProvider> providers, ILogger<GoldPriceProviderChain> logger)
+    {
+        _providers = providers.ToList();
+        _logger = logger;
+    }
+
+    public async Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _providers)
+        {
+            var price = await provider.GetMesghalPriceAsync(cancellationToken);
+
+            if (price is > 0)
+            {
+                _logger.LogInformation("Gold price {Price} obtained from {Provider}.", price, provider.Name);
+                return price;
+            }
+
+            _logger.LogWarning("{Provider} did not answer; trying the next source.", provider.Name);
+        }
+
+        _logger.LogWarning("No gold price source answered ({Count} tried).", _providers.Count);
+        return null;
+    }
+}

--- a/src/Order/Orders.Core/AutoQuoteSettings.cs
+++ b/src/Order/Orders.Core/AutoQuoteSettings.cs
@@ -1,0 +1,77 @@
+namespace Orders.Core;
+
+/// <summary>
+/// The admin-controlled settings for automatic quote publishing on one symbol: the spread
+/// applied to the fetched reference price, and whether the feature is on at all.
+///
+/// <para>
+/// <b>Why a table and not configuration:</b> the spread has to be changeable from inside the
+/// bot, at runtime, without a redeploy — a configuration-file value is only read at startup
+/// (see <c>Program.cs</c>'s <c>ResolveSharedConfigPath</c>). <see cref="IsEnabled"/> doubles as
+/// the feature's on/off switch, so a bad reading or a misbehaving provider can be turned off
+/// from inside the product, the same way <c>FeatureFlags:QuarantineStubEndpoints</c> already
+/// works for a different feature.
+/// </para>
+/// </summary>
+public class AutoQuoteSettings
+{
+    public Guid Id { get; private set; }
+
+    /// <summary>Symbol this row governs — mirrors <see cref="Quote"/>'s per-symbol shape.</summary>
+    public string Symbol { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Percentage spread applied around the fetched reference price to derive buy/sell — e.g.
+    /// 0.5 means the shop buys 0.5% below and sells 0.5% above the reference.
+    /// </summary>
+    public decimal SpreadPercent { get; private set; }
+
+    /// <summary>Whether the background publisher is allowed to publish for this symbol at all.</summary>
+    public bool IsEnabled { get; private set; }
+
+    public Guid UpdatedByUserId { get; private set; }
+
+    public DateTime UpdatedAt { get; private set; }
+
+    /// <summary>EF Core needs a parameterless constructor.</summary>
+    private AutoQuoteSettings() { }
+
+    /// <summary>
+    /// The row a symbol gets the first time it is asked about. Starts disabled and at zero
+    /// spread on purpose — an admin must explicitly opt in and set a spread before the
+    /// background publisher ever posts a price, rather than the feature silently activating the
+    /// moment the row is created.
+    /// </summary>
+    public static AutoQuoteSettings CreateDefault(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+            throw new ArgumentException("نماد نمی‌تواند خالی باشد.", nameof(symbol));
+
+        return new AutoQuoteSettings
+        {
+            Id = Guid.NewGuid(),
+            Symbol = symbol.Trim().ToUpperInvariant(),
+            SpreadPercent = 0m,
+            IsEnabled = false,
+            UpdatedByUserId = Guid.Empty,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    public void UpdateSpread(decimal spreadPercent, Guid updatedByUserId)
+    {
+        if (spreadPercent < 0)
+            throw new ArgumentException("اسپرد نمی‌تواند منفی باشد.", nameof(spreadPercent));
+
+        SpreadPercent = spreadPercent;
+        UpdatedByUserId = updatedByUserId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void SetEnabled(bool isEnabled, Guid updatedByUserId)
+    {
+        IsEnabled = isEnabled;
+        UpdatedByUserId = updatedByUserId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Order/Orders.Core/IAutoQuoteSettingsRepository.cs
+++ b/src/Order/Orders.Core/IAutoQuoteSettingsRepository.cs
@@ -1,0 +1,12 @@
+namespace Orders.Core;
+
+public interface IAutoQuoteSettingsRepository
+{
+    /// <summary>
+    /// The settings row for a symbol, creating and persisting the disabled-by-default row the
+    /// first time it is asked for. The caller never has to special-case "no row yet".
+    /// </summary>
+    Task<AutoQuoteSettings> GetOrCreateAsync(string symbol);
+
+    Task SaveAsync(AutoQuoteSettings settings);
+}

--- a/src/Order/Orders.Core/IGoldPriceProvider.cs
+++ b/src/Order/Orders.Core/IGoldPriceProvider.cs
@@ -1,0 +1,21 @@
+namespace Orders.Core;
+
+/// <summary>
+/// A source of the current melted 18k gold ("آبشده") price, in Toman per mesghal — the same
+/// unit and product an admin already prices manually. Multiple implementations exist so
+/// <c>GoldPriceProviderChain</c> can fall back from one external service to another; adding a
+/// third or fourth source later is just one more class implementing this interface.
+/// </summary>
+public interface IGoldPriceProvider
+{
+    /// <summary>A short name for logging which provider answered or was skipped.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The current price in Toman per mesghal, or null if this provider could not answer
+    /// (network failure, invalid/missing token, unexpected response shape). Never throws —
+    /// a provider that cannot answer is reported by returning null, not by an exception, so the
+    /// chain can move to the next one without a try/catch at every call site.
+    /// </summary>
+    Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Order/Orders.Infrastructure/AutoQuoteSettingsRepository.cs
+++ b/src/Order/Orders.Infrastructure/AutoQuoteSettingsRepository.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Orders.Core;
+
+namespace Orders.Infrastructure;
+
+public class AutoQuoteSettingsRepository : IAutoQuoteSettingsRepository
+{
+    private readonly OrdersDbContext _context;
+
+    public AutoQuoteSettingsRepository(OrdersDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<AutoQuoteSettings> GetOrCreateAsync(string symbol)
+    {
+        var normalized = symbol.Trim().ToUpperInvariant();
+
+        var existing = await _context.AutoQuoteSettings
+            .FirstOrDefaultAsync(s => s.Symbol == normalized);
+
+        if (existing is not null)
+            return existing;
+
+        var created = AutoQuoteSettings.CreateDefault(normalized);
+        _context.AutoQuoteSettings.Add(created);
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // Two requests racing to create the first row for this symbol — the unique index
+            // on Symbol rejects the loser. Whoever lost reads what the winner actually wrote,
+            // rather than surfacing a database error for what is, from the caller's point of
+            // view, a successful "get or create".
+            _context.Entry(created).State = EntityState.Detached;
+            return await _context.AutoQuoteSettings.SingleAsync(s => s.Symbol == normalized);
+        }
+
+        return created;
+    }
+
+    public Task SaveAsync(AutoQuoteSettings settings) => _context.SaveChangesAsync();
+}

--- a/src/Order/Orders.Infrastructure/Clients/BrsApiGoldPriceProvider.cs
+++ b/src/Order/Orders.Infrastructure/Clients/BrsApiGoldPriceProvider.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Clients;
+
+/// <summary>
+/// brsapi.ir — melted 18k gold ("طلای آب‌شده نقدی", symbol <c>IR_GOLD_MELTED</c>) priced per
+/// mesghal, authenticated with an API key in the query string. Same product as nerkh.io's
+/// <c>MESGHAL</c> — the two were cross-checked live and agreed to within 0.1% before this was
+/// written, which is what makes them a meaningful fallback pair rather than two different
+/// instruments that happen to both be called "gold".
+/// </summary>
+public class BrsApiGoldPriceProvider : IGoldPriceProvider
+{
+    private const string BaseUrl = "https://Api.BrsApi.ir/Market/Gold_Currency.php";
+    private const string TargetSymbol = "IR_GOLD_MELTED";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<BrsApiGoldPriceProvider> _logger;
+    private readonly string? _apiKey;
+
+    public string Name => "brsapi.ir";
+
+    public BrsApiGoldPriceProvider(HttpClient httpClient, ILogger<BrsApiGoldPriceProvider> logger, string? apiKey)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _apiKey = apiKey;
+    }
+
+    public async Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("brsapi.ir skipped: no API key configured (Services:Orders.Api:AutoQuote:BrsApiKey).");
+            return null;
+        }
+
+        try
+        {
+            using var response = await _httpClient.GetAsync($"{BaseUrl}?key={_apiKey}", cancellationToken);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("brsapi.ir returned {StatusCode}: {Body}", (int)response.StatusCode, body);
+                return null;
+            }
+
+            using var doc = JsonDocument.Parse(body);
+
+            foreach (var item in doc.RootElement.GetProperty("gold").EnumerateArray())
+            {
+                if (item.GetProperty("symbol").GetString() != TargetSymbol) continue;
+
+                // brsapi returns price as a JSON number, unlike nerkh's string — each provider
+                // parses its own shape rather than forcing a shared response type onto two
+                // APIs that were never designed to agree.
+                return item.GetProperty("price").GetDecimal();
+            }
+
+            _logger.LogWarning("brsapi.ir response did not contain symbol {Symbol}.", TargetSymbol);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "brsapi.ir request failed.");
+            return null;
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/Clients/NerkhGoldPriceProvider.cs
+++ b/src/Order/Orders.Infrastructure/Clients/NerkhGoldPriceProvider.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Clients;
+
+/// <summary>
+/// nerkh.io — melted 18k gold ("آبشده") priced per mesghal (<c>MESGHAL</c>), authenticated with
+/// a bearer token. <c>https://docs.nerkh.io/</c> (OpenAPI spec) is the source of the endpoint
+/// shape below; verified live against the real token before this was written.
+/// </summary>
+public class NerkhGoldPriceProvider : IGoldPriceProvider
+{
+    private const string Endpoint = "https://api.nerkh.io/v2/prices/json/gold/MESGHAL";
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<NerkhGoldPriceProvider> _logger;
+    private readonly string? _apiToken;
+
+    public string Name => "nerkh.io";
+
+    public NerkhGoldPriceProvider(HttpClient httpClient, ILogger<NerkhGoldPriceProvider> logger, string? apiToken)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _apiToken = apiToken;
+    }
+
+    public async Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_apiToken))
+        {
+            _logger.LogWarning("nerkh.io skipped: no API token configured (Services:Orders.Api:AutoQuote:NerkhApiToken).");
+            return null;
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, Endpoint);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _apiToken);
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("nerkh.io returned {StatusCode}: {Body}", (int)response.StatusCode, body);
+                return null;
+            }
+
+            using var doc = JsonDocument.Parse(body);
+
+            // data.prices.MESGHAL.current — a string, not a number, in nerkh's own schema.
+            var current = doc.RootElement
+                .GetProperty("data")
+                .GetProperty("prices")
+                .GetProperty("MESGHAL")
+                .GetProperty("current")
+                .GetString();
+
+            if (!decimal.TryParse(current, out var price))
+            {
+                _logger.LogWarning("nerkh.io returned an unparsable price: {Current}", current);
+                return null;
+            }
+
+            return price;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "nerkh.io request failed.");
+            return null;
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/Configurations/AutoQuoteSettingsConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/AutoQuoteSettingsConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Configurations;
+
+public class AutoQuoteSettingsConfiguration : IEntityTypeConfiguration<AutoQuoteSettings>
+{
+    public void Configure(EntityTypeBuilder<AutoQuoteSettings> builder)
+    {
+        builder.ToTable("AutoQuoteSettings");
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Symbol).IsRequired().HasMaxLength(20);
+        builder.Property(s => s.SpreadPercent).IsRequired().HasPrecision(9, 4);
+        builder.Property(s => s.IsEnabled).IsRequired();
+        builder.Property(s => s.UpdatedByUserId).IsRequired();
+        builder.Property(s => s.UpdatedAt).IsRequired();
+
+        // One row per symbol — the same "get or create" repository method that keeps this true
+        // would otherwise let a race create two.
+        builder.HasIndex(s => s.Symbol).IsUnique();
+    }
+}

--- a/src/Order/Orders.Infrastructure/Migrations/20260807160614_AddAutoQuoteSettings.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260807160614_AddAutoQuoteSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807160614_AddAutoQuoteSettings")]
+    partial class AddAutoQuoteSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260807160614_AddAutoQuoteSettings.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260807160614_AddAutoQuoteSettings.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutoQuoteSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AutoQuoteSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Symbol = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    SpreadPercent = table.Column<decimal>(type: "decimal(9,4)", precision: 9, scale: 4, nullable: false),
+                    IsEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    UpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AutoQuoteSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AutoQuoteSettings_Symbol",
+                table: "AutoQuoteSettings",
+                column: "Symbol",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AutoQuoteSettings");
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/OrdersDbContext.cs
+++ b/src/Order/Orders.Infrastructure/OrdersDbContext.cs
@@ -15,11 +15,15 @@ public class OrdersDbContext : DbContext
     /// <summary>مظنه‌های منتشرشدهٔ ادمین؛ یک مظنهٔ فعال به‌ازای هر نماد (issue #48).</summary>
     public DbSet<Quote> Quotes => Set<Quote>();
 
+    /// <summary>اسپرد و روشن/خاموش بودن مظنهٔ اتومات برای هر نماد (issue #90).</summary>
+    public DbSet<AutoQuoteSettings> AutoQuoteSettings => Set<AutoQuoteSettings>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new OrderConfigurations());
         modelBuilder.ApplyConfiguration(new TradeConfiguration());
         modelBuilder.ApplyConfiguration(new OutboxMessageConfiguration());
         modelBuilder.ApplyConfiguration(new QuoteConfiguration());
+        modelBuilder.ApplyConfiguration(new AutoQuoteSettingsConfiguration());
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/AutoQuoteSettingsDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/AutoQuoteSettingsDto.cs
@@ -1,0 +1,15 @@
+namespace TallaEgg.Core.DTOs.Order
+{
+    /// <summary>Auto-quote settings for one symbol, for transfer between the Orders service and the bot (issue #90).</summary>
+    public class AutoQuoteSettingsDto
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public decimal SpreadPercent { get; set; }
+        public bool IsEnabled { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public record UpdateAutoQuoteSpreadRequest(decimal SpreadPercent, Guid UpdatedByUserId);
+
+    public record SetAutoQuoteEnabledRequest(bool IsEnabled, Guid UpdatedByUserId);
+}

--- a/src/Wallet/Wallet.Tests/AutoQuoteCommandTests.cs
+++ b/src/Wallet/Wallet.Tests/AutoQuoteCommandTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core;
+using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Enums.User;
+using TallaEgg.TelegramBot;
+using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Conversations;
+using Telegram.Bot.Types;
+using Wallet.Tests.Fakes;
+using User = Telegram.Bot.Types.User;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// <c>اسپرد [درصد]</c> and <c>اتومات روشن</c>/<c>اتومات خاموش</c> — the two admin commands that
+/// control automatic quote publishing from inside the bot (issue #90). These only need to prove
+/// the parse and the delegation to <see cref="TallaEgg.TelegramBot.Infrastructure.Clients.IOrderApiClient"/>;
+/// the actual settings logic is covered on the Orders side by <c>AutoQuoteSettingsTests</c> and
+/// <c>AutoQuotePublisherServiceTests</c>.
+/// </summary>
+public class AutoQuoteCommandTests
+{
+    private const long AdminTelegramId = 5001;
+    private static readonly Guid AdminId = Guid.NewGuid();
+
+    private readonly FakeBotMessenger _messenger = new();
+    private readonly FakeUsersApiClient _usersApi = new();
+    private readonly FakeOrderApiClient _orderApi = new();
+
+    private BotHandler Build(UserRole callerRole = UserRole.Admin)
+    {
+        _usersApi.User = new UserDto
+        {
+            Id = AdminId,
+            TelegramId = AdminTelegramId,
+            FirstName = "مدیر",
+            PhoneNumber = "09000000000",
+            Status = UserStatus.Approved,
+            Role = callerRole
+        };
+
+        return new BotHandler(
+            NullLogger<BotHandler>.Instance,
+            botClient: null!,
+            messenger: _messenger,
+            conversations: new InMemoryConversationStore(),
+            orderApi: _orderApi,
+            usersApi: _usersApi,
+            affiliateApi: new FakeAffiliateApiClient(),
+            walletApi: new StubWalletApiClient(),
+            telegramLogger: new SilentTelegramLogger(),
+            versionService: new FakeVersionService());
+    }
+
+    private Task SayAsync(BotHandler handler, string text) =>
+        handler.HandleMessageAsync(new Message
+        {
+            Text = text,
+            Chat = new Chat { Id = AdminTelegramId },
+            From = new User { Id = AdminTelegramId }
+        });
+
+    // ── اسپرد ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnAdminCanSetTheSpread()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اسپرد 0.5");
+
+        var update = Assert.Single(_orderApi.SpreadUpdates);
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, update.Symbol);
+        Assert.Equal(0.5m, update.SpreadPercent);
+        Assert.Equal(AdminId, update.UpdatedByUserId);
+    }
+
+    [Fact]
+    public async Task AMalformedSpreadCommandIsAnsweredWithTheFormat()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اسپرد بالا");
+
+        Assert.Empty(_orderApi.SpreadUpdates);
+        Assert.Contains(_messenger.Texts, t => t.Contains("قالب"));
+    }
+
+    [Fact]
+    public async Task AFailureSettingTheSpreadIsReportedWithItsReason()
+    {
+        var handler = Build();
+        _orderApi.SpreadUpdateResult = (false, "نماد یافت نشد.");
+
+        await SayAsync(handler, "اسپرد 0.5");
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("نماد یافت نشد."));
+    }
+
+    /// <summary>
+    /// The dispatch guard requires the trailing space, the same way <c>"ن "</c> does — so an
+    /// unrelated word that happens to start the same way falls through to the normal menu
+    /// instead of being answered with a format error.
+    /// </summary>
+    [Fact]
+    public async Task AWordStartingWithSpreadButNotFollowedBySpaceIsNotTreatedAsThisCommand()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اسپردهای بازار زیاده");
+
+        Assert.Empty(_orderApi.SpreadUpdates);
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("قالب دستور درست نیست"));
+    }
+
+    // ── اتومات ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnAdminCanTurnAutoQuoteOn()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اتومات روشن");
+
+        var toggle = Assert.Single(_orderApi.EnabledToggles);
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, toggle.Symbol);
+        Assert.True(toggle.IsEnabled);
+        Assert.Equal(AdminId, toggle.UpdatedByUserId);
+    }
+
+    [Fact]
+    public async Task AnAdminCanTurnAutoQuoteOff()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اتومات خاموش");
+
+        Assert.False(Assert.Single(_orderApi.EnabledToggles).IsEnabled);
+    }
+
+    [Fact]
+    public async Task AMalformedToggleCommandIsAnsweredWithTheFormat()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "اتومات شاید");
+
+        Assert.Empty(_orderApi.EnabledToggles);
+        Assert.Contains(_messenger.Texts, t => t.Contains("قالب"));
+    }
+
+    // ── who may run these ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnOrdinaryUserCannotChangeTheSpread()
+    {
+        var handler = Build(UserRole.RegularUser);
+
+        await SayAsync(handler, "اسپرد 0.5");
+
+        Assert.Empty(_orderApi.SpreadUpdates);
+    }
+
+    [Fact]
+    public async Task AnOrdinaryUserCannotToggleAutoQuote()
+    {
+        var handler = Build(UserRole.RegularUser);
+
+        await SayAsync(handler, "اتومات روشن");
+
+        Assert.Empty(_orderApi.EnabledToggles);
+    }
+}

--- a/src/Wallet/Wallet.Tests/AutoQuotePublisherServiceTests.cs
+++ b/src/Wallet/Wallet.Tests/AutoQuotePublisherServiceTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// One tick of the auto-quote publisher (issue #90): whether it publishes at all, and whether
+/// what it publishes is arithmetically what an admin would have typed by hand.
+///
+/// Runs against a real <see cref="OrdersDbContext"/> (SQLite in-memory), the same pattern
+/// <c>OutboxDueSelectionTests</c> uses for the other <c>BackgroundService</c> in this project —
+/// the interesting bugs here are in what actually gets read from and written to the database,
+/// not in isolated arithmetic.
+/// </summary>
+public class AutoQuotePublisherServiceTests : IDisposable
+{
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+    private readonly StubProvider _stubProvider = new();
+
+    public AutoQuotePublisherServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var setup = new OrdersDbContext(Options()))
+            setup.Database.EnsureCreated();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddScoped(_ => new OrdersDbContext(Options()));
+        services.AddScoped<IAutoQuoteSettingsRepository, AutoQuoteSettingsRepository>();
+        services.AddScoped<IQuoteRepository, QuoteRepository>();
+        services.AddScoped(_ => new GoldPriceProviderChain([_stubProvider], NullLogger<GoldPriceProviderChain>.Instance));
+        _provider = services.BuildServiceProvider();
+    }
+
+    private DbContextOptions<OrdersDbContext> Options() =>
+        new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    /// <summary>The one gold price source the test container knows about; mutable per test.</summary>
+    private sealed class StubProvider : IGoldPriceProvider
+    {
+        public string Name => "stub";
+        public decimal? Price { get; set; }
+        public Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Price);
+    }
+
+    private async Task RunTickAsync()
+    {
+        var service = new AutoQuotePublisherService(
+            _provider.GetRequiredService<IServiceScopeFactory>(), NullLogger<AutoQuotePublisherService>.Instance);
+
+        await service.PublishIfDueAsync(CancellationToken.None);
+    }
+
+    private async Task SeedSettingsAsync(bool isEnabled, decimal spreadPercent, Guid updatedBy)
+    {
+        using var db = new OrdersDbContext(Options());
+        var settings = AutoQuoteSettings.CreateDefault(Symbol);
+        settings.UpdateSpread(spreadPercent, updatedBy);
+        settings.SetEnabled(isEnabled, updatedBy);
+        db.AutoQuoteSettings.Add(settings);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<Quote?> ActiveQuoteAsync()
+    {
+        using var db = new OrdersDbContext(Options());
+        return await db.Quotes.Where(q => q.Symbol == Symbol && q.IsActive).SingleOrDefaultAsync();
+    }
+
+    [Fact]
+    public async Task PublishesNothing_WhenDisabled()
+    {
+        await SeedSettingsAsync(isEnabled: false, spreadPercent: 1m, Guid.NewGuid());
+        _stubProvider.Price = 80_000_000m;
+
+        await RunTickAsync();
+
+        Assert.Null(await ActiveQuoteAsync());
+    }
+
+    [Fact]
+    public async Task PublishesNothing_WhenNoProviderAnswers()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        _stubProvider.Price = null;
+
+        await RunTickAsync();
+
+        Assert.Null(await ActiveQuoteAsync());
+    }
+
+    /// <summary>
+    /// 4,331,800 Toman/mesghal ÷ 4.3318 g/mesghal is exactly 1,000,000 Toman/gram — chosen so
+    /// the spread math below has no rounding to reason about.
+    /// </summary>
+    [Fact]
+    public async Task PublishesTheSpreadAroundTheConvertedPerGramPrice()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        _stubProvider.Price = 4_331_800m;
+
+        await RunTickAsync();
+
+        var quote = await ActiveQuoteAsync();
+        Assert.NotNull(quote);
+        Assert.Equal(995_000m, quote!.BuyPrice);
+        Assert.Equal(1_005_000m, quote.SellPrice);
+    }
+
+    [Fact]
+    public async Task ThePublishedQuoteBelongsToWhoeverLastConfiguredAutoQuote()
+    {
+        var admin = Guid.NewGuid();
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 0.5m, admin);
+        _stubProvider.Price = 4_331_800m;
+
+        await RunTickAsync();
+
+        var quote = await ActiveQuoteAsync();
+        Assert.Equal(admin, quote!.PublishedByUserId);
+    }
+
+    [Fact]
+    public async Task ASecondTickReplacesTheFirstQuoteRatherThanAddingASecondActiveOne()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+
+        _stubProvider.Price = 4_331_800m;
+        await RunTickAsync();
+
+        _stubProvider.Price = 4_500_000m;
+        await RunTickAsync();
+
+        using var db = new OrdersDbContext(Options());
+        Assert.Single(db.Quotes.Where(q => q.Symbol == Symbol && q.IsActive));
+    }
+}

--- a/src/Wallet/Wallet.Tests/AutoQuoteSettingsTests.cs
+++ b/src/Wallet/Wallet.Tests/AutoQuoteSettingsTests.cs
@@ -1,0 +1,65 @@
+using Orders.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The admin-controlled row that decides whether the auto-quote publisher is allowed to run at
+/// all for a symbol, and what spread it applies (issue #90).
+/// </summary>
+public class AutoQuoteSettingsTests
+{
+    /// <summary>
+    /// Starts disabled and at zero spread. An admin must explicitly turn it on and set a
+    /// spread — the row's mere existence must never cause a quote to be published.
+    /// </summary>
+    [Fact]
+    public void CreateDefault_StartsDisabledAtZeroSpread()
+    {
+        var settings = AutoQuoteSettings.CreateDefault("MAUA/IRT");
+
+        Assert.False(settings.IsEnabled);
+        Assert.Equal(0m, settings.SpreadPercent);
+    }
+
+    [Fact]
+    public void CreateDefault_NormalizesTheSymbol()
+    {
+        var settings = AutoQuoteSettings.CreateDefault("maua/irt");
+
+        Assert.Equal("MAUA/IRT", settings.Symbol);
+    }
+
+    [Fact]
+    public void UpdateSpread_RejectsANegativeValue()
+    {
+        var settings = AutoQuoteSettings.CreateDefault("MAUA/IRT");
+
+        Assert.Throws<ArgumentException>(() => settings.UpdateSpread(-0.1m, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void UpdateSpread_RecordsWhoChangedItAndWhen()
+    {
+        var settings = AutoQuoteSettings.CreateDefault("MAUA/IRT");
+        var admin = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        settings.UpdateSpread(0.5m, admin);
+
+        Assert.Equal(0.5m, settings.SpreadPercent);
+        Assert.Equal(admin, settings.UpdatedByUserId);
+        Assert.True(settings.UpdatedAt >= before);
+    }
+
+    [Fact]
+    public void SetEnabled_RecordsWhoChangedItAndWhen()
+    {
+        var settings = AutoQuoteSettings.CreateDefault("MAUA/IRT");
+        var admin = Guid.NewGuid();
+
+        settings.SetEnabled(true, admin);
+
+        Assert.True(settings.IsEnabled);
+        Assert.Equal(admin, settings.UpdatedByUserId);
+    }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -76,6 +76,32 @@ public sealed class FakeOrderApiClient : IOrderApiClient
         throw new NotSupportedException(nameof(CancelAllUserActiveOrdersAsync));
     public Task<ApiResponse<bool>> NotifyMatchingEngineAsync(NotifyMatchingEngineRequest request) =>
         throw new NotSupportedException(nameof(NotifyMatchingEngineAsync));
+
+    // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────────
+
+    public AutoQuoteSettingsDto? AutoQuoteSettings { get; set; }
+
+    public Task<AutoQuoteSettingsDto?> GetAutoQuoteSettingsAsync(string symbol) => Task.FromResult(AutoQuoteSettings);
+
+    /// <summary>Every spread update asked for.</summary>
+    public List<(string Symbol, decimal SpreadPercent, Guid UpdatedByUserId)> SpreadUpdates { get; } = [];
+    public (bool Success, string Message) SpreadUpdateResult { get; set; } = (true, "اسپرد به‌روزرسانی شد.");
+
+    public Task<(bool success, string message)> UpdateAutoQuoteSpreadAsync(string symbol, decimal spreadPercent, Guid updatedByUserId)
+    {
+        SpreadUpdates.Add((symbol, spreadPercent, updatedByUserId));
+        return Task.FromResult(SpreadUpdateResult);
+    }
+
+    /// <summary>Every enable/disable toggle asked for.</summary>
+    public List<(string Symbol, bool IsEnabled, Guid UpdatedByUserId)> EnabledToggles { get; } = [];
+    public (bool Success, string Message) EnabledToggleResult { get; set; } = (true, "انجام شد.");
+
+    public Task<(bool success, string message)> SetAutoQuoteEnabledAsync(string symbol, bool isEnabled, Guid updatedByUserId)
+    {
+        EnabledToggles.Add((symbol, isEnabled, updatedByUserId));
+        return Task.FromResult(EnabledToggleResult);
+    }
 }
 
 /// <summary>Answers with one known, approved customer.</summary>

--- a/src/Wallet/Wallet.Tests/GoldPriceProviderChainTests.cs
+++ b/src/Wallet/Wallet.Tests/GoldPriceProviderChainTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application.Services;
+using Orders.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Which gold price source wins when more than one is configured (issue #90). The whole point
+/// of having two providers (nerkh.io, brsapi.ir) is that one being down does not stop automatic
+/// quoting — this is what proves the fallback actually falls back.
+/// </summary>
+public class GoldPriceProviderChainTests
+{
+    private sealed class StubProvider : IGoldPriceProvider
+    {
+        public string Name { get; init; } = "stub";
+        public decimal? Price { get; init; }
+
+        public Task<decimal?> GetMesghalPriceAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Price);
+    }
+
+    [Fact]
+    public async Task ReturnsThePriceFromTheFirstProviderThatAnswers()
+    {
+        var chain = new GoldPriceProviderChain(
+            [new StubProvider { Name = "first", Price = 80_000_000m }, new StubProvider { Name = "second", Price = 79_000_000m }],
+            NullLogger<GoldPriceProviderChain>.Instance);
+
+        var price = await chain.GetMesghalPriceAsync();
+
+        Assert.Equal(80_000_000m, price);
+    }
+
+    [Fact]
+    public async Task FallsBackToTheNextProvider_WhenTheFirstReturnsNull()
+    {
+        var chain = new GoldPriceProviderChain(
+            [new StubProvider { Name = "down", Price = null }, new StubProvider { Name = "up", Price = 79_000_000m }],
+            NullLogger<GoldPriceProviderChain>.Instance);
+
+        var price = await chain.GetMesghalPriceAsync();
+
+        Assert.Equal(79_000_000m, price);
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenEveryProviderFails()
+    {
+        var chain = new GoldPriceProviderChain(
+            [new StubProvider { Name = "a", Price = null }, new StubProvider { Name = "b", Price = null }],
+            NullLogger<GoldPriceProviderChain>.Instance);
+
+        var price = await chain.GetMesghalPriceAsync();
+
+        Assert.Null(price);
+    }
+
+    /// <summary>
+    /// A provider returning zero or a negative number is a malformed answer, not a usable
+    /// price — the chain must treat it the same as "no answer" and move on, not publish a
+    /// quote built on garbage.
+    /// </summary>
+    [Fact]
+    public async Task TreatsAZeroOrNegativePriceAsAFailure()
+    {
+        var chain = new GoldPriceProviderChain(
+            [new StubProvider { Name = "broken", Price = 0m }, new StubProvider { Name = "good", Price = 79_000_000m }],
+            NullLogger<GoldPriceProviderChain>.Instance);
+
+        var price = await chain.GetMesghalPriceAsync();
+
+        Assert.Equal(79_000_000m, price);
+    }
+
+    [Fact]
+    public async Task AnEmptyProviderListReturnsNull()
+    {
+        var chain = new GoldPriceProviderChain([], NullLogger<GoldPriceProviderChain>.Instance);
+
+        Assert.Null(await chain.GetMesghalPriceAsync());
+    }
+}


### PR DESCRIPTION
## Description
Publishes a MAUA/IRT quote automatically from a live gold price on a timer, through the same `Quote.Publish` path an admin's manual `buyPrice-sellPrice` command already uses. Closes #90.

## Linked Task / Finding
Closes #90

## Type
- [x] Feature

## Changes
- `IGoldPriceProvider` + `GoldPriceProviderChain`: tries nerkh.io first, falls back to brsapi.ir. Both return melted 18k gold ("آبشده") priced per mesghal — verified live against real tokens before writing the parsers; the two agreed to within 0.1% and cross-checked against brsapi's directly reported per-gram 18k price via `GramsPerMesghal`.
- `AutoQuoteSettings` (new table, `AutoQuoteSettings`, one row per symbol): admin-controlled spread and on/off switch, read live each tick — a config-file value is only read at startup, so this couldn't live there.
- `AutoQuotePublisherService` (`BackgroundService` in `Orders.Api`, same pattern as `MatchingEngineService`/`OutboxProcessorService`): every 2 minutes, if enabled, fetches a price, applies the spread, publishes via the existing `IQuoteRepository`.
- Two new admin bot commands: `اسپرد [درصد]` and `اتومات روشن`/`اتومات خاموش`.
- Two new `Orders.Api` endpoints (`POST /api/autoquote-settings/{symbol}/spread`, `/enabled`) plus a `GET` for visibility.
- Off by default. A manual quote always overrides the automatic one (only one quote per symbol is ever active). If every provider fails on a tick, the previous quote stays active and nothing is published — same "log, don't break the shop" rule as #73.

## Testing Completed
### Unit Tests
- [x] New unit tests written (24 new: `AutoQuoteSettingsTests`, `GoldPriceProviderChainTests`, `AutoQuotePublisherServiceTests`, `AutoQuoteCommandTests`)
- [x] All unit tests pass (`dotnet test`) — 366 passed, 0 failed

```
Passed! - Failed: 0, Passed: 366, Skipped: 0, Total: 366, Duration: 2 s - Wallet.Tests.dll (net9.0)
```

`AutoQuotePublisherServiceTests` runs against a real `OrdersDbContext` (SQLite in-memory), same pattern as `OutboxDueSelectionTests` — covers disabled/no-provider skip behavior, the mesghal→gram spread math, quote ownership, and that a second tick replaces rather than duplicates the active quote.

### Environment
- [x] Tested locally on Windows
- [x] Both external providers verified live with real API tokens before implementation (not guessed)

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens — the two provider tokens are read from `Services:Orders.Api:AutoQuote:{NerkhApiToken,BrsApiKey}` in the never-committed local `config/appsettings.global.json`, same as every other secret in this repo
- [x] No sensitive data in logs or error messages
- [x] Code compiles without warnings (no new warnings; 123 pre-existing, unrelated)

## Code Quality
- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why"
- [x] No large blocks of commented-out code

## Documentation
- n/a — no `docs/` file describes this yet; issue #90 has the design writeup

## Breaking Changes?
- [x] No breaking changes

## Deployment Notes
**Pre-Deployment:**
- New migration `AddAutoQuoteSettings` — self-applies on next `Orders.Api` startup like every other migration in this repo.
- Requires `Services:Orders.Api:AutoQuote:NerkhApiToken` and `:BrsApiKey` in the deployment's `config/appsettings.global.json`. Without them, both providers log a warning and return null every tick — the feature is inert, not broken, until an admin also runs `اتومات روشن` (which stays off by default regardless).

**Rollback Plan:** revert the merge commit; `AutoQuoteSettings` table can stay (empty/unused) or be dropped via `ef migrations remove` before the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)