### PR TITLE
feat(api): add global exception-handling middleware to the 5 API services

### DIFF
--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TallaEgg.Core;
+using TallaEgg.Core.ErrorHandling;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -77,6 +78,7 @@ builder.Services.AddCors();
 
 builder.Services.AddScoped<IAffiliateRepository, AffiliateRepository>();
 builder.Services.AddScoped<AffiliateService>();
+builder.Services.AddTallaEggErrorHandling();
 
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
@@ -87,6 +89,8 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 var app = builder.Build();
+
+app.UseTallaEggErrorHandling();
 
 // --- مایگریشن و سیید اولیه ---
 using (var scope = app.Services.CreateScope())
@@ -129,16 +133,18 @@ app.MapPost("/api/affiliate/validate-invitation", async (ValidateInvitationReque
 
 app.MapPost("/api/affiliate/use-invitation", async (UseInvitationRequest request, AffiliateService affiliateService) =>
 {
+    // UseInvitationAsync throws InvalidOperationException with a user-facing message when the
+    // code is invalid — that message is the point, not boilerplate, so it stays local. See #88.
     try
     {
         var invitation = await affiliateService.UseInvitationAsync(
-            request.InvitationCode, 
-            request.UsedByUserId, 
-            request.UserAgent, 
+            request.InvitationCode,
+            request.UsedByUserId,
+            request.UserAgent,
             request.IpAddress);
         return Results.Ok(new { success = true, invitationId = invitation.Id });
     }
-    catch (Exception ex)
+    catch (InvalidOperationException ex)
     {
         return Results.BadRequest(new { success = false, message = ex.Message });
     }
@@ -146,19 +152,12 @@ app.MapPost("/api/affiliate/use-invitation", async (UseInvitationRequest request
 
 app.MapPost("/api/affiliate/create-invitation", async (CreateInvitationRequest request, AffiliateService affiliateService) =>
 {
-    try
-    {
-        var invitation = await affiliateService.CreateInvitationAsync(
-            request.CreatedByUserId, 
-            request.Type, 
-            request.MaxUses, 
-            request.ExpiresAt);
-        return Results.Ok(new { success = true, invitation = invitation });
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var invitation = await affiliateService.CreateInvitationAsync(
+        request.CreatedByUserId,
+        request.Type,
+        request.MaxUses,
+        request.ExpiresAt);
+    return Results.Ok(new { success = true, invitation = invitation });
 });
 
 app.MapGet("/api/affiliate/user-invitations/{userId}", async (Guid userId, AffiliateService affiliateService) =>

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -16,6 +16,7 @@ using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Responses.Order;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
@@ -102,6 +103,7 @@ builder.Services.AddHttpClient<TallaEgg.Infrastructure.Clients.IWalletApiClient,
 // اضافه کردن CORS
 builder.Services.AddCors();
 
+builder.Services.AddTallaEggErrorHandling();
 
 builder.Services.AddScoped<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>();
 
@@ -191,6 +193,8 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 var app = builder.Build();
+
+app.UseTallaEggErrorHandling();
 
 // --- مایگریشن و سیید اولیه ---
 using (var scope = app.Services.CreateScope())

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -8,6 +8,7 @@ using Orders.Core;
 using Orders.Infrastructure;
 using System.Text.Json;
 using TallaEgg.Core;
+using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Models;
 using Users.Application;
 using Users.Core;
@@ -70,6 +71,8 @@ builder.Services.AddScoped<IOrderRepository, OrderRepository>();
 // اضافه کردن CORS
 builder.Services.AddCors();
 
+builder.Services.AddTallaEggErrorHandling();
+
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -79,6 +82,8 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 var app = builder.Build();
+
+app.UseTallaEggErrorHandling();
 
 // تنظیم CORS
 app.UseCors(builder => builder

--- a/src/TallaEgg/TallaEgg.Core/ErrorHandling/ErrorHandlingExtensions.cs
+++ b/src/TallaEgg/TallaEgg.Core/ErrorHandling/ErrorHandlingExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace TallaEgg.Core.ErrorHandling;
+
+/// <summary>
+/// Wires up <see cref="GlobalExceptionHandler"/> plus per-request logging the same way in every
+/// API service, so each Program.cs only needs one call instead of repeating the registration.
+/// </summary>
+public static class ErrorHandlingExtensions
+{
+    public static IServiceCollection AddTallaEggErrorHandling(this IServiceCollection services)
+    {
+        services.AddExceptionHandler<GlobalExceptionHandler>();
+
+        // UseExceptionHandler() refuses to start without a fallback configured, even though
+        // GlobalExceptionHandler always handles every exception itself — this is never actually
+        // reached, but its absence is a hard startup failure.
+        services.AddProblemDetails();
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseTallaEggErrorHandling(this WebApplication app)
+    {
+        app.UseExceptionHandler();
+        app.UseSerilogRequestLogging();
+
+        return app;
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/ErrorHandling/GlobalExceptionHandler.cs
+++ b/src/TallaEgg/TallaEgg.Core/ErrorHandling/GlobalExceptionHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using TallaEgg.Core.DTOs;
+
+namespace TallaEgg.Core.ErrorHandling;
+
+/// <summary>
+/// Single point where every unhandled exception in an API service is logged and turned into a
+/// response. Keeps error shape and logging consistent across services instead of each endpoint
+/// doing its own catch/log/return. See issue #88.
+/// </summary>
+public sealed class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+
+    public GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var traceId = httpContext.TraceIdentifier;
+
+        _logger.LogError(
+            exception,
+            "Unhandled exception. TraceId={TraceId} Method={Method} Path={Path}",
+            traceId,
+            httpContext.Request.Method,
+            httpContext.Request.Path);
+
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        httpContext.Response.Headers["X-Trace-Id"] = traceId;
+
+        await httpContext.Response.WriteAsJsonAsync(
+            ApiResponse<object>.Error("خطای داخلی سرور"),
+            cancellationToken);
+
+        return true;
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
+++ b/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -13,6 +13,7 @@ using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.User;
+using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Requests.User;
 using Users.Api;
 using Users.Application;
@@ -83,6 +84,7 @@ else
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<UserMapper>();
+builder.Services.AddTallaEggErrorHandling();
 
 // HttpClient برای فراخوانی Wallet API
 builder.Services.AddHttpClient("WalletAPI", client =>
@@ -119,6 +121,7 @@ builder.Host.UseSerilog();
 
 var app = builder.Build();
 
+app.UseTallaEggErrorHandling();
 
 // --- مایگریشن و سیید اولیه ---
 using (var scope = app.Services.CreateScope())
@@ -210,13 +213,15 @@ app.UseSwaggerUI(c =>
 /// <response code="400">Invalid request data or validation error</response>
 app.MapPost("/api/user/register", async (RegisterUserRequest request, UserService userService) =>
 {
+    // RegisterUserAsync throws a plain Exception with a user-facing message when the invitation
+    // code is invalid — that message is the point, not boilerplate, so it stays local. See #88.
     try
     {
         var user = await userService.RegisterUserAsync(
             request.TelegramId,
             request.InvitationCode,
-            request.Username, 
-            request.FirstName, 
+            request.Username,
+            request.FirstName,
             request.LastName);
 
         return ApiResponse<UserDto>.Ok(user, "User loaded successfully");
@@ -238,12 +243,14 @@ app.MapPost("/api/user/register", async (RegisterUserRequest request, UserServic
 /// <response code="404">User not found</response>
 app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserService userService) =>
 {
+    // UpdateUserPhoneAsync throws InvalidOperationException("کاربر یافت نشد.") — a user-facing
+    // message, not boilerplate, so it stays local. See #88.
     try
     {
         var response = await userService.UpdateUserPhoneAsync(request.TelegramId, request.PhoneNumber);
         return Results.Ok(ApiResponse<UserDto>.Ok(response, "Phone number updated successfully"));
     }
-    catch (Exception ex)
+    catch (InvalidOperationException ex)
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }
@@ -276,29 +283,19 @@ app.MapGet("/api/user/{telegramId}", async (long telegramId, UserService userSer
 /// <response code="404">کاربر پیدا نشد</response>
 app.MapGet("/api/user/userId/{userId}", async (Guid userId, UserService userService) =>
 {
-    try
-    {
-        var user = await userService.GetUserByIdAsync(userId);
-        
-        if (user == null)
-        {
-            return Results.Json(
-                ApiResponse<UserDto>.NotFound("کاربر مورد نظر یافت نشد."),
-                statusCode: 404
-            );
-        }
+    var user = await userService.GetUserByIdAsync(userId);
 
-        return Results.Json(
-            ApiResponse<UserDto>.Ok(user, "اطلاعات کاربر با موفقیت دریافت شد.")
-        );
-    }
-    catch (Exception ex)
+    if (user == null)
     {
         return Results.Json(
-            ApiResponse<UserDto>.Error($"خطا در دریافت اطلاعات کاربر: {ex.Message}"),
-            statusCode: 500
+            ApiResponse<UserDto>.NotFound("کاربر مورد نظر یافت نشد."),
+            statusCode: 404
         );
     }
+
+    return Results.Json(
+        ApiResponse<UserDto>.Ok(user, "اطلاعات کاربر با موفقیت دریافت شد.")
+    );
 });
 
 /// <summary>
@@ -328,17 +325,8 @@ app.MapGet("/api/users/list", async (
     var page = pageNumber ?? 1;
     var size = Math.Clamp(pageSize ?? 10, 1, 100);
 
-    try
-    {
-        var users = await userService.GetUsersAsync(q, page, size);
-       return Results.Ok(ApiResponse<PagedResult<UserDto>>.Ok(users, "کاربران دریافت شد"));
-
-    }
-    catch (Exception ex)
-    {
-       return Results.BadRequest(ApiResponse<PagedResult<OrderHistoryDto>>.Fail("خطا در دریافت اطلاعات"));
-    }
-
+    var users = await userService.GetUsersAsync(q, page, size);
+    return Results.Ok(ApiResponse<PagedResult<UserDto>>.Ok(users, "کاربران دریافت شد"));
 });
 
 /// <summary>
@@ -352,12 +340,14 @@ app.MapGet("/api/users/list", async (
 /// <response code="404">User not found</response>
 app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserService userService) =>
 {
+    // UpdateUserStatusAsync throws InvalidOperationException("کاربر یافت نشد.") — a user-facing
+    // message, not boilerplate, so it stays local. See #88.
     try
     {
         var user = await userService.UpdateUserStatusAsync(request.TelegramId, request.NewStatus);
         return Results.Ok(ApiResponse<UserDto>.Ok(user, "وضعیت کاربر با موفقیت به‌روزرسانی شد."));
     }
-    catch (Exception ex)
+    catch (InvalidOperationException ex)
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }
@@ -374,28 +364,14 @@ app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserServi
 /// <response code="404">Invitation code not found</response>
 app.MapGet("/api/user/getUserIdByInvitationCode/{invitationCode}", async (string invitationCode, UserService userService) =>
 {
-    try
-    {
-        var userId = await userService.GetUserIdByInvitationCode(invitationCode);
-        return Results.Ok(userId);
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var userId = await userService.GetUserIdByInvitationCode(invitationCode);
+    return Results.Ok(userId);
 });
 
 app.MapGet("/api/user/getUserIdByPhoneNumber/{phonenumber}", async (string phonenumber, UserService userService) =>
 {
-    try
-    {
-        var userId = await userService.GetUserIdByPhoneNumber(phonenumber);
-        return Results.Ok(userId);
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var userId = await userService.GetUserIdByPhoneNumber(phonenumber);
+    return Results.Ok(userId);
 });
 
 /// <summary>
@@ -408,15 +384,8 @@ app.MapGet("/api/user/getUserIdByPhoneNumber/{phonenumber}", async (string phone
 /// <response code="400">Invalid invitation code or error occurred</response>
 app.MapPost("/api/user/validate-invitation", async (ValidateInvitationRequest request, UserService userService) =>
 {
-    try
-    {
-        var result = await userService.ValidateInvitationCodeAsync(request.InvitationCode);
-        return Results.Ok(new { isValid = result.isValid, message = result.message });
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var result = await userService.ValidateInvitationCodeAsync(request.InvitationCode);
+    return Results.Ok(new { isValid = result.isValid, message = result.message });
 });
 
 /// <summary>
@@ -429,15 +398,8 @@ app.MapPost("/api/user/validate-invitation", async (ValidateInvitationRequest re
 /// <response code="400">Invalid request data or validation error</response>
 app.MapPost("/api/user/register-with-invitation", async (RegisterUserWithInvitationRequest request, UserService userService) =>
 {
-    try
-    {
-        var user = await userService.RegisterUserAsync(request.User);
-        return Results.Ok(new { success = true, userId = user.Id });
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var user = await userService.RegisterUserAsync(request.User);
+    return Results.Ok(new { success = true, userId = user.Id });
 });
 
 /// <summary>
@@ -451,18 +413,11 @@ app.MapPost("/api/user/register-with-invitation", async (RegisterUserWithInvitat
 /// <response code="404">User not found</response>
 app.MapPost("/api/user/update-role", async (UpdateUserRoleRequest request, UserService userService) =>
 {
-    try
-    {
-        var user = await userService.UpdateUserRoleAsync(request.UserId, request.NewRole);
-        if (user == null)
-            return Results.NotFound(new { success = false, message = "کاربر یافت نشد." });
-        
-        return Results.Ok(new { success = true, message = "نقش کاربر با موفقیت به‌روزرسانی شد." });
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var user = await userService.UpdateUserRoleAsync(request.UserId, request.NewRole);
+    if (user == null)
+        return Results.NotFound(new { success = false, message = "کاربر یافت نشد." });
+
+    return Results.Ok(new { success = true, message = "نقش کاربر با موفقیت به‌روزرسانی شد." });
 });
 
 /// <summary>
@@ -475,18 +430,11 @@ app.MapPost("/api/user/update-role", async (UpdateUserRoleRequest request, UserS
 /// <response code="400">Invalid role or error occurred</response>
 app.MapGet("/api/users/by-role/{role}", async (string role, UserService userService) =>
 {
-    try
-    {
-        if (!Enum.TryParse<UserRole>(role, true, out var userRole))
-            return Results.BadRequest(new { success = false, message = "نقش نامعتبر است." });
+    if (!Enum.TryParse<UserRole>(role, true, out var userRole))
+        return Results.BadRequest(new { success = false, message = "نقش نامعتبر است." });
 
-        var users = await userService.GetUsersByRoleAsync(userRole);
-        return Results.Ok(users);
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var users = await userService.GetUsersByRoleAsync(userRole);
+    return Results.Ok(users);
 });
 
 /// <summary>
@@ -499,15 +447,8 @@ app.MapGet("/api/users/by-role/{role}", async (string role, UserService userServ
 /// <response code="400">Error occurred during check</response>
 app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService userService) =>
 {
-    try
-    {
-        var exists = await userService.UserExistsAsync(telegramId);
-        return Results.Ok(new { exists = exists });
-    }
-    catch (Exception ex)
-    {
-        return Results.BadRequest(new { success = false, message = ex.Message });
-    }
+    var exists = await userService.UserExistsAsync(telegramId);
+    return Results.Ok(new { exists = exists });
 });
 
 /// <summary>
@@ -521,41 +462,31 @@ app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService 
 /// <response code="404">کاربر یافت نشد</response>
 app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, UserService userService) =>
 {
-    try
-    {
-        var user = await userService.GetUserByIdAsync(userId);
-        if (user == null)
-        {
-            return Results.Json(
-                ApiResponse<object>.NotFound("کاربر مورد نظر یافت نشد."),
-                statusCode: 404
-            );
-        }
-
-        // فراخوانی endpoint کیف پول
-        using var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri("https://localhost:7001/");
-        var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
-
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            return Results.Json(
-                ApiResponse<object>.Ok(null, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند.")
-            );
-        }
-        else
-        {
-            return Results.Json(
-                ApiResponse<object>.Error("خطا در ایجاد کیف پول‌های پیش‌فرض."),
-                statusCode: 500
-            );
-        }
-    }
-    catch (Exception ex)
+    var user = await userService.GetUserByIdAsync(userId);
+    if (user == null)
     {
         return Results.Json(
-            ApiResponse<object>.Error($"خطا در ایجاد کیف پول‌های پیش‌فرض: {ex.Message}"),
+            ApiResponse<object>.NotFound("کاربر مورد نظر یافت نشد."),
+            statusCode: 404
+        );
+    }
+
+    // فراخوانی endpoint کیف پول
+    using var httpClient = new HttpClient();
+    httpClient.BaseAddress = new Uri("https://localhost:7001/");
+    var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
+
+    if (response.IsSuccessStatusCode)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return Results.Json(
+            ApiResponse<object>.Ok(null, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند.")
+        );
+    }
+    else
+    {
+        return Results.Json(
+            ApiResponse<object>.Error("خطا در ایجاد کیف پول‌های پیش‌فرض."),
             statusCode: 500
         );
     }

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -10,6 +10,7 @@ using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Requests.Trade;
 using TallaEgg.Core.Requests.Wallet;
 using Wallet.Application;
@@ -89,6 +90,7 @@ else
 builder.Services.AddScoped<IWalletRepository, WalletRepository>();
 builder.Services.AddScoped<IWalletService, WalletService>();
 builder.Services.AddScoped<WalletMapper>();
+builder.Services.AddTallaEggErrorHandling();
 
 // اضافه کردن CORS
 builder.Services.AddCors();
@@ -110,6 +112,7 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
+app.UseTallaEggErrorHandling();
 
 // --- مایگریشن و سیید اولیه ---
 using (var scope = app.Services.CreateScope())


### PR DESCRIPTION
## Description
Adds a single shared `IExceptionHandler` (`TallaEgg.Core.ErrorHandling.GlobalExceptionHandler`)
plus `AddTallaEggErrorHandling()` / `UseTallaEggErrorHandling()` extensions, wired into all 5 API
services. Every unhandled exception is now logged once, consistently, with a trace id — instead of
depending on each endpoint's own `catch (Exception ex)`. Also turns on `UseSerilogRequestLogging()`
(the package was referenced everywhere, the call never made).

## Linked Task / Finding
Closes #88 · Audit finding: H-2

## Type
- [x] Feature

## Changes
- New `GlobalExceptionHandler : IExceptionHandler` in `TallaEgg.Core/ErrorHandling/`: logs the full
  exception with `TraceId`/method/path, returns a generic `ApiResponse<object>` 500, sets an
  `X-Trace-Id` response header so a reported error can be grepped straight out of `logs/*.log`.
- `ErrorHandlingExtensions.AddTallaEggErrorHandling()` / `.UseTallaEggErrorHandling()`: one call per
  service instead of repeating registration 5 times. Wired into Users, Wallet, Orders, Affiliate,
  TallaEgg.Api.
- `TallaEgg.Core.csproj`: added `FrameworkReference Include="Microsoft.AspNetCore.App"` so the
  shared library can reference `IExceptionHandler`/`HttpContext` without becoming a Web SDK project.
- **Swept boilerplate catches** in `Affiliate.Api` and `Users.Api`: removed the
  `catch (Exception ex) { return BadRequest(...) }` blocks that added nothing beyond a generic
  failure (several were leaking raw `ex.Message` to the caller). Left the ones that carry real
  business-validation messages (invalid invite code, user not found) untouched — see below.
- **`Wallet.Api` and `Orders.Api`: wired only, zero catches removed.** On inspection,
  `WalletService`/`OrderService` and their repositories throw plain
  `Exception`/`InvalidOperationException`/`ArgumentException` as their de facto business-rule
  signal (insufficient balance, wallet not found, invalid status transition, self-transfer, etc.).
  In these two services the catch's `ex.Message` *is* the feature, not boilerplate — removing it
  would turn real validation feedback (e.g. "insufficient balance") into an opaque 500. They still
  get the safety net (anything that slips past those catches) and the same consistent logging.

## Testing Completed

### Unit Tests
- [x] All existing unit tests pass — `dotnet test TallaEgg.sln`: 375 passed, 0 failed (Wallet.Tests;
  no test project covers the other 4 API services today).

### Manual / Local
- `dotnet build TallaEgg.sln`: 0 errors.
- Ran `Affiliate.Api` locally and hit it live:
  - A genuinely unexpected exception (a stale local dev DB — unrelated to this change) was caught
    by the global handler, logged with full stack trace + `TraceId`, and returned as a clean
    generic 500 with a matching `X-Trace-Id` header.
  - Confirmed the narrowed `catch (InvalidOperationException)` in `use-invitation` does **not**
    swallow unrelated exception types — they correctly fall through to the global handler instead
    of being misclassified as a business failure.
- Did not run Wallet.Api/Orders.Api live (no catches changed there, so no new runtime behavior to
  verify beyond "the app still starts", confirmed by the full solution build).

### Environment
- [x] Tested locally on Windows.
- [ ] Not tested on staging (no staging environment exists yet — see `STANDARDS.md`).

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens.
- [x] No sensitive data in logs or error messages — the global handler logs the exception
      server-side only; the client response is always the generic message, never `ex.Message`.
- [x] `.gitignore` already blocks `logs/`.
- [x] Code compiles without errors (pre-existing nullable-reference warnings untouched).

## Code Quality
- [x] Follows `STANDARDS.md` naming conventions.
- [x] Comments in English, explain the "why" (e.g. why Wallet/Orders catches were left alone).
- [x] No commented-out code added.

## Breaking Changes?
- [x] No breaking changes for callers that already handle `ApiResponse<T>` — response shape is
      unchanged. Behavior changes only for the specific endpoints where a boilerplate catch was
      removed: an exception there now returns HTTP 500 (generic message) instead of HTTP 400 with
      the raw exception text. That HTTP-400-with-leaked-message behavior was itself the bug (H-2).

## Deployment Notes
**Pre-Deployment**: No DB migrations, no new config/env vars, no feature flags.

**Post-Deployment Verification**:
- [ ] Each service starts successfully (would have failed fast otherwise — `UseExceptionHandler()`
      throws at startup without `AddProblemDetails()`, which is why that's included).
- [ ] `logs/{service}-api-.log` shows request logging lines (`UseSerilogRequestLogging`) and, on a
      forced error, an `Unhandled exception. TraceId=...` line.

**Rollback Plan**: Revert this commit; no data/schema changes to unwind.

## Related Issues
- Closes #88 (companion bot-side issue: #99)
