### PR TITLE
[Deployment] Drop HTTPS bind addresses, document ports and Production env — #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Create your own copy from the template below.
       "WalletApiUrl": "http://localhost:60933/"
     },
     "Wallet.Api": {
-      "Urls": [ "https://localhost:60932", "http://localhost:60933" ]
+      "Urls": [ "http://localhost:60933" ]
     },
     "Orders.Api": {
-      "Urls": [ "https://localhost:7140", "http://localhost:5140" ],
+      "Urls": [ "http://localhost:5140" ],
       "WalletApiUrl": "http://localhost:60933/api",
       "Matching": {
         "RequireMarketMakerCounterparty": true,
@@ -103,7 +103,7 @@ Create your own copy from the template below.
       }
     },
     "Affiliate.Api": {
-      "Urls": [ "https://localhost:60811", "http://localhost:60812" ]
+      "Urls": [ "http://localhost:60812" ]
     },
     "TallaEgg.TelegramBot.Infrastructure": {
       "Urls": [ "http://localhost:57546" ],
@@ -132,6 +132,30 @@ Create your own copy from the template below.
 | `Matching:MarketModes` | Without `"MAUA/IRT": "Dealer"` the symbol falls back to `OrderBook` and every quote fill is refused. |
 | `TelegramBotToken` | Read from this file. `TELEGRAM_BOT_TOKEN` is only a fallback for the standalone notification API, **not** for the bot itself. |
 
+### Ports and bind addresses
+
+Every `Urls` entry above is plain HTTP on loopback (`localhost`), on purpose — see
+[#69](https://github.com/MohKardan/TallaEgg/issues/69):
+
+- The bot reaches Telegram by **long polling**; it dials out, Telegram never dials in.
+- The four real APIs are only ever called by the bot, on the same host.
+- So **no inbound port needs to be open**, and no HTTPS bind address is needed either — a
+  `https://localhost:...` entry requires a dev certificate that will not exist on a server, and
+  the only thing between an internet-facing port and the database would be the shared API key
+  above. Binding to loopback is the actual security control here, not a placeholder to replace.
+
+| Service | Port | Purpose |
+| --- | --- | --- |
+| Users.Api | 5136 | Registration, roles, wallet provisioning |
+| Wallet.Api | 60933 | Balances, settlement |
+| Orders.Api | 5140 | Quotes, trades, matching |
+| Affiliate.Api | 60812 | Not deployed — see [Database Setup](#database-setup) |
+| TallaEgg.TelegramBot.Infrastructure | 57546 | Bot's own notification endpoint |
+| TallaEgg.Api | 5135 | Not deployed — legacy, nothing calls it |
+
+On a real server, confirm none of these show up in `netstat`/`ss` on a public interface — only on
+`127.0.0.1`.
+
 ### Shared API key
 
 Wallet.Api, Users.Api, Orders.Api, and Affiliate.Api authenticate inter-service calls with a
@@ -142,6 +166,12 @@ shared key sent via the `X-API-Key` header (`TallaEgg.Core.APIKeyConstant`). It 
   up when `ASPNETCORE_ENVIRONMENT=Production`. Leave the variable unset locally.
 - **Production**: set `TALLAEGG_API_KEY` before starting any service; each one throws at startup
   if it is missing.
+
+> **`ASPNETCORE_ENVIRONMENT` must be set explicitly on a server.** Locally `dotnet run` always
+> reports `Development` because of `launchSettings.json` — that file is not used by a published
+> deployment, so a server defaults to `Production` the moment it's set (or left implicit) outside
+> `dotnet run`. Until [#69](https://github.com/MohKardan/TallaEgg/issues/69), the `Production`
+> code path — API-key auth, no Swagger redirect exemption — had never actually been exercised.
 
 ## Database Setup
 

--- a/config/appsettings.global.example.json
+++ b/config/appsettings.global.example.json
@@ -16,7 +16,6 @@
     "Services": {
         "TallaEgg.Api": {
             "Urls": [
-                "https://localhost:7296",
                 "http://localhost:5135"
             ],
             "UsersApiUrl": "http://localhost:5136",
@@ -35,7 +34,6 @@
         },
         "Orders.Api": {
             "Urls": [
-                "https://localhost:7140",
                 "http://localhost:5140"
             ],
             "WalletApiUrl": "http://localhost:60933/api",
@@ -55,7 +53,6 @@
         },
         "Wallet.Api": {
             "Urls": [
-                "https://localhost:60932",
                 "http://localhost:60933"
             ],
             "Cors": {
@@ -64,7 +61,6 @@
         },
         "Affiliate.Api": {
             "Urls": [
-                "https://localhost:60811",
                 "http://localhost:60812"
             ],
             "Cors": {
@@ -73,7 +69,6 @@
         },
         "TallaEgg.TelegramBot.Infrastructure": {
             "Urls": [
-                "https://localhost:57545",
                 "http://localhost:57546"
             ],
             "OrderApiUrl": "http://localhost:5140/api",


### PR DESCRIPTION
## Description
Config/docs pass for #69. `localhost` bind addresses stay (correct on purpose — inter-process
traffic on one host, no inbound port needed), but the HTTPS variants go, and the risk the issue
flagged (Production has never actually been exercised) gets verified, not just documented.

## Issue/Task Reference
Part of #69 (deployment tracking). Details and verification results also recorded as a comment
on that issue.

## Changes Made
- Removed the `https://localhost:...` bind entries for Wallet.Api, Orders.Api, Affiliate.Api,
  TallaEgg.Api, and the bot from `config/appsettings.global.example.json` and the README's config
  template — an HTTPS bind needs a dev certificate that won't exist on a server, and inter-process
  loopback HTTP needs no TLS.
- Added a **Ports and bind addresses** section to the README: a table of every port and purpose,
  and the reasoning for why loopback-only is the actual security control here (not a placeholder).
- Added a note that `ASPNETCORE_ENVIRONMENT` must be set explicitly on a server — `dotnet run`
  always forces `Development` via `launchSettings.json`, which a published deployment never uses.
- Recorded the `TallaEgg.Api`-not-deployed decision explicitly on #69 (already noted in the
  README from an earlier pass; the issue asked for it to be recorded there too).

## Testing
- [x] Rebuilt the full solution after pulling #104, then ran all four real services
  (`Users.Api`, `Wallet.Api`, `Orders.Api`, `Affiliate.Api`) with
  `ASPNETCORE_ENVIRONMENT=Production TALLAEGG_API_KEY=<test value> dotnet run --no-launch-profile`
  — `--no-launch-profile` is what actually exercises the Production path locally, since plain
  `dotnet run` forces Development regardless of the env var.
- [x] Verified auth on all four: no header → 401, wrong key → 401, correct key → request reaches
  application logic (200/400/500 by service, never 401).
- [x] Confirmed via `netstat` that all four bind only to `127.0.0.1`/`::1`.
- [x] `Affiliate.Api` starts cleanly in Production (confirms the #72 fix holds there, not just in
  Development).
- [x] No secrets/tokens in the diff — only bind-address and doc changes.

## Deployment Notes
No code changed, so nothing to redeploy on its own. Relevant the next time #69/#70 stand up a
real server: use the ports table below and set `ASPNETCORE_ENVIRONMENT=Production` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)