### PR TITLE
feat(bot): add on-disk logging and a user-facing fallback on unhandled errors

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -140,84 +140,79 @@ namespace TallaEgg.TelegramBot
 
         public async Task HandleMessageAsync(Message message)
         {
-            try
+            // No local catch here (issue #99) — this used to swallow every exception with a
+            // log line and total silence to the user, which TelegramBotHostedService.
+            // HandleUpdateAsync's own catch can never see or recover from because nothing
+            // propagates past this point. Letting it bubble means the caller's catch — which
+            // does log to disk and reply with a fallback message — is the one and only place
+            // an unhandled exception from a customer's message is handled, for every message,
+            // not just the ones that happen not to hit this now-removed try.
+            var chatId = message.Chat.Id;
+            var telegramId = message.From?.Id ?? 0;
+            await _telegramLogger.LogAsync<Message>($"✔➕ new message:",message);
+
+
+            message.Text = TallaEgg.Core.Utilties.Utils.ConvertPersianDigitsToEnglish(message.Text);
+
+            // Check if user exists
+            var user = await _usersApi.GetUserAsync(telegramId);
+
+            if (user == null)
             {
-                var chatId = message.Chat.Id;
-                var telegramId = message.From?.Id ?? 0;
-                await _telegramLogger.LogAsync<Message>($"✔➕ new message:",message);
+                // /start is the registration command, so telling somebody to send it while
+                // they are sending it is noise — and it arrived as the reply to their very
+                // first message, which reads like a rejection. Anything else still gets the
+                // prompt.
+                if (!(message.Text ?? string.Empty).StartsWith("/start"))
+                    await _messenger.SendAsync(chatId, BotMsgs.MsgAccountNotFound);
 
-
-                message.Text = TallaEgg.Core.Utilties.Utils.ConvertPersianDigitsToEnglish(message.Text);
-
-                // Check if user exists
-                var user = await _usersApi.GetUserAsync(telegramId);
-
-                if (user == null)
-                {
-                    // /start is the registration command, so telling somebody to send it while
-                    // they are sending it is noise — and it arrived as the reply to their very
-                    // first message, which reads like a rejection. Anything else still gets the
-                    // prompt.
-                    if (!(message.Text ?? string.Empty).StartsWith("/start"))
-                        await _messenger.SendAsync(chatId, BotMsgs.MsgAccountNotFound);
-
-                    await HandleNewUserAsync(chatId, telegramId, message);
-                    return;
-                }
-
-                // Keyed on the Telegram user id, as every other access is. This one line
-                // used the chat id; the two are equal in a private chat, so it worked, but
-                // the entry was written under one key and read under another anywhere else.
-                _conversations.GetOrStart(telegramId, user.Id);
-
-                if (string.IsNullOrEmpty(user?.PhoneNumber))
-                {
-                    await HandlePhoneNumberRequestAsync(chatId, telegramId, message);
-                    return;
-                }
-
-                // A configured owner is exempt from the approval gate, and this is the whole
-                // reason the exemption exists: a new account is created Pending, approval
-                // arrives only as a callback from an administrator of a hard-coded Telegram
-                // group, and the operator commands live inside the else-branch below. On an
-                // empty database that is a closed loop — the one person who is supposed to
-                // appoint the first administrator sits behind an approval only an existing
-                // administrator can give.
-                //
-                // Ownership already comes from configuration, which is to say from whoever
-                // controls the deployment. Requiring a second, in-product approval on top of
-                // that adds no protection; it only makes the product impossible to start.
-                if (user.Status != TallaEgg.Core.Enums.User.UserStatus.Approved
-                    && !_ownerTelegramIds.Contains(telegramId))
-                {
-                    await _messenger.SendAsync(
-                         chatId,
-                         string.Format(BotMsgs.MsgAccountNotApproved, user.FirstName).AutoRtl()
-                     );
-                }
-                else
-                {
-                    // احتمالا بهتره که در آینده این کار را رول حسابدار انجام دهد
-                    //if (await IsTelegramAdmin(user))
-                    if (IsOperator(user))
-                    {
-                        // Check for admin commands first
-                        bool isAdminCmd = await HandleAdminCommandsAsync(chatId, telegramId, message, user);
-                        if (isAdminCmd) return;
-                    }
-
-                    await HandleMainMenuAsync(chatId, telegramId, message, user.Id);
-                }
-
-            }
-            catch (Exception ex)
-            {
-                await _telegramLogger.ErrorAsync(ex, "❌ Error in HandleUpdateAsync");
-
-                Console.WriteLine($"❌ Error in HandleUpdateAsync: {ex.Message}");
-
+                await HandleNewUserAsync(chatId, telegramId, message);
+                return;
             }
 
+            // Keyed on the Telegram user id, as every other access is. This one line
+            // used the chat id; the two are equal in a private chat, so it worked, but
+            // the entry was written under one key and read under another anywhere else.
+            _conversations.GetOrStart(telegramId, user.Id);
+
+            if (string.IsNullOrEmpty(user?.PhoneNumber))
+            {
+                await HandlePhoneNumberRequestAsync(chatId, telegramId, message);
+                return;
+            }
+
+            // A configured owner is exempt from the approval gate, and this is the whole
+            // reason the exemption exists: a new account is created Pending, approval
+            // arrives only as a callback from an administrator of a hard-coded Telegram
+            // group, and the operator commands live inside the else-branch below. On an
+            // empty database that is a closed loop — the one person who is supposed to
+            // appoint the first administrator sits behind an approval only an existing
+            // administrator can give.
+            //
+            // Ownership already comes from configuration, which is to say from whoever
+            // controls the deployment. Requiring a second, in-product approval on top of
+            // that adds no protection; it only makes the product impossible to start.
+            if (user.Status != TallaEgg.Core.Enums.User.UserStatus.Approved
+                && !_ownerTelegramIds.Contains(telegramId))
+            {
+                await _messenger.SendAsync(
+                     chatId,
+                     string.Format(BotMsgs.MsgAccountNotApproved, user.FirstName).AutoRtl()
+                 );
+            }
+            else
+            {
+                // احتمالا بهتره که در آینده این کار را رول حسابدار انجام دهد
+                //if (await IsTelegramAdmin(user))
+                if (IsOperator(user))
+                {
+                    // Check for admin commands first
+                    bool isAdminCmd = await HandleAdminCommandsAsync(chatId, telegramId, message, user);
+                    if (isAdminCmd) return;
+                }
+
+                await HandleMainMenuAsync(chatId, telegramId, message, user.Id);
+            }
         }
 
         private async Task HandleNewUserAsync(long chatId, long telegramId, Message message)
@@ -1395,12 +1390,16 @@ namespace TallaEgg.TelegramBot
                         });
                 }
             }
-            catch (Exception ex)
-            {
-                await _messenger.SendAsync(chatId, $"خطا در ثبت سفارش: {ex.Message}");
-            }
             finally
             {
+                // Business failures (insufficient balance, no quote, etc.) already come back
+                // as (orderSuccess: false, orderMessage) above and are shown to the customer
+                // there — this method only ever throws for something genuinely unexpected, and
+                // the catch that used to sit here sent the customer ex.Message verbatim, with
+                // no logging anywhere (issue #99). Letting it bubble reaches
+                // TelegramBotHostedService.HandleUpdateAsync's catch, which does both. The
+                // conversation must still be cleared on that path — same as any other exit —
+                // or the next order silently inherits this one's half-filled state.
                 _conversations.Clear(telegramId);
             }
         }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -641,56 +641,54 @@ namespace TallaEgg.TelegramBot
         /// </remarks>
         private async Task HandlePricePairOrdersAsync(long chatId, Guid userId, decimal buyPrice, decimal sellPrice)
         {
-            try
-            {
-                const string defaultAsset = CurrenciesConstant.MAUA_IRT; // Default asset for admin price pair orders
-                const decimal defaultAmount = 1000m;    // Default amount
+            // No local catch here (issue #99) — publish failure already comes back as
+            // (published: false, publishMessage) below and is shown to the admin there. The
+            // catch that used to wrap this method only ever fired for something genuinely
+            // unexpected, sent the admin ex.Message verbatim, and logged nowhere. Letting it
+            // bubble reaches TelegramBotHostedService.HandleUpdateAsync's catch, which does
+            // both.
+            const string defaultAsset = CurrenciesConstant.MAUA_IRT; // Default asset for admin price pair orders
+            const decimal defaultAmount = 1000m;    // Default amount
 
-                // First, cancel all existing active orders for this user
-                //await _messenger.SendAsync(chatId, "⏳ در حال کنسل سفارشات قبلی...");
-                await _messenger.SendAsync(chatId, BotMsgs.MsgAdminProcessing);
+            // First, cancel all existing active orders for this user
+            //await _messenger.SendAsync(chatId, "⏳ در حال کنسل سفارشات قبلی...");
+            await _messenger.SendAsync(chatId, BotMsgs.MsgAdminProcessing);
 
-                var cancelResults = await CancelUserActiveOrdersAsync(userId);
-                if (cancelResults.CancelledCount > 0)
-                {
-                    await _messenger.SendAsync(chatId,
-                        string.Format(BotMsgs.MsgAdminPreviousPricesCancelled,
-                            PersianFormat.Number(cancelResults.CancelledCount)));
-                }
-                else if (cancelResults.HasError)
-                {
-                    await _messenger.SendAsync(chatId,
-                        string.Format(BotMsgs.MsgAdminCancelPreviousFailed, cancelResults.ErrorMessage));
-                }
-
-                // A quote is published — no more pair of 1000-gram orders (issue #48).
-                //
-                // The 1000 was arbitrary and locked roughly 19 billion toman and 1000 grams
-                // of the admin's collateral purely to announce a price. Publishing a quote
-                // locks nothing; orders are created only when a customer trades, for exactly
-                // the requested quantity, and are consumed in the same moment.
-                //
-                // Conversion and confirmation text come from one call, so the price
-                // published and the price shown cannot drift apart (issue #65).
-                var quote = QuoteMessage.Prepare(defaultAsset, buyPrice, sellPrice);
-
-                var (published, publishMessage) = await _orderApi.PublishQuoteAsync(
-                    defaultAsset, quote.BuyPricePerGram, quote.SellPricePerGram, userId);
-
-                if (published)
-                {
-                    await _messenger.SendAsync(chatId, quote.Text);
-                }
-                else
-                {
-                    await _messenger.SendAsync(chatId,
-                        string.Format(BotMsgs.MsgAdminQuoteFailed, publishMessage));
-                }
-            }
-            catch (Exception ex)
+            var cancelResults = await CancelUserActiveOrdersAsync(userId);
+            if (cancelResults.CancelledCount > 0)
             {
                 await _messenger.SendAsync(chatId,
-                    string.Format(BotMsgs.MsgAdminPriceSubmitError, ex.Message));
+                    string.Format(BotMsgs.MsgAdminPreviousPricesCancelled,
+                        PersianFormat.Number(cancelResults.CancelledCount)));
+            }
+            else if (cancelResults.HasError)
+            {
+                await _messenger.SendAsync(chatId,
+                    string.Format(BotMsgs.MsgAdminCancelPreviousFailed, cancelResults.ErrorMessage));
+            }
+
+            // A quote is published — no more pair of 1000-gram orders (issue #48).
+            //
+            // The 1000 was arbitrary and locked roughly 19 billion toman and 1000 grams
+            // of the admin's collateral purely to announce a price. Publishing a quote
+            // locks nothing; orders are created only when a customer trades, for exactly
+            // the requested quantity, and are consumed in the same moment.
+            //
+            // Conversion and confirmation text come from one call, so the price
+            // published and the price shown cannot drift apart (issue #65).
+            var quote = QuoteMessage.Prepare(defaultAsset, buyPrice, sellPrice);
+
+            var (published, publishMessage) = await _orderApi.PublishQuoteAsync(
+                defaultAsset, quote.BuyPricePerGram, quote.SellPricePerGram, userId);
+
+            if (published)
+            {
+                await _messenger.SendAsync(chatId, quote.Text);
+            }
+            else
+            {
+                await _messenger.SendAsync(chatId,
+                    string.Format(BotMsgs.MsgAdminQuoteFailed, publishMessage));
             }
         }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -411,6 +411,12 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string MsgNotAuthorized = "شما اجازهٔ این کار را ندارید.";
 
         /// <summary>
+        /// پاسخ عمومی وقتی پردازش پیام کاربر با خطای غیرمنتظره (بدون پاسخ اختصاصی از خود
+        /// هندلر) متوقف شود — issue #99. تنها جایی که پیام خام exception به کاربر نمی‌رسد.
+        /// </summary>
+        public const string MsgUnexpectedError = "❌ مشکلی پیش آمد.\n\nلطفاً دوباره تلاش کنید. اگر ادامه داشت، به طلافروشی خود اطلاع دهید.";
+
+        /// <summary>
         /// وقتی پیامی از کسی می‌رسد که هنوز ثبت‌نام نکرده است.
         ///
         /// «/start» عمداً به همین شکل و بدون هیچ نشانه‌گذاری نوشته شده تا تلگرام خودش آن را
@@ -569,9 +575,6 @@ namespace TallaEgg.TelegramBot.Infrastructure
 
         /// <summary>{0} = دلیل ناموفق بودن</summary>
         public const string MsgAdminQuoteFailed = "❌ انتشار مظنه انجام نشد.\n\nدلیل: {0}";
-
-        /// <summary>{0} = دلیل خطا</summary>
-        public const string MsgAdminPriceSubmitError = "❌ ثبت قیمت‌ها انجام نشد.\n\nدلیل: {0}";
 
         // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -28,6 +28,14 @@ public class Program
 
     public static async Task Main(string[] args)
     {
+        // Matches the 5 API services' own pattern (issue #88) — console for a live session,
+        // file for everything else. Before this the bot had no file sink at all: an
+        // exception left no trace once the console it printed to was gone (issue #99).
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .WriteTo.File("logs/telegrambot-.log", rollingInterval: RollingInterval.Day)
+            .CreateLogger();
+
         _ = Task.Run(() => TelegramNotificationApi.RunNotificationApi(args));
 
         using var host = CreateHostBuilder(args).Build();
@@ -36,6 +44,7 @@ public class Program
 
     private static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
+            .UseSerilog()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {
                 var sharedConfigPath = ResolveSharedConfigPath(SharedConfigFileName);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
@@ -172,9 +172,15 @@ public class TelegramBotHostedService : BackgroundService
 
     private async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, CancellationToken cancellationToken)
     {
+        // Resolved once so both the log entry and the fallback reply below can use them —
+        // whichever branch below throws, this is who was talking to the bot (issue #99).
+        var chatId = update.Message?.Chat.Id ?? update.CallbackQuery?.Message?.Chat.Id;
+        var telegramId = update.Message?.From?.Id ?? update.CallbackQuery?.From?.Id;
+        var handler = update.Message is not null ? "HandleMessageAsync" : "HandleCallbackQueryAsync";
+
         try
         {
-            
+
             if (update.Message is not null && update.Message.Chat.Type == ChatType.Private)
             {
                 var preview = update.Message.Text is null
@@ -191,7 +197,24 @@ public class TelegramBotHostedService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error handling update");
+            _logger.LogError(ex,
+                "Unhandled exception in {Handler}. ChatId={ChatId} TelegramId={TelegramId} UpdateType={UpdateType}",
+                handler, chatId, telegramId, update.Type);
+
+            // Without this the customer sees nothing at all — the exception was already
+            // logged above, but until now that was the only trace of it anywhere, including
+            // to the one person actually waiting on a reply.
+            if (chatId is { } id)
+            {
+                try
+                {
+                    await botClient.SendMessage(id, BotMsgs.MsgUnexpectedError, cancellationToken: cancellationToken);
+                }
+                catch (Exception sendEx)
+                {
+                    _logger.LogError(sendEx, "Could not send the fallback error message to ChatId={ChatId}.", id);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Companion to #88 (bot side): adds on-disk logging to the bot and makes unhandled errors
visible to the customer instead of silent, per issue #99.

## Linked Task / Finding
Closes #99

## Type
- [x] Feature
- [x] Refactor

## Changes
- **On-disk logging**: Serilog with a file sink added to the bot
  (`logs/telegrambot-.log`, daily rolling) — matches the pattern all 5 API services
  already use. Before this, an exception left zero trace once the console showing it
  was gone.
- **User-facing fallback**: `TelegramBotHostedService.HandleUpdateAsync`'s top-level
  catch now logs with `ChatId`, `TelegramId`, `UpdateType`, and the full exception, and
  sends the user one generic message (`BotMsgs.MsgUnexpectedError`) instead of leaving
  them in silence.
- **Removed a catch that made the above pointless most of the time**:
  `BotHandler.HandleMessageAsync` had its own top-level catch that silently swallowed
  every exception (logged to a Telegram diagnostic channel + console, no disk log, no
  reply) before it could ever reach `HandleUpdateAsync`'s catch. Removed, so the hosted
  service's catch is the one place an unhandled exception from a customer's message is
  actually handled.
- **Swept two catches that leaked `ex.Message` verbatim with no logging at all**:
  - `HandleOrderConfirmationAsync` — sent the raw exception message to the customer.
  - `HandlePricePairOrdersAsync` (admin) — sent the raw exception message to the admin.
  
  Both call sites already report business failures (insufficient balance, publish
  failure, etc.) via a `(success, message)` tuple *before* reaching their catch, so the
  catch only ever fired for something genuinely unexpected — removing it doesn't lose
  any business-meaningful message, only the leak.
- Removed `BotMsgs.MsgAdminPriceSubmitError`, unused after the above.

## Explicitly left untouched
Every other catch in `BotHandler.cs` / `BotHandlerAdmin.cs` does something the
top-level handler can't replace:
- Per-item tolerance in a loop (a phone-number lookup failing shouldn't blank a whole
  trade-history page; one user failing a startup broadcast shouldn't stop the rest).
- A documented "must not fail the trade" guard (`SendTradeExecutedAsync` — the trade
  already executed; a failed confirmation message must not read as a failed trade).
- Retry/backoff (`SendMessageWithRetryAsync`) and its own error-sending helper
  (`SendErrorMessageAsync`).
- A fire-and-forget background task's own catch, explicitly documented as needed to
  avoid an unobserved task exception.
- `CancelUserActiveOrdersAsync`, which converts failure into a typed result its caller
  depends on — same shape as the API client wrapper pattern, not a user-facing reply.

## Testing Completed

### Manual / Local
- `dotnet build TallaEgg.sln`: 0 errors.
- Ran the bot simulator (`TallaEgg.TelegramBot.Simulator`, added in #101) end to end at
  small scale (10 users, 10 quotes, 30 trades) against live local APIs after these
  changes: 0 errors — registration, admin approve/reject, quote publishing (the exact
  method edited: `HandlePricePairOrdersAsync`), and scattered navigation (help/history/
  balance) all still work.
- Ran the real bot process: `logs/telegrambot-*.log` was created and captured a real
  scenario end to end — simulated users have no live Telegram chat, so the startup
  broadcast's per-user send failures were logged individually with full exception
  detail (type, message, stack trace), confirming the file sink works and the
  surrounding per-item catch (correctly left alone) still tolerates the failure.
- Did not get a live demonstration of `HandleUpdateAsync`'s new fallback message firing
  end-to-end over real Telegram (that needs an incoming update that genuinely throws);
  verified by code reading instead — `HandleMessageAsync` no longer catches locally, and
  `HandleCallbackQueryAsync` never did, so any unhandled exception from either now
  reaches this one catch.

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens.
- [x] No sensitive data in the user-facing fallback message — it's a fixed generic
      string, never `ex.Message`. The two catches removed were the two places that were
      leaking `ex.Message` to a chat.
- [x] `.gitignore` already blocks `logs/`.

## Breaking Changes?
- [x] No breaking changes. Behavior change only for the specific paths swept: an
      unhandled exception there now shows a generic Persian message instead of the raw
      exception text (fixing the leak — the actual bug, not incidentally).

## Related Issues
- Closes #99
- Companion to #88 (same root problem, HTTP-API side)
