### PR TITLE
feat(config): add sanitized appsettings.global example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -382,6 +382,7 @@ FodyWeavers.xsd
 appsettings.*.json
 !appsettings.json
 !config/appsettings.global.json
+!config/appsettings.global.example.json
 !appsettings.Example.json
 *.user
 *.suo
@@ -690,6 +691,7 @@ chocolatey/
 # Keep important configuration files
 !appsettings.json
 !config/appsettings.global.json
+!config/appsettings.global.example.json
 !appsettings.Example.json
 !appsettings.Template.json
 # Keep important documentation

--- a/config/appsettings.global.example.json
+++ b/config/appsettings.global.example.json
@@ -1,0 +1,80 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "ConnectionStrings": {
+        "OrdersDb": "Server=localhost;Database=TallaEggOrders;Trusted_Connection=True;TrustServerCertificate=True;",
+        "TallaEggDb": "Server=localhost;Database=TallaEgg;Trusted_Connection=True;TrustServerCertificate=True;",
+        "UsersDb": "Server=localhost;Database=TallaEggUsers;Trusted_Connection=True;TrustServerCertificate=True;",
+        "WalletDb": "Server=localhost;Database=TallaEggWallet;Trusted_Connection=True;TrustServerCertificate=True;",
+        "AffiliateDb": "Server=localhost;Database=TallaEggAffiliate;Trusted_Connection=True;TrustServerCertificate=True;"
+    },
+    "Services": {
+        "TallaEgg.Api": {
+            "Urls": [
+                "https://localhost:7296",
+                "http://localhost:5135"
+            ],
+            "UsersApiUrl": "http://localhost:5136"
+        },
+        "Users.Api": {
+            "Urls": [
+                "http://localhost:5136"
+            ],
+            "WalletApiUrl": "http://localhost:60933/"
+        },
+        "Orders.Api": {
+            "Urls": [
+                "https://localhost:7140",
+                "http://localhost:5140"
+            ],
+            "WalletApiUrl": "http://localhost:60933/api",
+            "Matching": {
+                "RequireMarketMakerCounterparty": true,
+                "MarketModes": {
+                    "MAUA/IRT": "Dealer"
+                }
+            },
+            "AutoQuote": {
+                "NerkhApiToken": "REPLACE_WITH_TEST_NERKH_API_TOKEN",
+                "BrsApiKey": "REPLACE_WITH_TEST_BRSAPI_KEY"
+            }
+        },
+        "Wallet.Api": {
+            "Urls": [
+                "https://localhost:60932",
+                "http://localhost:60933"
+            ]
+        },
+        "Affiliate.Api": {
+            "Urls": [
+                "https://localhost:60811",
+                "http://localhost:60812"
+            ]
+        },
+        "TallaEgg.TelegramBot.Infrastructure": {
+            "Urls": [
+                "https://localhost:57545",
+                "http://localhost:57546"
+            ],
+            "OrderApiUrl": "http://localhost:5140/api",
+            "UsersApiUrl": "http://localhost:5136/api",
+            "AffiliateApiUrl": "http://localhost:60812/api",
+            "PricesApiUrl": "http://localhost:5140/api",
+            "WalletApiUrl": "http://localhost:60933/api",
+            "BotSettings": {
+                "RequireReferralCode": false,
+                "DefaultReferralCode": "admin",
+                "OwnerTelegramIds": [ 0 ]
+            },
+            "TelegramBotToken": "REPLACE_WITH_TEST_BOT_TOKEN_FROM_BOTFATHER"
+        }
+    },
+    "FeatureFlags": {
+        "QuarantineStubEndpoints": true
+    }
+}


### PR DESCRIPTION
## Description
External contributors need to fork the repo and run services locally, but `config/appsettings.global.json` is tracked and holds live secrets (bot token, price-feed API keys). This adds `config/appsettings.global.example.json` — same schema, placeholder values — so a fork gets a working, up-to-date config shape without any real credentials. Real test values are shared with contributors out-of-band (not via git).

## Type of Change
- [x] Feature (new capability)

## Changes Made
- Added `config/appsettings.global.example.json`, mirroring the current schema of `config/appsettings.global.json` (including the `Matching`, `AutoQuote`, and `OwnerTelegramIds` sections that the tracked file didn't have until now) with `REPLACE_WITH_...` placeholders for `TelegramBotToken`, `NerkhApiToken`, and `BrsApiKey`.
- Added `!config/appsettings.global.example.json` to `.gitignore` (the broad `appsettings.*.json` ignore rule was catching this file too).

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] `.gitignore` blocks sensitive files (config, .env, secrets) — this PR only un-ignores the placeholder file, not the real one

## Testing Completed
- Verified the new file is no longer excluded by `.gitignore` (`git check-ignore` returns nothing for it) and that `config/appsettings.global.json` remains untouched by this change.

## Related Issues
- Groundwork for #33 (config/appsettings.global.json should not be tracked)