### PR TITLE
[Security][Critical] Gate TLS validation & restrict CORS — #31

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
@@ -19,9 +19,11 @@ public class AffiliateApiClient : IAffiliateApiClient
         _apiUrl = apiUrl;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        // برای حل مشکل SSL در محیط توسعه
         var handler = new HttpClientHandler();
+#if DEBUG
+        // DEV ONLY: accept self-signed certs for local inter-service calls.
         handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+#endif
         _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -26,9 +26,11 @@ public class OrderApiClient : IOrderApiClient
         _baseUrl = configuration["OrderApiUrl"] ?? "http://localhost:5135/api";
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        // برای حل مشکل SSL در محیط توسعه
         var handler = new HttpClientHandler();
+#if DEBUG
+        // DEV ONLY: accept self-signed certs for local inter-service calls.
         handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+#endif
         _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }

--- a/config/appsettings.global.example.json
+++ b/config/appsettings.global.example.json
@@ -19,13 +19,19 @@
                 "https://localhost:7296",
                 "http://localhost:5135"
             ],
-            "UsersApiUrl": "http://localhost:5136"
+            "UsersApiUrl": "http://localhost:5136",
+            "Cors": {
+                "AllowedOrigins": []
+            }
         },
         "Users.Api": {
             "Urls": [
                 "http://localhost:5136"
             ],
-            "WalletApiUrl": "http://localhost:60933/"
+            "WalletApiUrl": "http://localhost:60933/",
+            "Cors": {
+                "AllowedOrigins": []
+            }
         },
         "Orders.Api": {
             "Urls": [
@@ -33,6 +39,9 @@
                 "http://localhost:5140"
             ],
             "WalletApiUrl": "http://localhost:60933/api",
+            "Cors": {
+                "AllowedOrigins": []
+            },
             "Matching": {
                 "RequireMarketMakerCounterparty": true,
                 "MarketModes": {
@@ -48,13 +57,19 @@
             "Urls": [
                 "https://localhost:60932",
                 "http://localhost:60933"
-            ]
+            ],
+            "Cors": {
+                "AllowedOrigins": []
+            }
         },
         "Affiliate.Api": {
             "Urls": [
                 "https://localhost:60811",
                 "http://localhost:60812"
-            ]
+            ],
+            "Cors": {
+                "AllowedOrigins": []
+            }
         },
         "TallaEgg.TelegramBot.Infrastructure": {
             "Urls": [

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TallaEgg.Core;
+using TallaEgg.Core.Cors;
 using TallaEgg.Core.ErrorHandling;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -74,7 +75,9 @@ else
 // Registered unconditionally, matching the other four services. It was missing entirely,
 // which meant app.UseCors below could not resolve ICorsService and the process died at
 // startup in Production — the one environment nobody runs locally (issue #72).
-builder.Services.AddCors();
+//
+// Now a whitelist read from configuration instead of AllowAnyOrigin (issue #31).
+builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddScoped<IAffiliateRepository, AffiliateRepository>();
 builder.Services.AddScoped<AffiliateService>();
@@ -115,14 +118,7 @@ app.UseAuthorization();
 // from a missing registration; it was hiding a service that could never start in Production.
 //
 // Now registered unconditionally, so this runs in both, as it does in the other four services.
-//
-// AllowAnyOrigin is what #31 is about. Worth noting there: CORS constrains browsers, and this
-// product has no browser client — the APIs are called only by the bot over loopback. The
-// protection that matters is not opening these ports to the internet at all, which #69 covers.
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+app.UseTallaEggCors();
 
 // Affiliate management endpoints
 app.MapPost("/api/affiliate/validate-invitation", async (ValidateInvitationRequest request, AffiliateService affiliateService) =>

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using TallaEgg.Core;
+using TallaEgg.Core.Cors;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
@@ -100,8 +101,8 @@ builder.Services.AddHttpClient<TallaEgg.Infrastructure.Clients.IWalletApiClient,
     client.BaseAddress = new Uri(walletApiUrl);
 });
 
-// اضافه کردن CORS
-builder.Services.AddCors();
+// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddTallaEggErrorHandling();
 
@@ -215,10 +216,7 @@ if (app.Environment.IsProduction())
 app.UseAuthorization();
 
 // تنظیم CORS
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+app.UseTallaEggCors();
 
 
 

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -8,6 +8,7 @@ using Orders.Core;
 using Orders.Infrastructure;
 using System.Text.Json;
 using TallaEgg.Core;
+using TallaEgg.Core.Cors;
 using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Models;
 using Users.Application;
@@ -68,8 +69,8 @@ builder.Services.AddScoped<IOrderRepository, OrderRepository>();
 // builder.Services.AddScoped<ISymbolRepository, SymbolRepository>();
 // builder.Services.AddScoped<ISymbolService, SymbolService>();
 
-// اضافه کردن CORS
-builder.Services.AddCors();
+// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddTallaEggErrorHandling();
 
@@ -86,10 +87,7 @@ var app = builder.Build();
 app.UseTallaEggErrorHandling();
 
 // تنظیم CORS
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+app.UseTallaEggCors();
 
 static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironment environment, string fileName)
 {

--- a/src/TallaEgg/TallaEgg.Core/Cors/CorsExtensions.cs
+++ b/src/TallaEgg/TallaEgg.Core/Cors/CorsExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TallaEgg.Core.Cors;
+
+/// <summary>
+/// Restricts CORS to a configured whitelist instead of <c>AllowAnyOrigin</c>, the same way in
+/// every API service, so each Program.cs only needs one call instead of repeating the policy.
+/// See issue #31 / audit finding C-9.
+///
+/// <para>
+/// An empty or missing <c>Cors:AllowedOrigins</c> allows no cross-origin browser request —
+/// the safe default, since none of these services expect a browser client today (they are
+/// called only by the bot, over loopback).
+/// </para>
+/// </summary>
+public static class CorsExtensions
+{
+    private const string PolicyName = "TallaEggWhitelist";
+
+    public static IServiceCollection AddTallaEggCors(this IServiceCollection services, IConfiguration configuration)
+    {
+        var allowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+
+        services.AddCors(options =>
+        {
+            options.AddPolicy(PolicyName, policy =>
+            {
+                if (allowedOrigins.Length > 0)
+                {
+                    policy.WithOrigins(allowedOrigins).AllowAnyMethod().AllowAnyHeader();
+                }
+            });
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseTallaEggCors(this IApplicationBuilder app)
+    {
+        app.UseCors(PolicyName);
+        return app;
+    }
+}

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -26,9 +26,11 @@ public class UsersApiClient : IUsersApiClient
         _baseUrl = ResolveUsersApiBaseUrl(configuration) ?? "http://localhost:5001/api";
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        // برای حل مشکل SSL در محیط توسعه
         var handler = new HttpClientHandler();
+#if DEBUG
+        // DEV ONLY: accept self-signed certs for local inter-service calls.
         handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+#endif
         _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -24,9 +24,11 @@ public class WalletApiClient : IWalletApiClient
     public WalletApiClient(string? apiUrl)
     {
 
-        // برای حل مشکل SSL در محیط توسعه
         var handler = new HttpClientHandler();
+#if DEBUG
+        // DEV ONLY: accept self-signed certs for local inter-service calls.
         handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+#endif
         _httpClient = new HttpClient(handler);
 
         _walletApiUrl = apiUrl ?? "http://localhost:60933/api";

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TallaEgg.Core;
+using TallaEgg.Core.Cors;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
@@ -93,8 +94,8 @@ builder.Services.AddHttpClient("WalletAPI", client =>
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
-// اضافه کردن CORS
-builder.Services.AddCors();
+// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+builder.Services.AddTallaEggCors(builder.Configuration);
 
 // Add Swagger services
 builder.Services.AddEndpointsApiExplorer();
@@ -188,10 +189,7 @@ app.UseSwaggerUI(c =>
 });
 
 // تنظیم CORS
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+app.UseTallaEggCors();
 
 // Add Swagger middleware
 app.UseSwagger();

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using TallaEgg.Core;
+using TallaEgg.Core.Cors;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
@@ -92,8 +93,8 @@ builder.Services.AddScoped<IWalletService, WalletService>();
 builder.Services.AddScoped<WalletMapper>();
 builder.Services.AddTallaEggErrorHandling();
 
-// اضافه کردن CORS
-builder.Services.AddCors();
+// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+builder.Services.AddTallaEggCors(builder.Configuration);
 
 // Add Swagger services
 builder.Services.AddEndpointsApiExplorer();
@@ -132,10 +133,7 @@ if (app.Environment.IsProduction())
 app.UseAuthorization();
 
 // تنظیم CORS
-app.UseCors(builder => builder
-    .AllowAnyOrigin()
-    .AllowAnyMethod()
-    .AllowAnyHeader());
+app.UseTallaEggCors();
 
 
 

--- a/src/Wallet/Wallet.Tests/CorsExtensionsTests.cs
+++ b/src/Wallet/Wallet.Tests/CorsExtensionsTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TallaEgg.Core.Cors;
+
+namespace Wallet.Tests;
+
+// Exercises TallaEgg.Core.Cors.CorsExtensions the same way every API service wires it up
+// (issue #31), against a bare TestServer instead of any specific service's Program — none of
+// them can boot in this environment without a live SQL Server (issue #68).
+public class CorsExtensionsTests
+{
+    [Fact]
+    public async Task UnlistedOrigin_IsRejected()
+    {
+        var client = await CreateClientAsync("https://allowed.example.com");
+
+        var response = await SendWithOriginAsync(client, "https://not-allowed.example.com");
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public async Task ListedOrigin_IsAllowed()
+    {
+        var client = await CreateClientAsync("https://allowed.example.com");
+
+        var response = await SendWithOriginAsync(client, "https://allowed.example.com");
+
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var values));
+        Assert.Contains("https://allowed.example.com", values!);
+    }
+
+    [Fact]
+    public async Task NoConfiguredOrigins_RejectsEveryOrigin()
+    {
+        var client = await CreateClientAsync();
+
+        var response = await SendWithOriginAsync(client, "https://anything.example.com");
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    private static Task<HttpResponseMessage> SendWithOriginAsync(HttpClient client, string origin)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.Add("Origin", origin);
+        return client.SendAsync(request);
+    }
+
+    private static async Task<HttpClient> CreateClientAsync(params string[] allowedOrigins)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(BuildOriginsConfig(allowedOrigins))
+            .Build();
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services => services.AddTallaEggCors(configuration))
+                    .Configure(app =>
+                    {
+                        app.UseTallaEggCors();
+                        app.Run(context => context.Response.WriteAsync("ok"));
+                    });
+            })
+            .StartAsync();
+
+        return host.GetTestClient();
+    }
+
+    private static IEnumerable<KeyValuePair<string, string?>> BuildOriginsConfig(string[] allowedOrigins)
+    {
+        for (var i = 0; i < allowedOrigins.Length; i++)
+        {
+            yield return new KeyValuePair<string, string?>($"Cors:AllowedOrigins:{i}", allowedOrigins[i]);
+        }
+    }
+}

--- a/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
+++ b/src/Wallet/Wallet.Tests/Wallet.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Gates TLS certificate validation to Debug-only builds and restricts CORS to a configured origin whitelist across all 5 API services, instead of accepting any certificate and any origin unconditionally.

## Issue/Task Reference
Closes #31

## Changes Made
- Wrapped `ServerCertificateCustomValidationCallback = (...) => true` in `#if DEBUG` at all 4 call sites (UsersApiClient, WalletApiClient, OrderApiClient, AffiliateApiClient) — Release builds now perform real certificate-chain validation.
- Added `TallaEgg.Core.Cors.CorsExtensions` (`AddTallaEggCors` / `UseTallaEggCors`), mirroring the shared error-handling extension from #88, so all 5 services configure CORS identically.
- Replaced `AllowAnyOrigin()` in Wallet.Api, Users.Api, TallaEgg.Api, Affiliate.Api, and Orders.Api with a whitelist read from `Cors:AllowedOrigins`. An empty/missing whitelist rejects every cross-origin request — the safe default, since none of these services have a browser client today.
- Documented `Cors:AllowedOrigins` (empty array) for all 5 services in `config/appsettings.global.example.json`.
- Added `CorsExtensionsTests` (TestServer-based) verifying an unlisted origin is rejected, a listed origin is allowed, and no configuration rejects everything.

## Testing
- [x] Unit tests added (`CorsExtensionsTests`, 3 cases) — all pass
- [x] `dotnet build TallaEgg.sln` — Debug and Release both succeed
- [ ] Integration tests run on staging (no staging environment yet — see STANDARDS.md)

## Security Checklist
- [x] TLS validation active in Release builds; bypass compiles only under `DEBUG`
- [x] CORS restricted to origins from config in all 5 services; no `AllowAnyOrigin` in the Release path
- [x] No hardcoded credentials
- [x] `Cors:AllowedOrigins` documented in the appsettings template

## Related Issues
- Audit findings C-7 (TLS validation disabled) and C-9 (CORS fully open) — `docs/operations/AUDIT_FINDINGS.md`