### PR TITLE
[Deployment] Native Windows services for process supervision — #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ dotnet run --no-build --project TelegramBot/TallaEgg.TelegramBot.Infrastructure/
 
 Swagger UI is at `/api-docs` on each service — for example `http://localhost:5136/api-docs`. The bot host also exposes `/api/telegram/notifications/trade-match`.
 
+## Production Deployment
+
+On a server, the four deployed services (not Affiliate.Api or TallaEgg.Api — see above) run as
+native Windows services instead of a terminal per process, so they restart automatically after a
+crash or reboot. See
+[`docs/operations/WINDOWS_DEPLOYMENT.md`](docs/operations/WINDOWS_DEPLOYMENT.md) — issue #70 —
+for the one-time setup and the `scripts/windows-services/` install scripts.
+
 ## Service Highlights
 
 - **Users.Api** — registration with invitation codes, phone updates, role and status management, default wallet provisioning, lookups by Telegram id, phone, or role.

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -33,7 +33,7 @@ public class Program
         // exception left no trace once the console it printed to was gone (issue #99).
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()
-            .WriteTo.File("logs/telegrambot-.log", rollingInterval: RollingInterval.Day)
+            .WriteTo.File("logs/telegrambot-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
             .CreateLogger();
 
         _ = Task.Run(() => TelegramNotificationApi.RunNotificationApi(args));
@@ -44,6 +44,10 @@ public class Program
 
     private static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
+            // No-op outside an actual Windows Service Control Manager session (e.g. local
+            // `dotnet run`), so this is always safe to include. Lets `sc.exe create` manage
+            // this process directly — no third-party supervisor needed (issue #70).
+            .UseWindowsService()
             .UseSerilog()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Telegram.Bot" Version="22.6.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -1,0 +1,93 @@
+# Windows Deployment (issue #70)
+
+How to run Users.Api, Wallet.Api, Orders.Api, and the Telegram bot as native Windows services on
+the production server, so they restart automatically after a crash or a reboot — the actual
+target of KR1's 7-consecutive-days uptime measurement.
+
+`Affiliate.Api` and `TallaEgg.Api` are not part of this: nothing calls `TallaEgg.Api`, and
+`Affiliate.Api` starts but has no migrations (see the README's Database Setup section), so
+neither belongs in a deployment. Decision recorded on
+[#69](https://github.com/MohKardan/TallaEgg/issues/69).
+
+## Why native Windows services, not NSSM or Docker
+
+- **No third-party binary.** Every deployed project now calls
+  `builder.Host.UseWindowsService()` (the APIs) or `.UseWindowsService()` on the bot's
+  `IHostBuilder` chain — a single line from the official
+  `Microsoft.Extensions.Hosting.WindowsServices` package. That's a no-op outside a real Service
+  Control Manager session, so it never affects `dotnet run` locally. Once present, plain
+  `sc.exe` — already on every Windows box — can create, start, and configure crash-recovery for
+  the process directly. NSSM would be one more thing to download, trust, and keep updated for no
+  extra capability here.
+- **Not Docker.** Same reasoning the issue itself gives: `ResolveSharedConfigPath()` walks *up*
+  the directory tree from the content root looking for `config\appsettings.global.json`, which
+  doesn't exist in a from-scratch container image without a volume mount recreating it. That's
+  packaging work with no payoff for four processes on one host, this close to a review.
+
+## One-time setup
+
+1. On the server, pick a deployment root — these scripts default to `C:\TallaEgg`, unrelated to
+   where (or whether) a git checkout lives.
+2. Create `C:\TallaEgg\config\appsettings.global.json` from
+   `config\appsettings.global.example.json` (see the main README's Configuration section) with
+   production values. Bind addresses stay as `http://localhost:<port>` — see the README's Ports
+   and bind addresses section (#69); nothing here should listen on a public interface.
+3. From a dev machine or the server itself, with this repo checked out:
+   ```powershell
+   .\scripts\windows-services\publish-all.ps1 -InstallRoot C:\TallaEgg
+   ```
+4. From an elevated PowerShell session on the server:
+   ```powershell
+   .\scripts\windows-services\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString "TallaEgg API key")
+   ```
+   This creates four services (`TallaEggWalletApi`, `TallaEggUsersApi`, `TallaEggOrdersApi`,
+   `TallaEggBot`), each set to start automatically at boot and restart on crash (10s, then 30s,
+   then 60s backoff, resetting after 24h of stability), with `ASPNETCORE_ENVIRONMENT=Production`
+   and `TALLAEGG_API_KEY` set directly in the service's registry environment — sc.exe has no
+   flag for this, so there is no other native way to hand a Windows service its own environment
+   variables.
+
+## Redeploying a new version
+
+```powershell
+.\scripts\windows-services\publish-all.ps1 -InstallRoot C:\TallaEgg
+.\scripts\windows-services\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString "TallaEgg API key")
+```
+
+`install-services.ps1` stops and recreates each service, so re-running it is the redeploy step —
+there's no separate update path to remember.
+
+## Start order — what's covered and what isn't
+
+`Orders.Api` and `Users.Api` call `Wallet.Api` on startup paths, and all three run
+`Database.MigrateAsync()` as the first thing they do. The service dependency graph
+(`Wallet.Api` before `Users.Api`/`Orders.Api`, all three before the bot) makes Windows wait for
+each dependency to reach the *Running* state first, which absorbs most of the simultaneous-boot
+noise the issue warns about.
+
+What it does **not** guarantee: "Running" means the process started, not that its own migration
+or first outbound call has finished. A dependent service can still log a handful of connection
+retries in the first few seconds after boot. That's expected — restart-on-crash absorbs it — but
+if it's ever not just noise, tighten this with an explicit `Start-Sleep` between dependency tiers
+in `install-services.ps1` rather than assuming SCM ordering alone is sufficient.
+
+## Logs
+
+Each service writes its own `logs\<service>-.log` (bot: `logs\telegrambot-.log`) via Serilog,
+rolling daily, independent of anything the SCM does. Retention is capped at 30 files
+(`retainedFileCountLimit: 30` — issue #70's log-rotation item); before that fix these grew
+without bound. `Get-Content -Wait` on the relevant file is the fastest way to watch a service
+live; nothing here writes to the Windows Event Log.
+
+## Removing the services
+
+```powershell
+.\scripts\windows-services\uninstall-services.ps1
+```
+
+Stops and deletes all four. Published files, logs, and the database are untouched.
+
+## Not covered here
+
+A liveness signal (the running bot proactively reporting a restart, e.g. through the existing
+`TelegramLoggerService`) was noted in #70 as worth doing but not required — it's still open.

--- a/scripts/windows-services/install-services.ps1
+++ b/scripts/windows-services/install-services.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Installs Users.Api, Wallet.Api, Orders.Api, and the Telegram bot as native Windows services
+    (issue #70), so they survive a crash or a reboot without an operator starting them by hand.
+
+.DESCRIPTION
+    Uses only sc.exe and the registry — no third-party supervisor (NSSM, etc.) — because every
+    service already calls builder.Host.UseWindowsService() / Host.UseWindowsService(), which
+    makes the process a proper Windows Service under the SCM. That call is a no-op outside a
+    real service session, so it never affects `dotnet run`.
+
+    Affiliate.Api and TallaEgg.Api are deliberately not installed here — see #69: nothing calls
+    TallaEgg.Api, and Affiliate.Api starts but has no migrations, so its endpoints 500. Neither
+    is part of a deployment.
+
+.PARAMETER InstallRoot
+    Root folder containing `config\appsettings.global.json` and a `publish\<Service>\` folder
+    per service (see publish-all.ps1 in this same directory). Defaults to C:\TallaEgg.
+
+.PARAMETER TallaEggApiKey
+    The shared inter-service API key (see README's "Shared API key" section). Required — every
+    service throws at startup in Production if this is missing, by design (issue #33).
+
+.EXAMPLE
+    .\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString)
+
+.NOTES
+    Run as Administrator. Re-running is safe: existing services are stopped and deleted first,
+    then recreated with the current configuration.
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallRoot = "C:\TallaEgg",
+
+    [Parameter(Mandatory = $true)]
+    [Security.SecureString]$TallaEggApiKey
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated (Administrator) PowerShell session."
+}
+
+$configPath = Join-Path $InstallRoot "config\appsettings.global.json"
+if (-not (Test-Path $configPath)) {
+    throw "Missing $configPath. Create it from config\appsettings.global.example.json with production values before installing services."
+}
+
+$plainApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+    [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($TallaEggApiKey))
+
+# Order matters for the -DependsOn column: Orders.Api and Users.Api call Wallet.Api on startup
+# paths, and all three run MigrateAsync() as the first thing they do. sc.exe's service
+# dependency only guarantees the dependency reached "Running" before this one starts — not that
+# its own startup work (migration, first HTTP call) has finished — so this absorbs most of the
+# ordering risk the issue calls out, not all of it. See the runbook for the residual case.
+$services = @(
+    @{ Name = "TallaEggWalletApi"; Publish = "Wallet.Api";  Exe = "Wallet.Api.exe";                          DependsOn = @() }
+    @{ Name = "TallaEggUsersApi";  Publish = "Users.Api";   Exe = "Users.Api.exe";                           DependsOn = @("TallaEggWalletApi") }
+    @{ Name = "TallaEggOrdersApi"; Publish = "Orders.Api";  Exe = "Orders.Api.exe";                          DependsOn = @("TallaEggWalletApi") }
+    @{ Name = "TallaEggBot";       Publish = "Bot";         Exe = "TallaEgg.TelegramBot.Infrastructure.exe"; DependsOn = @("TallaEggWalletApi", "TallaEggUsersApi", "TallaEggOrdersApi") }
+)
+
+foreach ($svc in $services) {
+    $exePath = Join-Path $InstallRoot "publish\$($svc.Publish)\$($svc.Exe)"
+    if (-not (Test-Path $exePath)) {
+        throw "Missing $exePath. Run publish-all.ps1 first (or dotnet publish that project into $InstallRoot\publish\$($svc.Publish))."
+    }
+
+    $existing = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+    if ($existing) {
+        Write-Host "Stopping and removing existing service $($svc.Name)..."
+        Stop-Service -Name $svc.Name -Force -ErrorAction SilentlyContinue
+        sc.exe delete $svc.Name | Out-Null
+        Start-Sleep -Seconds 1
+    }
+
+    Write-Host "Creating service $($svc.Name)..."
+    sc.exe create $svc.Name binPath= "`"$exePath`"" start= auto obj= "LocalSystem" | Out-Null
+    sc.exe description $svc.Name "TallaEgg $($svc.Publish) (issue #70)" | Out-Null
+
+    # Restart on crash: after 10s, then 30s, then 60s for any subsequent crash within the same
+    # 24h window (reset= 86400). A tight, unthrottled restart loop would mask the first real
+    # failure in noise — the exact risk the issue warns about for simultaneous startup.
+    sc.exe failure $svc.Name reset= 86400 actions= restart/10000/restart/30000/restart/60000 | Out-Null
+    sc.exe failureflag $svc.Name 1 | Out-Null
+
+    if ($svc.DependsOn.Count -gt 0) {
+        $dependString = ($svc.DependsOn -join "/") + "/"
+        sc.exe config $svc.Name depend= $dependString | Out-Null
+    }
+
+    # Native services have no ASPNETCORE_ENVIRONMENT/TALLAEGG_API_KEY unless set here — sc.exe
+    # has no flag for this, so it goes directly into the per-service registry key the SCM reads
+    # at process launch.
+    $envKey = "HKLM:\SYSTEM\CurrentControlSet\Services\$($svc.Name)"
+    Set-ItemProperty -Path $envKey -Name "Environment" -Value @(
+        "ASPNETCORE_ENVIRONMENT=Production",
+        "TALLAEGG_API_KEY=$plainApiKey"
+    ) -Type MultiString
+
+    Write-Host "Starting $($svc.Name)..."
+    Start-Service -Name $svc.Name
+}
+
+$plainApiKey = $null
+[GC]::Collect()
+
+Write-Host ""
+Write-Host "All services installed and started. Check status with:"
+Write-Host "  Get-Service TallaEgg*"
+Write-Host "Logs are under each publish folder's logs\ directory (Serilog), independent of these services."

--- a/scripts/windows-services/publish-all.ps1
+++ b/scripts/windows-services/publish-all.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Publishes the four deployed services into <InstallRoot>\publish\<Service>\, the layout
+    install-services.ps1 expects.
+
+.PARAMETER InstallRoot
+    Root folder to publish into. Defaults to C:\TallaEgg. The repository itself does not need
+    to live here — this script can be run from a normal dev clone with -InstallRoot pointed at
+    the server's deployment folder (e.g. a mapped drive during setup, or run locally on the
+    server after a `git pull`).
+
+.NOTES
+    Requires config\appsettings.global.json to exist in this repo checkout at publish time —
+    Directory.Build.props copies it into each output folder automatically when present. Without
+    it, ResolveSharedConfigPath() falls back to walking up from <InstallRoot>\config\, which
+    install-services.ps1 checks for separately before creating any service.
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallRoot = "C:\TallaEgg"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path "$PSScriptRoot\..\.."
+
+$projects = @(
+    @{ Path = "src\Wallet\Wallet.Api\Wallet.Api.csproj"; Publish = "Wallet.Api" }
+    @{ Path = "src\User\Users.Api\Users.Api.csproj"; Publish = "Users.Api" }
+    @{ Path = "src\Order\Orders.Api\Orders.Api.csproj"; Publish = "Orders.Api" }
+    @{ Path = "TelegramBot\TallaEgg.TelegramBot.Infrastructure\TallaEgg.TelegramBot.Infrastructure.csproj"; Publish = "Bot" }
+)
+
+foreach ($proj in $projects) {
+    $csproj = Join-Path $repoRoot $proj.Path
+    $outDir = Join-Path $InstallRoot "publish\$($proj.Publish)"
+    Write-Host "Publishing $($proj.Path) -> $outDir"
+    dotnet publish $csproj --configuration Release --output $outDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed for $($proj.Path)"
+    }
+}
+
+Write-Host ""
+Write-Host "Done. Next: create $InstallRoot\config\appsettings.global.json (from config\appsettings.global.example.json) if it isn't there yet, then run install-services.ps1."

--- a/scripts/windows-services/uninstall-services.ps1
+++ b/scripts/windows-services/uninstall-services.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Stops and removes the four TallaEgg Windows services installed by install-services.ps1.
+    Does not touch published files, logs, or the database.
+
+.NOTES
+    Run as Administrator.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated (Administrator) PowerShell session."
+}
+
+$serviceNames = @("TallaEggBot", "TallaEggOrdersApi", "TallaEggUsersApi", "TallaEggWalletApi")
+
+foreach ($name in $serviceNames) {
+    $existing = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if (-not $existing) {
+        Write-Host "$name is not installed, skipping."
+        continue
+    }
+
+    Write-Host "Stopping and removing $name..."
+    Stop-Service -Name $name -Force -ErrorAction SilentlyContinue
+    sc.exe delete $name | Out-Null
+}
+
+Write-Host "Done."

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -86,7 +86,7 @@ builder.Services.AddTallaEggErrorHandling();
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day)
+    .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/Order/Orders.Api/Orders.Api.csproj
+++ b/src/Order/Orders.Api/Orders.Api.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -25,6 +25,10 @@ using CancelActiveOrdersResponseDto = TallaEgg.Core.DTOs.Order.CancelActiveOrder
 
 var builder = WebApplication.CreateBuilder(args);
 
+// No-op outside an actual Windows Service Control Manager session (e.g. local `dotnet run`),
+// so this is always safe to include. Lets `sc.exe create` manage this process directly —
+// no third-party supervisor needed (issue #70).
+builder.Host.UseWindowsService();
 
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
@@ -188,7 +192,7 @@ builder.Services.AddSwaggerGen(c =>
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Warning)
     .WriteTo.Console()
-    .WriteTo.File("logs/orders-api-.log", rollingInterval: RollingInterval.Day)
+    .WriteTo.File("logs/orders-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -77,7 +77,7 @@ builder.Services.AddTallaEggErrorHandling();
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day)
+    .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -24,6 +24,11 @@ using Users.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// No-op outside an actual Windows Service Control Manager session (e.g. local `dotnet run`),
+// so this is always safe to include. Lets `sc.exe create` manage this process directly —
+// no third-party supervisor needed (issue #70).
+builder.Host.UseWindowsService();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -115,7 +120,7 @@ builder.Services.AddSwaggerGen(c =>
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day)
+    .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/User/Users.Api/Users.Api.csproj
+++ b/src/User/Users.Api/Users.Api.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -21,6 +21,11 @@ using Wallet.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// No-op outside an actual Windows Service Control Manager session (e.g. local `dotnet run`),
+// so this is always safe to include. Lets `sc.exe create` manage this process directly —
+// no third-party supervisor needed (issue #70).
+builder.Host.UseWindowsService();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -54,7 +59,7 @@ if (urls is { Length: > 0 })
 // پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/wallet-api-.log", rollingInterval: RollingInterval.Day)
+    .WriteTo.File("logs/wallet-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/Wallet/Wallet.Api/Wallet.Api.csproj
+++ b/src/Wallet/Wallet.Api/Wallet.Api.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />


### PR DESCRIPTION
## Description
Process supervision for #70, targeting Windows (confirmed as the real production OS) using
native Windows services instead of a third-party supervisor.

## Issue/Task Reference
Closes #70 (except the optional liveness-signal item, noted as still open).

## Changes Made
- Added `Microsoft.Extensions.Hosting.WindowsServices` and a `UseWindowsService()` call to the
  four deployed services (`Users.Api`, `Wallet.Api`, `Orders.Api`, the bot) — a one-line, no-op
  addition outside a real Service Control Manager session, so it makes each process installable
  as a native service via plain `sc.exe`. No NSSM or other third-party binary needed.
- `scripts/windows-services/publish-all.ps1` — publishes the four projects into a deployment
  layout (`<InstallRoot>\publish\<Service>\`).
- `scripts/windows-services/install-services.ps1` — creates the four Windows services: auto-start
  at boot, crash-recovery backoff (10s/30s/60s, resetting after 24h), start-order dependencies
  (`Wallet.Api` before `Users.Api`/`Orders.Api`, all three before the bot — addresses the
  simultaneous-startup noise the issue calls out), and `ASPNETCORE_ENVIRONMENT`/
  `TALLAEGG_API_KEY` set directly in each service's registry environment (the only native way to
  give a Windows service its own env vars).
- `scripts/windows-services/uninstall-services.ps1` — companion cleanup.
- `docs/operations/WINDOWS_DEPLOYMENT.md` — full runbook: one-time setup, redeploy steps, what
  the start-order dependency does and doesn't guarantee, logs, removal.
- `retainedFileCountLimit: 30` added to all 6 Serilog file sinks (5 APIs + bot) — logs rolled
  daily but nothing ever deleted old files; the issue's log-rotation item.
- README: short "Production Deployment" section pointing at the new runbook.

## Testing
- [x] Full solution build (Debug and Release), 0 errors.
- [x] `dotnet test` — all 378 tests pass.
- [x] Smoke-tested that `UseWindowsService()` doesn't change local behavior: ran Wallet.Api via
  plain `dotnet run` after the change, confirmed identical startup and a working request.
- [x] Syntax-validated all three PowerShell scripts (`Parser]::ParseFile`).
- [x] Not run against a real server — no Windows server exists yet to install onto; the scripts
  and runbook are the deliverable for when #69/#70's target server exists. Installing them
  locally would create persistent real Windows services on a dev machine, which felt like the
  wrong kind of "testing" to do without asking first.
- [x] No secrets/tokens in the diff.

## Deployment Notes
Not usable until a real Windows server exists (tracked separately). When it does: publish via
`publish-all.ps1`, create `config\appsettings.global.json` there from the example template, then
`install-services.ps1`. Full steps in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)