### PR TITLE
feat(orders,bot): make adding/activating trading symbols config- and command-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ The platform supports two market modes per symbol, set in configuration:
 
 `MAUA/IRT` (gold / toman), `SEKE_BAHAR/IRT` (Bahar Azadi coin / toman), and `BTC/IRT` (Bitcoin / toman) run in `Dealer` mode. The counterparty of a fill is whoever published the quote, so nothing needs to name the shop in configuration.
 
+### Adding a trading symbol
+
+Two independent things determine whether customers can trade a symbol, deliberately kept apart:
+
+| What | Where it lives | How it changes |
+| --- | --- | --- |
+| **Metadata** — decimal precision, min/max quantity, Persian display name, which nerkh.io/brsapi.ir instrument prices it | `Symbols:{Base}/{Quote}` in `appsettings.global.json` (see the block already there for the three symbols above) | Edit the file, restart the affected service(s). No code change, no rebuild. |
+| **Active or not** — shown in the customer's symbol picker, eligible for auto-quote, usable for a manual quote | A database row per symbol (`SymbolSettings`, next to `AutoQuoteSettings`) | A bot command, immediately, no restart: `نماد فعال [سکه\|بیت]` / `نماد غیرفعال [...]`. No keyword means MAUA/IRT. |
+
+A symbol that fits the standard shape — Toman-denominated, priced by nerkh.io and/or brsapi.ir the same way gold/coin/Bitcoin already are — needs **only a config block**, then an admin turning it on. `TallaEgg.Core.CurrenciesConstant` ships with the three symbols above as compiled defaults (so the test suite and a fresh clone need no config file at all); a config block for a *new* key adds a fourth entry on top, and a block for an *existing* key overrides only the fields it sets.
+
+`Matching:MarketModes` (above) is separate again — it decides `Dealer` vs `OrderBook`, and still needs its own entry per symbol.
+
+A symbol priced by a source neither nerkh.io nor brsapi.ir covers still needs a new class implementing `Orders.Core.IReferencePriceProvider` — that's the one part of this that's unavoidably code, because it's a new external integration, not a new symbol definition.
+
 ## Tech Stack
 
 - .NET 9.0 with C# 12, minimal APIs, and background services.

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -798,9 +798,9 @@ namespace TallaEgg.TelegramBot
         /// </summary>
         private async Task ShowLatestQuoteAsync(long chatId)
         {
-            foreach (var pair in CurrenciesConstant.AllTradingPairs.Where(p => p.IsActive))
+            foreach (var symbol in await _orderApi.GetActiveSymbolsAsync())
             {
-                var page = await _orderApi.GetQuoteHistoryAsync(pair.Symbol, pageNumber: 1, pageSize: 1);
+                var page = await _orderApi.GetQuoteHistoryAsync(symbol, pageNumber: 1, pageSize: 1);
 
                 await _messenger.SendAsync(chatId, QuoteHistoryHandler.BuildQuoteHistoryAsync(page, currentPage: 1, isAdmin: true));
             }
@@ -822,14 +822,14 @@ namespace TallaEgg.TelegramBot
             // One message (with its own paging keyboard) per active symbol — paging then
             // continues to work exactly as it does today, since each keyboard's callback data
             // already carries the symbol it pages within (QuoteHistoryHandler.CallbackPrefix).
-            foreach (var pair in CurrenciesConstant.AllTradingPairs.Where(p => p.IsActive))
+            foreach (var symbol in await _orderApi.GetActiveSymbolsAsync())
             {
-                var page = await _orderApi.GetQuoteHistoryAsync(pair.Symbol, pageNumber: 1, pageSize: 5);
+                var page = await _orderApi.GetQuoteHistoryAsync(symbol, pageNumber: 1, pageSize: 5);
 
                 await _messenger.SendAsync(
                     chatId,
                     QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin),
-                    replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(page, 1, pair.Symbol));
+                    replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(page, 1, symbol));
             }
         }
 
@@ -963,7 +963,7 @@ namespace TallaEgg.TelegramBot
                 }
 
                 // دریافت جفت‌های معاملاتی فعال
-                var activeTradingPairs = GetActiveTradingPairs();
+                var activeTradingPairs = await GetActiveTradingPairsAsync();
 
                 if (!activeTradingPairs.Any())
                 {
@@ -1016,24 +1016,24 @@ namespace TallaEgg.TelegramBot
         }
 
         /// <summary>
-        /// دریافت لیست جفت‌های معاملاتی فعال با validation
+        /// نمادهایی که الان قابل معامله‌اند — فعال/غیرفعال بودن هر نماد در دیتابیس سرویس
+        /// Orders نگه‌داری می‌شود (نه اینجا)، چون باید با یک دستور ادمین در بات قابل‌تغییر
+        /// باشد، بدون rebuild یا ری‌استارت. متادیتای هر نماد (نام فارسی و غیره) هنوز از
+        /// <see cref="CurrenciesConstant"/> خوانده می‌شود.
         /// </summary>
         /// <returns>لیست جفت‌های معاملاتی فعال</returns>
-        private List<TradingPairInfo> GetActiveTradingPairs()
+        private async Task<List<TradingPairInfo>> GetActiveTradingPairsAsync()
         {
             try
             {
-                if (CurrenciesConstant.AllTradingPairs == null)
-                {
-                    _logger.LogError("CurrenciesConstant.AllTradingPairs is null");
-                    return new List<TradingPairInfo>();
-                }
+                var activeSymbols = await _orderApi.GetActiveSymbolsAsync();
 
-                var activePairs = CurrenciesConstant.AllTradingPairs
-                    .Where(pair => pair != null &&
-                                  pair.IsActive &&
+                var activePairs = activeSymbols
+                    .Select(CurrenciesConstant.GetTradingPairInfo)
+                    .Where(pair => pair is not null &&
                                   !string.IsNullOrWhiteSpace(pair.Symbol) &&
                                   !string.IsNullOrWhiteSpace(pair.PersianName))
+                    .Cast<TradingPairInfo>()
                     .ToList();
 
                 _logger.LogDebug($"Found {activePairs.Count} active trading pairs");

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -293,6 +293,12 @@ namespace TallaEgg.TelegramBot
                 return true;
             }
 
+            if (msgText.StartsWith("نماد "))
+            {
+                await HandleSymbolActiveCommandAsync(chatId, msgText, user);
+                return true;
+            }
+
             //دستور ثبت قیمت جفتی برای ادمین
             // Handle price pair format: buyPrice-sellPrice, with an optional trailing symbol
             // keyword (e.g., 8523690-8529630 یا 8523690-8529630 سکه). No keyword means MAUA/IRT
@@ -583,25 +589,13 @@ namespace TallaEgg.TelegramBot
         }
 
         /// <summary>
-        /// Resolves the optional trailing symbol keyword on the auto-quote and manual-quote
-        /// commands ("سکه", "بیت"/"بیتکوین") to a trading-pair symbol. No keyword, or an empty
-        /// one, means MAUA/IRT — every admin habit from before these symbols existed keeps
-        /// working unchanged. Returns null for a keyword that matches nothing, so the caller can
-        /// tell "no symbol given" apart from "unrecognised symbol".
+        /// Resolves the optional trailing symbol keyword on the auto-quote, manual-quote, and
+        /// active/inactive commands to a trading-pair symbol — delegates to
+        /// <see cref="CurrenciesConstant.ResolveSymbolByAlias"/> so a symbol added purely via
+        /// config (with its own <c>Aliases</c> entry) is recognised here with no code change.
         /// </summary>
-        private static string? ResolveAdminQuoteSymbol(string? keyword)
-        {
-            var trimmed = keyword?.Trim();
-            if (string.IsNullOrEmpty(trimmed))
-                return CurrenciesConstant.MAUA_IRT;
-
-            return trimmed switch
-            {
-                "سکه" => CurrenciesConstant.SEKE_BAHAR_IRT,
-                "بیت" or "بیتکوین" or "بیت‌کوین" => CurrenciesConstant.BTC_IRT,
-                _ => null
-            };
-        }
+        private static string? ResolveAdminQuoteSymbol(string? keyword) =>
+            CurrenciesConstant.ResolveSymbolByAlias(keyword);
 
         /// <summary>
         /// <c>اسپرد [درصد]</c> / <c>اسپرد [درصد] [نماد]</c> — sets the spread the automatic
@@ -664,6 +658,39 @@ namespace TallaEgg.TelegramBot
             await _messenger.SendAsync(chatId, success
                 ? (enable ? BotMsgs.MsgAutoQuoteEnabled : BotMsgs.MsgAutoQuoteDisabled)
                 : string.Format(BotMsgs.MsgAutoQuoteToggleFailed, message));
+        }
+
+        /// <summary>
+        /// <c>نماد فعال</c> / <c>نماد غیرفعال</c> (+ optional trailing symbol keyword) — turns a
+        /// symbol tradable or not: shown in the customer's symbol picker, eligible for
+        /// auto-quote, usable for a manual quote. No symbol keyword means MAUA/IRT, the same
+        /// convention as <see cref="HandleAutoQuoteToggleCommandAsync"/>. Independent of
+        /// auto-quote's own on/off switch — a symbol can be tradable with only manual quotes.
+        /// </summary>
+        private async Task HandleSymbolActiveCommandAsync(long chatId, string msgText, UserDto actor)
+        {
+            var match = Regex.Match(msgText.Trim(), @"^نماد\s+(?<state>فعال|غیرفعال)(?:\s+(?<symbol>\S+))?$", RegexOptions.Compiled);
+
+            if (!match.Success)
+            {
+                await _messenger.SendAsync(chatId, BotMsgs.MsgSymbolActiveFormatError);
+                return;
+            }
+
+            var makeActive = match.Groups["state"].Value == "فعال";
+
+            var symbol = ResolveAdminQuoteSymbol(match.Groups["symbol"].Success ? match.Groups["symbol"].Value : null);
+            if (symbol is null)
+            {
+                await _messenger.SendAsync(chatId, BotMsgs.MsgAdminUnknownQuoteSymbol);
+                return;
+            }
+
+            var (success, message) = await _orderApi.SetSymbolActiveAsync(symbol, makeActive, actor.Id);
+
+            await _messenger.SendAsync(chatId, success
+                ? (makeActive ? BotMsgs.MsgSymbolActivated : BotMsgs.MsgSymbolDeactivated)
+                : string.Format(BotMsgs.MsgSymbolActiveFailed, message));
         }
 
         /// <summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
@@ -55,4 +55,12 @@ public interface IOrderApiClient
 
     /// <summary>روشن/خاموش کردن مظنهٔ اتومات یک نماد.</summary>
     Task<(bool success, string message)> SetAutoQuoteEnabledAsync(string symbol, bool isEnabled, Guid updatedByUserId);
+
+    // ── فعال/غیرفعال بودن نماد ───────────────────────────────────────────────────
+
+    /// <summary>نمادهایی که الان قابل معامله‌اند.</summary>
+    Task<List<string>> GetActiveSymbolsAsync();
+
+    /// <summary>فعال/غیرفعال کردن یک نماد.</summary>
+    Task<(bool success, string message)> SetSymbolActiveAsync(string symbol, bool isActive, Guid updatedByUserId);
 }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -510,6 +510,48 @@ public class OrderApiClient : IOrderApiClient
         }
     }
 
+    /// <summary>نمادهایی که الان قابل معامله‌اند — خالی اگر سرور در دسترس نبود.</summary>
+    public async Task<List<string>> GetActiveSymbolsAsync()
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{_baseUrl}/symbols/active");
+            if (!response.IsSuccessStatusCode) return new List<string>();
+
+            var body = await response.Content.ReadAsStringAsync();
+            var parsed = System.Text.Json.JsonSerializer.Deserialize<TallaEgg.Core.DTOs.ApiResponse<List<string>>>(
+                body, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return parsed?.Data ?? new List<string>();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+
+    public async Task<(bool success, string message)> SetSymbolActiveAsync(string symbol, bool isActive, Guid updatedByUserId)
+    {
+        try
+        {
+            var payload = new { isActive, updatedByUserId };
+            var content = new StringContent(
+                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync($"{_baseUrl}/symbols/{symbol}/active", content);
+            var body = await response.Content.ReadAsStringAsync();
+            var message = TryReadMessage(body);
+
+            return response.IsSuccessStatusCode
+                ? (true, message ?? "انجام شد.")
+                : (false, message ?? $"خطا (کد {(int)response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+        }
+    }
+
     /// <summary>مظنهٔ فعال یک نماد، یا null اگر منتشر نشده باشد.</summary>
     public async Task<QuoteDto?> GetActiveQuoteAsync(string symbol)
     {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -620,10 +620,26 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string MsgAutoQuoteToggleFailed = "❌ انجام نشد.\n\nدلیل: {0}";
 
         /// <summary>
-        /// وقتی نماد نوشته‌شده بعد از دستور «اسپرد»، «اتومات»، یا قیمت‌جفتی شناخته‌شده نیست.
+        /// وقتی نماد نوشته‌شده بعد از دستور «اسپرد»، «اتومات»، «نماد»، یا قیمت‌جفتی شناخته‌شده
+        /// نیست.
         /// </summary>
         public const string MsgAdminUnknownQuoteSymbol = "❌ این نماد شناخته‌شده نیست.\n\n" +
                                                           "نمادهای معتبر: (خالی = آبشده)، سکه، بیت";
+
+        // ── فعال/غیرفعال بودن نماد ───────────────────────────────────────────────
+
+        public const string MsgSymbolActiveFormatError = "❌ قالب دستور درست نیست.\n\n" +
+                                                          "قالب صحیح:\n" +
+                                                          "نماد فعال\n" +
+                                                          "نماد غیرفعال\n\n" +
+                                                          "با نماد دیگر: نماد فعال سکه";
+
+        public const string MsgSymbolActivated = "✅ نماد فعال شد و برای مشتریان قابل‌معامله است.";
+
+        public const string MsgSymbolDeactivated = "⏸️ نماد غیرفعال شد.";
+
+        /// <summary>{0} = دلیل خطا</summary>
+        public const string MsgSymbolActiveFailed = "❌ انجام نشد.\n\nدلیل: {0}";
 
         /// <summary>
         /// وقتی ربات بدون تغییر نسخه دوباره اجرا می‌شود (ری‌استارت معمولی).

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -80,6 +80,9 @@ public class Program
             })
             .ConfigureServices((context, services) =>
             {
+                // نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+                TallaEgg.Core.CurrenciesConstant.Configure(context.Configuration);
+
                 services.AddOptions<TelegramBotOptions>()
                     .Bind(context.Configuration)
                     .ValidateDataAnnotations();

--- a/config/appsettings.global.example.json
+++ b/config/appsettings.global.example.json
@@ -13,6 +13,49 @@
         "WalletDb": "Server=localhost\\SQLEXPRESS;Database=TallaEggWallet;Trusted_Connection=True;TrustServerCertificate=True;",
         "AffiliateDb": "Server=localhost\\SQLEXPRESS;Database=TallaEggAffiliate;Trusted_Connection=True;TrustServerCertificate=True;"
     },
+    "Symbols": {
+        "MAUA/IRT": {
+            "PersianName": "آبشده/تومان",
+            "BaseAssetPersianName": "آبشده",
+            "BaseUnit": "گرم",
+            "BaseDecimalPlaces": 2,
+            "MinQuantity": 0.1,
+            "MaxQuantity": 1000,
+            "PriceDecimalPlaces": 0,
+            "QuantityDecimalPlaces": 3,
+            "MinNotional": 100000,
+            "Nerkh": { "Path": "gold/MESGHAL", "Key": "MESGHAL", "ConvertFromMesghal": true },
+            "BrsApi": { "Array": "gold", "Symbol": "IR_GOLD_MELTED", "ConvertFromMesghal": true }
+        },
+        "SEKE_BAHAR/IRT": {
+            "PersianName": "سکه تمام بهار آزادی/تومان",
+            "BaseAssetPersianName": "سکه تمام بهار آزادی",
+            "BaseUnit": "سکه",
+            "BaseDecimalPlaces": 2,
+            "MinQuantity": 0.01,
+            "MaxQuantity": 50,
+            "PriceDecimalPlaces": 0,
+            "QuantityDecimalPlaces": 2,
+            "MinNotional": 1000000,
+            "Aliases": [ "سکه" ],
+            "Nerkh": { "Path": "gold/SEKE_BAHAR", "Key": "SEKE_BAHAR", "ConvertFromMesghal": false },
+            "BrsApi": { "Array": "gold", "Symbol": "IR_COIN_BAHAR", "ConvertFromMesghal": false }
+        },
+        "BTC/IRT": {
+            "PersianName": "بیت‌کوین/تومان",
+            "BaseAssetPersianName": "بیت‌کوین",
+            "BaseUnit": "بیت‌کوین",
+            "BaseDecimalPlaces": 8,
+            "MinQuantity": 0.0001,
+            "MaxQuantity": 100,
+            "PriceDecimalPlaces": 0,
+            "QuantityDecimalPlaces": 8,
+            "MinNotional": 1000000,
+            "Aliases": [ "بیت", "بیتکوین", "بیت‌کوین" ],
+            "Nerkh": { "Path": "crypto/BTC", "Key": "BTC", "ConvertFromMesghal": false },
+            "BrsApi": { "Array": "cryptocurrency", "Symbol": "BTC", "ConvertFromMesghal": false }
+        }
+    },
     "Services": {
         "TallaEgg.Api": {
             "Urls": [

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -38,6 +38,9 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
+
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
 if (urls is { Length: > 0 })
 {

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -54,6 +54,9 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
+
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
 if (urls is { Length: > 0 })
 {
@@ -135,25 +138,26 @@ builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorSer
 // Bitcoin — see Orders.Core.IReferencePriceProvider) and publishes a quote the same way an
 // admin does by hand. Off for a symbol until an admin turns it on via the bot.
 // A named HttpClient per provider rather than AddHttpClient<TInterface,TImplementation>: two
-// implementations share IReferencePriceProvider, and each needs its own API token/key, which is
-// a plain configuration string DI cannot inject as a constructor parameter on its own.
+// implementations share IReferencePriceProvider. Each now takes IConfiguration directly (not
+// just its own token/key) so it can also resolve a config-driven instrument mapping for a
+// symbol added without a code change — see NerkhPriceProvider/BrsApiPriceProvider.InstrumentFor.
 builder.Services.AddHttpClient("NerkhPriceProvider");
 builder.Services.AddHttpClient("BrsApiPriceProvider");
 
-var nerkhApiToken = builder.Configuration["AutoQuote:NerkhApiToken"];
-var brsApiKey = builder.Configuration["AutoQuote:BrsApiKey"];
-
 builder.Services.AddScoped<Orders.Core.IAutoQuoteSettingsRepository, Orders.Infrastructure.AutoQuoteSettingsRepository>();
+
+// فعال/غیرفعال بودن هر نماد، تغییرپذیر با دستور ادمین در بات — نه یک const که rebuild بخواهد.
+builder.Services.AddScoped<Orders.Core.ISymbolSettingsRepository, Orders.Infrastructure.SymbolSettingsRepository>();
 
 builder.Services.AddScoped<Orders.Core.IReferencePriceProvider>(sp => new Orders.Infrastructure.Clients.NerkhPriceProvider(
     sp.GetRequiredService<IHttpClientFactory>().CreateClient("NerkhPriceProvider"),
     sp.GetRequiredService<ILogger<Orders.Infrastructure.Clients.NerkhPriceProvider>>(),
-    nerkhApiToken));
+    sp.GetRequiredService<IConfiguration>()));
 
 builder.Services.AddScoped<Orders.Core.IReferencePriceProvider>(sp => new Orders.Infrastructure.Clients.BrsApiPriceProvider(
     sp.GetRequiredService<IHttpClientFactory>().CreateClient("BrsApiPriceProvider"),
     sp.GetRequiredService<ILogger<Orders.Infrastructure.Clients.BrsApiPriceProvider>>(),
-    brsApiKey));
+    sp.GetRequiredService<IConfiguration>()));
 
 builder.Services.AddScoped<Orders.Application.Services.ReferencePriceProviderChain>();
 builder.Services.AddHostedService<Orders.Application.Services.AutoQuotePublisherService>();
@@ -330,6 +334,36 @@ static AutoQuoteSettingsDto ToAutoQuoteSettingsDto(Orders.Core.AutoQuoteSettings
     Symbol = s.Symbol,
     SpreadPercent = s.SpreadPercent,
     IsEnabled = s.IsEnabled,
+    UpdatedAt = s.UpdatedAt
+};
+
+// ─────────────────────── فعال/غیرفعال بودن نماد ─────────────────────────
+
+/// <summary>نمادهایی که الان قابل معامله‌اند — بات از این برای منوی انتخاب نماد استفاده می‌کند.</summary>
+app.MapGet("/api/symbols/active", async (Orders.Core.ISymbolSettingsRepository settingsRepo) =>
+{
+    var symbols = await settingsRepo.GetActiveSymbolsAsync();
+    return Results.Ok(ApiResponse<List<string>>.Ok(symbols.ToList()));
+});
+
+/// <summary>فعال/غیرفعال کردن یک نماد.</summary>
+app.MapPost("/api/symbols/{Base}/{Quote}/active", async (
+    string Base, string Quote, SetSymbolActiveRequest request, Orders.Core.ISymbolSettingsRepository settingsRepo) =>
+{
+    var symbol = $"{Base}/{Quote}";
+
+    var settings = await settingsRepo.GetOrCreateAsync(symbol);
+    settings.SetActive(request.IsActive, request.UpdatedByUserId);
+    await settingsRepo.SaveAsync(settings);
+
+    return Results.Ok(ApiResponse<SymbolSettingsDto>.Ok(ToSymbolSettingsDto(settings),
+        request.IsActive ? "نماد فعال شد." : "نماد غیرفعال شد."));
+});
+
+static SymbolSettingsDto ToSymbolSettingsDto(Orders.Core.SymbolSettings s) => new()
+{
+    Symbol = s.Symbol,
+    IsActive = s.IsActive,
     UpdatedAt = s.UpdatedAt
 };
 

--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -13,10 +13,12 @@ namespace Orders.Application.Services;
 /// changes (issue #90).
 ///
 /// <para>
-/// Originally MAUA/IRT only; generalized to loop over <see cref="CurrenciesConstant.AllTradingPairs"/>
-/// when coin and Bitcoin quoting were added, so a new active symbol needs no change here — only
-/// a <see cref="CurrenciesConstant"/> entry and, per symbol, an admin explicitly opting in (see
-/// <see cref="AutoQuoteSettings"/>).
+/// Originally MAUA/IRT only; generalized to loop over every symbol <see cref="ISymbolSettingsRepository"/>
+/// reports active when coin and Bitcoin quoting were added, so a newly activated symbol needs no
+/// change here — only a bot command to turn it on (<see cref="SymbolSettings"/>) and, per symbol,
+/// an admin explicitly opting into auto-quote too (see <see cref="AutoQuoteSettings"/>). The two
+/// are independent switches on purpose: a symbol can be tradable with only manual quotes, or not
+/// tradable at all regardless of its auto-quote setting.
 /// </para>
 ///
 /// A manually published quote always overrides the automatic one on the next customer action,
@@ -42,11 +44,13 @@ public class AutoQuotePublisherService : BackgroundService
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            foreach (var pair in CurrenciesConstant.AllTradingPairs.Where(p => p.IsActive))
+            var activeSymbols = await ActiveSymbolsAsync(stoppingToken);
+
+            foreach (var symbol in activeSymbols)
             {
                 try
                 {
-                    await PublishIfDueAsync(pair.Symbol, stoppingToken);
+                    await PublishIfDueAsync(symbol, stoppingToken);
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
@@ -57,7 +61,7 @@ public class AutoQuotePublisherService : BackgroundService
                     // A misconfiguration or a bug for one symbol must never take the rest of the
                     // shop down — manual quotes and trading, and every other symbol's auto-quote,
                     // are unrelated to this one failing (same rule already established for #73).
-                    _logger.LogError(ex, "Unexpected error auto-publishing a quote for {Symbol}.", pair.Symbol);
+                    _logger.LogError(ex, "Unexpected error auto-publishing a quote for {Symbol}.", symbol);
                 }
             }
 
@@ -69,6 +73,13 @@ public class AutoQuotePublisherService : BackgroundService
         }
 
         _logger.LogInformation("AutoQuotePublisherService stopped.");
+    }
+
+    private async Task<IReadOnlyList<string>> ActiveSymbolsAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var symbolSettingsRepo = scope.ServiceProvider.GetRequiredService<ISymbolSettingsRepository>();
+        return await symbolSettingsRepo.GetActiveSymbolsAsync();
     }
 
     /// <summary>internal so the tick logic can be tested directly, without waiting on the poll loop.</summary>

--- a/src/Order/Orders.Core/ISymbolSettingsRepository.cs
+++ b/src/Order/Orders.Core/ISymbolSettingsRepository.cs
@@ -1,0 +1,15 @@
+namespace Orders.Core;
+
+public interface ISymbolSettingsRepository
+{
+    /// <summary>
+    /// The settings row for a symbol, creating and persisting the inactive-by-default row the
+    /// first time it is asked for. The caller never has to special-case "no row yet".
+    /// </summary>
+    Task<SymbolSettings> GetOrCreateAsync(string symbol);
+
+    /// <summary>Symbols currently active, for the bot's symbol picker and the auto-quote loop.</summary>
+    Task<IReadOnlyList<string>> GetActiveSymbolsAsync();
+
+    Task SaveAsync(SymbolSettings settings);
+}

--- a/src/Order/Orders.Core/SymbolSettings.cs
+++ b/src/Order/Orders.Core/SymbolSettings.cs
@@ -1,0 +1,60 @@
+namespace Orders.Core;
+
+/// <summary>
+/// Whether a trading pair is currently tradable — shown in the bot's symbol picker, eligible
+/// for automatic quoting, and (via <see cref="Quote"/>/<see cref="QuoteFillService"/>) able to
+/// be traded at all. A database row rather than a compiled constant, the same reasoning as
+/// <see cref="AutoQuoteSettings"/>: activating or deactivating a symbol needs to be a bot
+/// command an admin can run, not a code change and a redeploy.
+///
+/// <para>
+/// Everything else about a symbol — decimal precision, min/max quantity, which external price
+/// providers know it and under what instrument key — lives in configuration
+/// (<c>Symbols:{symbol}</c> in <c>appsettings.global.json</c>, read by
+/// <c>TallaEgg.Core.CurrenciesConstant</c>). Only the on/off switch is here, because it is the
+/// one property an admin needs to flip at runtime without touching a file or a deploy.
+/// </para>
+/// </summary>
+public class SymbolSettings
+{
+    public Guid Id { get; private set; }
+
+    /// <summary>Symbol this row governs, e.g. <c>MAUA/IRT</c>.</summary>
+    public string Symbol { get; private set; } = string.Empty;
+
+    public bool IsActive { get; private set; }
+
+    public Guid UpdatedByUserId { get; private set; }
+
+    public DateTime UpdatedAt { get; private set; }
+
+    /// <summary>EF Core needs a parameterless constructor.</summary>
+    private SymbolSettings() { }
+
+    /// <summary>
+    /// The row a symbol gets the first time it is asked about. Starts <b>inactive</b> — a newly
+    /// configured symbol must be explicitly turned on by an admin before customers see it,
+    /// rather than becoming tradable the moment someone adds a config block for it.
+    /// </summary>
+    public static SymbolSettings CreateDefault(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+            throw new ArgumentException("نماد نمی‌تواند خالی باشد.", nameof(symbol));
+
+        return new SymbolSettings
+        {
+            Id = Guid.NewGuid(),
+            Symbol = symbol.Trim().ToUpperInvariant(),
+            IsActive = false,
+            UpdatedByUserId = Guid.Empty,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    public void SetActive(bool isActive, Guid updatedByUserId)
+    {
+        IsActive = isActive;
+        UpdatedByUserId = updatedByUserId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Order/Orders.Infrastructure/Clients/BrsApiPriceProvider.cs
+++ b/src/Order/Orders.Infrastructure/Clients/BrsApiPriceProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 using TallaEgg.Core;
@@ -10,6 +11,13 @@ namespace Orders.Infrastructure.Clients;
 /// endpoint (<c>Gold_Currency.php</c>), keyed with an API key in the query string. Same product
 /// as nerkh.io's gold/coin instruments — cross-checked live and agreed to within 0.1% before
 /// this was written, which is what makes the two a meaningful fallback pair.
+///
+/// <para>
+/// The instrument each symbol maps to (which of brsapi's response arrays, and which symbol
+/// inside it) is a compiled default for the three symbols this platform trades today, and falls
+/// back to <c>Symbols:{symbol}:BrsApi</c> in configuration for anything else — see
+/// <see cref="InstrumentFor"/>.
+/// </para>
 /// </summary>
 public class BrsApiPriceProvider : IReferencePriceProvider
 {
@@ -17,28 +25,36 @@ public class BrsApiPriceProvider : IReferencePriceProvider
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<BrsApiPriceProvider> _logger;
-    private readonly string? _apiKey;
+    private readonly IConfiguration _configuration;
 
     public string Name => "brsapi.ir";
 
-    public BrsApiPriceProvider(HttpClient httpClient, ILogger<BrsApiPriceProvider> logger, string? apiKey)
+    public BrsApiPriceProvider(HttpClient httpClient, ILogger<BrsApiPriceProvider> logger, IConfiguration configuration)
     {
         _httpClient = httpClient;
         _logger = logger;
-        _apiKey = apiKey;
+        _configuration = configuration;
     }
 
     public async Task<decimal?> GetPriceAsync(string symbol, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(_apiKey))
+        var apiKey = _configuration["AutoQuote:BrsApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
         {
             _logger.LogWarning("brsapi.ir skipped: no API key configured (Services:Orders.Api:AutoQuote:BrsApiKey).");
             return null;
         }
 
+        var instrument = InstrumentFor(symbol);
+        if (instrument is null)
+        {
+            _logger.LogWarning("brsapi.ir has no configured instrument for {Symbol}.", symbol);
+            return null;
+        }
+
         try
         {
-            using var response = await _httpClient.GetAsync($"{Url}?key={_apiKey}", cancellationToken);
+            using var response = await _httpClient.GetAsync($"{Url}?key={apiKey}", cancellationToken);
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
 
             if (!response.IsSuccessStatusCode)
@@ -48,23 +64,14 @@ public class BrsApiPriceProvider : IReferencePriceProvider
             }
 
             using var doc = JsonDocument.Parse(body);
+            var (array, instrumentSymbol, convertFromMesghal) = instrument.Value;
 
-            switch (symbol)
-            {
-                case CurrenciesConstant.MAUA_IRT:
-                    var melted = FindGoldPrice(doc, "IR_GOLD_MELTED");
-                    return melted is null ? null : melted / CurrenciesConstant.GramsPerMesghal;
-
-                case CurrenciesConstant.SEKE_BAHAR_IRT:
-                    return FindGoldPrice(doc, "IR_COIN_BAHAR");
-
-                case CurrenciesConstant.BTC_IRT:
-                    return ConvertCryptoToToman(doc, "BTC");
-
-                default:
-                    _logger.LogWarning("brsapi.ir has no configured instrument for {Symbol}.", symbol);
-                    return null;
-            }
+            // brsapi's "cryptocurrency" array is USD-denominated (a JSON string) and needs a
+            // USD/Toman conversion from the same response's "currency" array; "gold" is already
+            // Toman (a JSON number) and covers both metal and coin instruments alike.
+            return array == "cryptocurrency"
+                ? ConvertCryptoToToman(doc, instrumentSymbol)
+                : FindGoldPrice(doc, instrumentSymbol, convertFromMesghal);
         }
         catch (Exception ex)
         {
@@ -73,8 +80,33 @@ public class BrsApiPriceProvider : IReferencePriceProvider
         }
     }
 
+    /// <summary>
+    /// Maps our trading-pair symbol to brsapi.ir's response array and instrument symbol. The
+    /// three symbols traded today are compiled defaults; anything else is looked up under
+    /// <c>Symbols:{symbol}:BrsApi</c> (fields: <c>Array</c> — "gold" or "cryptocurrency" —
+    /// <c>Symbol</c>, and the optional bool <c>ConvertFromMesghal</c>) in configuration.
+    /// </summary>
+    private (string Array, string Symbol, bool ConvertFromMesghal)? InstrumentFor(string symbol)
+    {
+        (string, string, bool)? compiled = symbol switch
+        {
+            CurrenciesConstant.MAUA_IRT => ("gold", "IR_GOLD_MELTED", true),
+            CurrenciesConstant.SEKE_BAHAR_IRT => ("gold", "IR_COIN_BAHAR", false),
+            CurrenciesConstant.BTC_IRT => ("cryptocurrency", "BTC", false),
+            _ => null
+        };
+        if (compiled is not null) return compiled;
+
+        var section = _configuration.GetSection($"Symbols:{symbol}:BrsApi");
+        var array = section["Array"];
+        var instrumentSymbol = section["Symbol"];
+        if (string.IsNullOrWhiteSpace(array) || string.IsNullOrWhiteSpace(instrumentSymbol)) return null;
+
+        return (array, instrumentSymbol, section.GetValue("ConvertFromMesghal", false));
+    }
+
     /// <summary>Toman-denominated instruments — the "gold" array covers metal and coins alike.</summary>
-    private decimal? FindGoldPrice(JsonDocument doc, string targetSymbol)
+    private decimal? FindGoldPrice(JsonDocument doc, string targetSymbol, bool convertFromMesghal)
     {
         foreach (var item in doc.RootElement.GetProperty("gold").EnumerateArray())
         {
@@ -83,7 +115,8 @@ public class BrsApiPriceProvider : IReferencePriceProvider
             // brsapi returns gold prices as a JSON number, unlike nerkh's string — each
             // provider parses its own shape rather than forcing a shared response type onto two
             // APIs that were never designed to agree.
-            return item.GetProperty("price").GetDecimal();
+            var price = item.GetProperty("price").GetDecimal();
+            return convertFromMesghal ? price / CurrenciesConstant.GramsPerMesghal : price;
         }
 
         _logger.LogWarning("brsapi.ir response did not contain gold symbol {Symbol}.", targetSymbol);

--- a/src/Order/Orders.Infrastructure/Clients/NerkhPriceProvider.cs
+++ b/src/Order/Orders.Infrastructure/Clients/NerkhPriceProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 using TallaEgg.Core;
@@ -9,6 +10,14 @@ namespace Orders.Infrastructure.Clients;
 /// nerkh.io — melted 18k gold ("آبشده"), the Bahar Azadi coin, and Bitcoin, all authenticated
 /// with the same bearer token. <c>https://docs.nerkh.io/</c> (OpenAPI spec) is the source of the
 /// endpoint shapes below; each verified live against the real token before this was written.
+///
+/// <para>
+/// The instrument each symbol maps to (nerkh's endpoint path, its JSON property key, and
+/// whether the price needs converting from mesghal) is a compiled default for the three symbols
+/// this platform trades today, and falls back to <c>Symbols:{symbol}:Nerkh</c> in configuration
+/// for anything else — so a new symbol nerkh.io also happens to price needs no code change here,
+/// only a config block (see <see cref="InstrumentFor"/>).
+/// </para>
 /// </summary>
 public class NerkhPriceProvider : IReferencePriceProvider
 {
@@ -16,20 +25,21 @@ public class NerkhPriceProvider : IReferencePriceProvider
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<NerkhPriceProvider> _logger;
-    private readonly string? _apiToken;
+    private readonly IConfiguration _configuration;
 
     public string Name => "nerkh.io";
 
-    public NerkhPriceProvider(HttpClient httpClient, ILogger<NerkhPriceProvider> logger, string? apiToken)
+    public NerkhPriceProvider(HttpClient httpClient, ILogger<NerkhPriceProvider> logger, IConfiguration configuration)
     {
         _httpClient = httpClient;
         _logger = logger;
-        _apiToken = apiToken;
+        _configuration = configuration;
     }
 
     public async Task<decimal?> GetPriceAsync(string symbol, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(_apiToken))
+        var apiToken = _configuration["AutoQuote:NerkhApiToken"];
+        if (string.IsNullOrWhiteSpace(apiToken))
         {
             _logger.LogWarning("nerkh.io skipped: no API token configured (Services:Orders.Api:AutoQuote:NerkhApiToken).");
             return null;
@@ -42,31 +52,46 @@ public class NerkhPriceProvider : IReferencePriceProvider
             return null;
         }
 
-        var (path, key) = instrument.Value;
-        var price = await FetchAsync(path, key, cancellationToken);
+        var (path, key, convertFromMesghal) = instrument.Value;
+        var price = await FetchAsync(path, key, apiToken, cancellationToken);
         if (price is null) return null;
 
-        // MESGHAL is nerkh's native gold unit; quotes for MAUA/IRT are stored per gram. The
-        // coin and Bitcoin instruments are already priced per the whole unit we trade, so no
-        // further conversion applies to them.
-        return key == "MESGHAL" ? price / CurrenciesConstant.GramsPerMesghal : price;
+        // MESGHAL is nerkh's native gold unit; quotes for MAUA/IRT are stored per gram. Every
+        // other instrument (coins, crypto) is already priced per the whole unit we trade.
+        return convertFromMesghal ? price / CurrenciesConstant.GramsPerMesghal : price;
     }
 
-    /// <summary>Maps our trading-pair symbol to nerkh.io's endpoint category and instrument key.</summary>
-    private static (string Path, string Key)? InstrumentFor(string symbol) => symbol switch
+    /// <summary>
+    /// Maps our trading-pair symbol to nerkh.io's endpoint category and instrument key. The
+    /// three symbols traded today are compiled defaults; anything else is looked up under
+    /// <c>Symbols:{symbol}:Nerkh</c> (fields: <c>Path</c>, <c>Key</c>, and the optional bool
+    /// <c>ConvertFromMesghal</c>) in configuration.
+    /// </summary>
+    private (string Path, string Key, bool ConvertFromMesghal)? InstrumentFor(string symbol)
     {
-        CurrenciesConstant.MAUA_IRT => ("gold/MESGHAL", "MESGHAL"),
-        CurrenciesConstant.SEKE_BAHAR_IRT => ("gold/SEKE_BAHAR", "SEKE_BAHAR"),
-        CurrenciesConstant.BTC_IRT => ("crypto/BTC", "BTC"),
-        _ => null
-    };
+        (string, string, bool)? compiled = symbol switch
+        {
+            CurrenciesConstant.MAUA_IRT => ("gold/MESGHAL", "MESGHAL", true),
+            CurrenciesConstant.SEKE_BAHAR_IRT => ("gold/SEKE_BAHAR", "SEKE_BAHAR", false),
+            CurrenciesConstant.BTC_IRT => ("crypto/BTC", "BTC", false),
+            _ => null
+        };
+        if (compiled is not null) return compiled;
 
-    private async Task<decimal?> FetchAsync(string path, string key, CancellationToken cancellationToken)
+        var section = _configuration.GetSection($"Symbols:{symbol}:Nerkh");
+        var path = section["Path"];
+        var key = section["Key"];
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(key)) return null;
+
+        return (path, key, section.GetValue("ConvertFromMesghal", false));
+    }
+
+    private async Task<decimal?> FetchAsync(string path, string key, string apiToken, CancellationToken cancellationToken)
     {
         try
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, BaseUrl + path);
-            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _apiToken);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiToken);
 
             using var response = await _httpClient.SendAsync(request, cancellationToken);
             var body = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/src/Order/Orders.Infrastructure/Configurations/SymbolSettingsConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/SymbolSettingsConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Configurations;
+
+public class SymbolSettingsConfiguration : IEntityTypeConfiguration<SymbolSettings>
+{
+    public void Configure(EntityTypeBuilder<SymbolSettings> builder)
+    {
+        builder.ToTable("SymbolSettings");
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Symbol).IsRequired().HasMaxLength(20);
+        builder.Property(s => s.IsActive).IsRequired();
+        builder.Property(s => s.UpdatedByUserId).IsRequired();
+        builder.Property(s => s.UpdatedAt).IsRequired();
+
+        // One row per symbol — the same "get or create" repository method that keeps this true
+        // would otherwise let a race create two.
+        builder.HasIndex(s => s.Symbol).IsUnique();
+    }
+}

--- a/src/Order/Orders.Infrastructure/Migrations/20260814073154_AddSymbolSettings.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260814073154_AddSymbolSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814073154_AddSymbolSettings")]
+    partial class AddSymbolSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260814073154_AddSymbolSettings.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260814073154_AddSymbolSettings.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSymbolSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SymbolSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Symbol = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    UpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SymbolSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SymbolSettings_Symbol",
+                table: "SymbolSettings",
+                column: "Symbol",
+                unique: true);
+
+            // Seeded active, not left to the inactive-by-default row a fresh GetOrCreateAsync
+            // would produce — these three symbols were already live and tradable the moment
+            // before this migration ran. A symbol added after this one starts inactive, same as
+            // SymbolSettings.CreateDefault documents, since nothing was trading it before.
+            migrationBuilder.InsertData(
+                table: "SymbolSettings",
+                columns: new[] { "Id", "Symbol", "IsActive", "UpdatedByUserId", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { new Guid("9a1b1a2e-6b7e-4b2e-8b2e-0a1a1a1a1a01"), "MAUA/IRT", true, Guid.Empty, new DateTime(2026, 8, 14, 0, 0, 0, DateTimeKind.Utc) },
+                    { new Guid("9a1b1a2e-6b7e-4b2e-8b2e-0a1a1a1a1a02"), "SEKE_BAHAR/IRT", true, Guid.Empty, new DateTime(2026, 8, 14, 0, 0, 0, DateTimeKind.Utc) },
+                    { new Guid("9a1b1a2e-6b7e-4b2e-8b2e-0a1a1a1a1a03"), "BTC/IRT", true, Guid.Empty, new DateTime(2026, 8, 14, 0, 0, 0, DateTimeKind.Utc) }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SymbolSettings");
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/OrdersDbContext.cs
+++ b/src/Order/Orders.Infrastructure/OrdersDbContext.cs
@@ -18,6 +18,9 @@ public class OrdersDbContext : DbContext
     /// <summary>اسپرد و روشن/خاموش بودن مظنهٔ اتومات برای هر نماد (issue #90).</summary>
     public DbSet<AutoQuoteSettings> AutoQuoteSettings => Set<AutoQuoteSettings>();
 
+    /// <summary>فعال/غیرفعال بودن هر نماد برای معامله — قابل تغییر با دستور ادمین در بات.</summary>
+    public DbSet<SymbolSettings> SymbolSettings => Set<SymbolSettings>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new OrderConfigurations());
@@ -25,5 +28,6 @@ public class OrdersDbContext : DbContext
         modelBuilder.ApplyConfiguration(new OutboxMessageConfiguration());
         modelBuilder.ApplyConfiguration(new QuoteConfiguration());
         modelBuilder.ApplyConfiguration(new AutoQuoteSettingsConfiguration());
+        modelBuilder.ApplyConfiguration(new SymbolSettingsConfiguration());
     }
 }

--- a/src/Order/Orders.Infrastructure/SymbolSettingsRepository.cs
+++ b/src/Order/Orders.Infrastructure/SymbolSettingsRepository.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Orders.Core;
+
+namespace Orders.Infrastructure;
+
+public class SymbolSettingsRepository : ISymbolSettingsRepository
+{
+    private readonly OrdersDbContext _context;
+
+    public SymbolSettingsRepository(OrdersDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<SymbolSettings> GetOrCreateAsync(string symbol)
+    {
+        var normalized = symbol.Trim().ToUpperInvariant();
+
+        var existing = await _context.SymbolSettings
+            .FirstOrDefaultAsync(s => s.Symbol == normalized);
+
+        if (existing is not null)
+            return existing;
+
+        var created = SymbolSettings.CreateDefault(normalized);
+        _context.SymbolSettings.Add(created);
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // Two requests racing to create the first row for this symbol — the unique index
+            // on Symbol rejects the loser. Whoever lost reads what the winner actually wrote,
+            // rather than surfacing a database error for what is, from the caller's point of
+            // view, a successful "get or create" (same race handled the same way in
+            // AutoQuoteSettingsRepository).
+            _context.Entry(created).State = EntityState.Detached;
+            return await _context.SymbolSettings.SingleAsync(s => s.Symbol == normalized);
+        }
+
+        return created;
+    }
+
+    public async Task<IReadOnlyList<string>> GetActiveSymbolsAsync()
+    {
+        return await _context.SymbolSettings
+            .Where(s => s.IsActive)
+            .Select(s => s.Symbol)
+            .ToListAsync();
+    }
+
+    public Task SaveAsync(SymbolSettings settings) => _context.SaveChangesAsync();
+}

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -42,6 +42,9 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
+
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
 if (urls is { Length: > 0 })
 {

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -1,4 +1,6 @@
-﻿namespace TallaEgg.Core
+using Microsoft.Extensions.Configuration;
+
+namespace TallaEgg.Core
 {
     public class CurrenciesConstant
     {
@@ -25,52 +27,6 @@
         /// </summary>
         public const decimal GramsPerMesghal = 4.3318m;
 
-        // 🔹 مجموعه‌ای از اطلاعات ارزها
-        public static readonly List<CurrencyInfo> AllCurrencies = new List<CurrencyInfo>
-        {
-            new CurrencyInfo
-            {
-                Code = Maua,
-                PersianName = "آبشده",
-                Unit = "گرم",
-                DecimalPlaces = 2,
-                IsTradable = true
-            },
-            new CurrencyInfo
-            {
-                Code = Toman,
-                PersianName = "تومان",
-                Unit = "تومان",
-                DecimalPlaces = 0,
-                IsTradable = false
-            },
-            new CurrencyInfo
-            {
-                Code = Credit_MAUA,
-                PersianName = "اعتبار آبشده",
-                Unit = "گرم",
-                DecimalPlaces = 2,
-                IsTradable = false
-            },
-            new CurrencyInfo
-            {
-                Code = SekeBahar,
-                PersianName = "سکه تمام بهار آزادی",
-                Unit = "سکه",
-                DecimalPlaces = 2,
-                IsTradable = true
-            },
-            new CurrencyInfo
-            {
-                Code = Btc,
-                PersianName = "بیت‌کوین",
-                Unit = "بیت‌کوین",
-                DecimalPlaces = 8,
-                IsTradable = true
-            }
-        };
-
-
         // 🔹 ثابت‌های جفت‌های معاملاتی
         public const string BTC_USDT = "BTC/USDT";
         public const string ETH_USDT = "ETH/USDT";
@@ -80,91 +36,179 @@
         public const string MAUA_IRT = "MAUA/IRT";
         public const string SEKE_BAHAR_IRT = "SEKE_BAHAR/IRT";
 
-        // 🔹 مجموعه‌ای از اطلاعات جفت‌های معاملاتی
-        public static readonly List<TradingPairInfo> AllTradingPairs = new List<TradingPairInfo>
+        /// <summary>
+        /// Compiled defaults for every symbol this platform trades today. A process that never
+        /// calls <see cref="Configure"/> sees exactly these — nothing about existing behaviour
+        /// depends on a config file being present (the test suite's CI runner has none, by
+        /// design — see build-and-test.yml).
+        ///
+        /// <para>
+        /// <b>Adding a new symbol does not require editing this dictionary.</b> A block under
+        /// <c>Symbols:{Base}/{Quote}</c> in <c>config/appsettings.global.json</c> — decimal
+        /// precision, min/max quantity, Persian display name, and which external price provider
+        /// instrument feeds it — is enough; see README's "Adding a trading symbol" section. This
+        /// dictionary only needs a new entry if the symbol should also work with zero config
+        /// present (i.e. it becomes one of the platform's built-in defaults).
+        /// </para>
+        /// </summary>
+        private static readonly Dictionary<string, TradingPairInfo> DefaultTradingPairs =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                [BTC_USDT] = new TradingPairInfo
+                {
+                    Symbol = BTC_USDT, BaseAsset = "BTC", QuoteAsset = "USDT", PersianName = "بیت‌کوین/تتر",
+                    MinQuantity = 0.001m, MaxQuantity = 1000m, PriceDecimalPlaces = 2, QuantityDecimalPlaces = 6,
+                    MinNotional = 10m, BaseAssetPersianName = "بیت‌کوین", BaseUnit = "بیت‌کوین", BaseDecimalPlaces = 8
+                },
+                [ETH_USDT] = new TradingPairInfo
+                {
+                    Symbol = ETH_USDT, BaseAsset = "ETH", QuoteAsset = "USDT", PersianName = "اتریوم/تتر",
+                    MinQuantity = 0.01m, MaxQuantity = 10000m, PriceDecimalPlaces = 2, QuantityDecimalPlaces = 4,
+                    MinNotional = 10m, BaseAssetPersianName = "اتریوم", BaseUnit = "اتریوم", BaseDecimalPlaces = 8
+                },
+                [BTC_IRT] = new TradingPairInfo
+                {
+                    Symbol = BTC_IRT, BaseAsset = Btc, QuoteAsset = Toman, PersianName = "بیت‌کوین/تومان",
+                    MinQuantity = 0.0001m, MaxQuantity = 100m, PriceDecimalPlaces = 0, QuantityDecimalPlaces = 8,
+                    MinNotional = 1000000m, BaseAssetPersianName = "بیت‌کوین", BaseUnit = "بیت‌کوین",
+                    BaseDecimalPlaces = 8, Aliases = new List<string> { "بیت", "بیتکوین", "بیت‌کوین" }
+                },
+                [MAUA_IRT] = new TradingPairInfo
+                {
+                    Symbol = MAUA_IRT, BaseAsset = Maua, QuoteAsset = Toman, PersianName = "آبشده/تومان",
+                    MinQuantity = 0.1m, MaxQuantity = 1000m, PriceDecimalPlaces = 0, QuantityDecimalPlaces = 3,
+                    MinNotional = 100000m, BaseAssetPersianName = "آبشده", BaseUnit = "گرم", BaseDecimalPlaces = 2
+                },
+                [SEKE_BAHAR_IRT] = new TradingPairInfo
+                {
+                    Symbol = SEKE_BAHAR_IRT, BaseAsset = SekeBahar, QuoteAsset = Toman,
+                    PersianName = "سکه تمام بهار آزادی/تومان", MinQuantity = 0.01m, MaxQuantity = 50m,
+                    PriceDecimalPlaces = 0, QuantityDecimalPlaces = 2, MinNotional = 1000000m,
+                    BaseAssetPersianName = "سکه تمام بهار آزادی", BaseUnit = "سکه", BaseDecimalPlaces = 2,
+                    Aliases = new List<string> { "سکه" }
+                }
+            };
+
+        private static Dictionary<string, TradingPairInfo> _pairs =
+            new(DefaultTradingPairs, StringComparer.OrdinalIgnoreCase);
+
+        // Toman and the gold credit ceiling are structural to the whole system — the one unit of
+        // account, and a credit facility tied specifically to gold — rather than "a symbol", so
+        // they are fixed entries instead of being derived from a trading pair like every base
+        // asset below is.
+        private static readonly CurrencyInfo TomanInfo = new()
+        { Code = Toman, PersianName = "تومان", Unit = "تومان", DecimalPlaces = 0, IsTradable = false };
+
+        private static readonly CurrencyInfo CreditMauaInfo = new()
+        { Code = Credit_MAUA, PersianName = "اعتبار آبشده", Unit = "گرم", DecimalPlaces = 2, IsTradable = false };
+
+        private static Dictionary<string, CurrencyInfo> _currencies = BuildCurrencies(_pairs);
+
+        /// <summary>
+        /// Merges the "Symbols" section of the shared config file on top of the compiled
+        /// defaults: an unrecognised key becomes a brand-new trading pair, a known one has only
+        /// the fields the config block actually sets overridden. Call once at each service's
+        /// startup (see each Program.cs). Safe to skip — every symbol traded today has a
+        /// compiled default, so a process that never calls this behaves exactly as if it had; the
+        /// call only matters for a symbol nobody has written a <see cref="TradingPairInfo"/> for.
+        /// </summary>
+        public static void Configure(IConfiguration configuration)
         {
-            new TradingPairInfo
+            _pairs = MergeWithConfiguration(_pairs, configuration);
+            _currencies = BuildCurrencies(_pairs);
+        }
+
+        /// <summary>
+        /// The pure merge <see cref="Configure"/> applies — split out so it can be unit-tested
+        /// against an arbitrary starting dictionary and configuration, without mutating this
+        /// class's shared static state (which every test in the process reads).
+        /// </summary>
+        public static Dictionary<string, TradingPairInfo> MergeWithConfiguration(
+            IReadOnlyDictionary<string, TradingPairInfo> current, IConfiguration configuration)
+        {
+            var merged = new Dictionary<string, TradingPairInfo>(current, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var child in configuration.GetSection("Symbols").GetChildren())
             {
-                Symbol = BTC_USDT,
-                BaseAsset = "BTC",
-                QuoteAsset = "USDT",
-                PersianName = "بیت‌کوین/تتر",
-                IsActive = false,
-                MinQuantity = 0.001m,
-                MaxQuantity = 1000m,
-                PriceDecimalPlaces = 2,
-                QuantityDecimalPlaces = 6,
-                MinNotional = 10m // حداقل ارزش معامله
-            },
-            new TradingPairInfo
-            {
-                Symbol = ETH_USDT,
-                BaseAsset = "ETH",
-                QuoteAsset = "USDT",
-                PersianName = "اتریوم/تتر",
-                IsActive = false,
-                MinQuantity = 0.01m,
-                MaxQuantity = 10000m,
-                PriceDecimalPlaces = 2,
-                QuantityDecimalPlaces = 4,
-                MinNotional = 10m
-            },
-            new TradingPairInfo
-            {
-                Symbol = BTC_IRT,
-                BaseAsset = Btc,
-                QuoteAsset = Toman,
-                PersianName = "بیت‌کوین/تومان",
-                IsActive = true,
-                MinQuantity = 0.0001m,
-                MaxQuantity = 100m,
-                PriceDecimalPlaces = 0,
-                QuantityDecimalPlaces = 8,
-                MinNotional = 1000000m // 1 میلیون تومان
-            },
-            new TradingPairInfo
-            {
-                Symbol = MAUA_IRT,
-                BaseAsset = Maua,
-                QuoteAsset = Toman,
-                PersianName = "آبشده/تومان",
-                IsActive = true,
-                MinQuantity = 0.1m,
-                MaxQuantity = 1000m,
-                PriceDecimalPlaces = 0,
-                QuantityDecimalPlaces = 3,
-                MinNotional = 100000m // 100 هزار تومان
-            },
-            new TradingPairInfo
-            {
-                Symbol = SEKE_BAHAR_IRT,
-                BaseAsset = SekeBahar,
-                QuoteAsset = Toman,
-                PersianName = "سکه تمام بهار آزادی/تومان",
-                IsActive = true,
-                MinQuantity = 0.01m,
-                MaxQuantity = 50m,
-                PriceDecimalPlaces = 0,
-                QuantityDecimalPlaces = 2,
-                MinNotional = 1000000m // 1 میلیون تومان
+                var info = merged.TryGetValue(child.Key, out var existing) ? Clone(existing) : new TradingPairInfo();
+                child.Bind(info);
+                info.Symbol = child.Key;
+
+                if (string.IsNullOrWhiteSpace(info.BaseAsset) || string.IsNullOrWhiteSpace(info.QuoteAsset))
+                {
+                    var parts = child.Key.Split('/');
+                    if (parts.Length == 2)
+                    {
+                        if (string.IsNullOrWhiteSpace(info.BaseAsset)) info.BaseAsset = parts[0];
+                        if (string.IsNullOrWhiteSpace(info.QuoteAsset)) info.QuoteAsset = parts[1];
+                    }
+                }
+
+                merged[child.Key] = info;
             }
+
+            return merged;
+        }
+
+        private static TradingPairInfo Clone(TradingPairInfo source) => new()
+        {
+            Symbol = source.Symbol,
+            BaseAsset = source.BaseAsset,
+            QuoteAsset = source.QuoteAsset,
+            PersianName = source.PersianName,
+            MinQuantity = source.MinQuantity,
+            MaxQuantity = source.MaxQuantity,
+            PriceDecimalPlaces = source.PriceDecimalPlaces,
+            QuantityDecimalPlaces = source.QuantityDecimalPlaces,
+            MinNotional = source.MinNotional,
+            BaseAssetPersianName = source.BaseAssetPersianName,
+            BaseUnit = source.BaseUnit,
+            BaseDecimalPlaces = source.BaseDecimalPlaces,
+            Aliases = new List<string>(source.Aliases)
         };
 
-        // 🔹 دیکشنری برای دسترسی سریع (case-insensitive)
-        private static readonly Dictionary<string, CurrencyInfo> _map =
-            AllCurrencies.ToDictionary(c => c.Code, c => c, StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, CurrencyInfo> BuildCurrencies(Dictionary<string, TradingPairInfo> pairs)
+        {
+            var map = new Dictionary<string, CurrencyInfo>(StringComparer.OrdinalIgnoreCase)
+            {
+                [Toman] = TomanInfo,
+                [Credit_MAUA] = CreditMauaInfo
+            };
+
+            foreach (var pair in pairs.Values)
+            {
+                if (string.IsNullOrWhiteSpace(pair.BaseAsset)) continue;
+
+                map[pair.BaseAsset] = new CurrencyInfo
+                {
+                    Code = pair.BaseAsset,
+                    PersianName = string.IsNullOrWhiteSpace(pair.BaseAssetPersianName) ? pair.BaseAsset : pair.BaseAssetPersianName,
+                    Unit = pair.BaseUnit,
+                    DecimalPlaces = pair.BaseDecimalPlaces,
+                    IsTradable = true
+                };
+            }
+
+            return map;
+        }
+
+        // 🔹 مجموعه‌ای از اطلاعات ارزها
+        public static List<CurrencyInfo> AllCurrencies => _currencies.Values.ToList();
+
+        // 🔹 مجموعه‌ای از اطلاعات جفت‌های معاملاتی
+        public static List<TradingPairInfo> AllTradingPairs => _pairs.Values.ToList();
 
         // 🔹 دریافت کد همه ارزها (با فرمت اصلی)
         public static List<string> GetAllCodes() =>
-            AllCurrencies.Select(c => c.Code).ToList();
+            _currencies.Values.Select(c => c.Code).ToList();
 
         // 🔹 گرفتن مشخصات ارز (case-insensitive)
         public static CurrencyInfo GetCurrencyInfo(string code) =>
-            _map.TryGetValue(code, out var info) ? info : null;
+            _currencies.TryGetValue(code, out var info) ? info : null;
 
         // 🔹 بررسی معتبر بودن ارز (case-insensitive)
         public static bool IsValidCurrency(string code) =>
-            _map.ContainsKey(code);
+            _currencies.ContainsKey(code);
 
         /// <summary>
         /// گرد کردن یک مبلغ به دقت واقعی همان دارایی (مثلاً تومان: بدون اعشار، آبشده: دو رقم).
@@ -263,13 +307,9 @@
         public static decimal RoundOrderPrice(decimal price) =>
             Math.Round(price, OrderPriceDecimalPlaces, MidpointRounding.AwayFromZero);
 
-        // 🔹 دیکشنری جفت‌های معاملاتی برای دسترسی سریع (case-insensitive)
-        private static readonly Dictionary<string, TradingPairInfo> _pairMap =
-            AllTradingPairs.ToDictionary(p => p.Symbol, p => p, StringComparer.OrdinalIgnoreCase);
-
         /// <summary>گرفتن مشخصات جفت معاملاتی (case-insensitive). اگر پیدا نشود null.</summary>
         public static TradingPairInfo? GetTradingPairInfo(string symbol) =>
-            symbol is not null && _pairMap.TryGetValue(symbol, out var info) ? info : null;
+            symbol is not null && _pairs.TryGetValue(symbol, out var info) ? info : null;
 
         /// <summary>
         /// نام فارسی ارز برای نمایش به کاربر. اگر ارز ناشناس باشد خود کد برگردانده می‌شود.
@@ -290,11 +330,11 @@
             var trimmed = input.Trim();
 
             // ابتدا تطبیق با کد ارز
-            if (_map.TryGetValue(trimmed, out var byCode))
+            if (_currencies.TryGetValue(trimmed, out var byCode))
                 return byCode.Code;
 
             // سپس تطبیق با نام فارسی
-            var byName = AllCurrencies.FirstOrDefault(c =>
+            var byName = _currencies.Values.FirstOrDefault(c =>
                 string.Equals(c.PersianName, trimmed, StringComparison.OrdinalIgnoreCase));
 
             return byName?.Code;
@@ -304,7 +344,7 @@
         /// فهرست نام‌های فارسی ارزها برای نمایش در پیام خطا (به‌جای کدهای لاتین).
         /// </summary>
         public static string GetPersianNamesList() =>
-            string.Join("، ", AllCurrencies.Select(c => c.PersianName));
+            string.Join("، ", _currencies.Values.Select(c => c.PersianName));
 
         /// <summary>
         /// نام فارسی جفت معاملاتی برای نمایش به کاربر (مثل «آبشده/تومان»).
@@ -323,9 +363,30 @@
 
             return symbol ?? string.Empty;
         }
+
+        /// <summary>
+        /// یک نماد را از روی کلیدواژهٔ فارسی دستورهای ادمین («سکه»، «بیت») برمی‌گرداند —
+        /// از <see cref="TradingPairInfo.Aliases"/> هر نماد می‌خواند، پس اضافه‌کردن یک
+        /// نماد جدید با کلیدواژهٔ خودش نیازی به تغییر این متد ندارد. کلیدواژهٔ خالی یعنی
+        /// آبشده — عادت ادمین از قبل از وجود این نمادهای دیگر. کلیدواژه‌ای که به هیچ
+        /// نمادی نمی‌خورد null برمی‌گرداند، تا فراخوان بتواند «کلیدواژه‌ای داده نشده» را
+        /// از «کلیدواژهٔ ناشناخته» تشخیص دهد.
+        /// </summary>
+        public static string? ResolveSymbolByAlias(string? keyword)
+        {
+            var trimmed = keyword?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+                return MAUA_IRT;
+
+            foreach (var pair in _pairs.Values)
+            {
+                if (pair.Aliases.Contains(trimmed, StringComparer.OrdinalIgnoreCase))
+                    return pair.Symbol;
+            }
+
+            return null;
+        }
     }
-
-
 
     public class CurrencyInfo
     {
@@ -350,9 +411,6 @@
         /// <summary>نام فارسی</summary>
         public string PersianName { get; set; } = string.Empty;
 
-        /// <summary>آیا فعال است؟</summary>
-        public bool IsActive { get; set; }
-
         /// <summary>حداقل مقدار قابل معامله</summary>
         public decimal MinQuantity { get; set; }
 
@@ -367,6 +425,17 @@
 
         /// <summary>حداقل ارزش معامله</summary>
         public decimal MinNotional { get; set; }
-    }
 
+        /// <summary>نام فارسی دارایی پایه به‌تنهایی (مثل «آبشده»)</summary>
+        public string BaseAssetPersianName { get; set; } = string.Empty;
+
+        /// <summary>واحد نمایش دارایی پایه (مثل «گرم» یا «سکه»)</summary>
+        public string BaseUnit { get; set; } = string.Empty;
+
+        /// <summary>تعداد اعشار دارایی پایه، برای گرد کردن مبالغ (CurrenciesConstant.RoundToCurrencyPrecision)</summary>
+        public int BaseDecimalPlaces { get; set; }
+
+        /// <summary>کلیدواژه‌های فارسی که دستورهای ادمین در بات برای این نماد می‌پذیرند (مثل «سکه»)</summary>
+        public List<string> Aliases { get; set; } = new();
+    }
 }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/SymbolSettingsDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/SymbolSettingsDto.cs
@@ -1,0 +1,12 @@
+namespace TallaEgg.Core.DTOs.Order
+{
+    /// <summary>Whether one symbol is currently tradable, for transfer between the Orders service and the bot.</summary>
+    public class SymbolSettingsDto
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public record SetSymbolActiveRequest(bool IsActive, Guid UpdatedByUserId);
+}

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -53,6 +53,9 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
+
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
 if (urls is { Length: > 0 })
 {

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -50,6 +50,9 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
+
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
 if (urls is { Length: > 0 })
 {

--- a/src/Wallet/Wallet.Tests/AutoQuoteCommandTests.cs
+++ b/src/Wallet/Wallet.Tests/AutoQuoteCommandTests.cs
@@ -188,6 +188,76 @@ public class AutoQuoteCommandTests
         Assert.Contains(_messenger.Texts, t => t.Contains("قالب"));
     }
 
+    // ── نماد فعال/غیرفعال ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnAdminCanActivateASymbol()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "نماد فعال سکه");
+
+        var toggle = Assert.Single(_orderApi.ActiveToggles);
+        Assert.Equal(CurrenciesConstant.SEKE_BAHAR_IRT, toggle.Symbol);
+        Assert.True(toggle.IsActive);
+        Assert.Equal(AdminId, toggle.UpdatedByUserId);
+    }
+
+    [Fact]
+    public async Task AnAdminCanDeactivateASymbol()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "نماد غیرفعال بیت");
+
+        var toggle = Assert.Single(_orderApi.ActiveToggles);
+        Assert.Equal(CurrenciesConstant.BTC_IRT, toggle.Symbol);
+        Assert.False(toggle.IsActive);
+    }
+
+    /// <summary>No symbol keyword means MAUA/IRT — the same convention as اسپرد/اتومات.</summary>
+    [Fact]
+    public async Task NoSymbolKeywordMeansGold()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "نماد فعال");
+
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, Assert.Single(_orderApi.ActiveToggles).Symbol);
+    }
+
+    [Fact]
+    public async Task AMalformedSymbolActiveCommandIsAnsweredWithTheFormat()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "نماد شاید");
+
+        Assert.Empty(_orderApi.ActiveToggles);
+        Assert.Contains(_messenger.Texts, t => t.Contains("قالب"));
+    }
+
+    [Fact]
+    public async Task AnUnrecognisedSymbolKeywordForActivationIsRejected()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "نماد فعال نقره");
+
+        Assert.Empty(_orderApi.ActiveToggles);
+        Assert.Contains(_messenger.Texts, t => t.Contains("شناخته‌شده نیست"));
+    }
+
+    [Fact]
+    public async Task AnOrdinaryUserCannotActivateASymbol()
+    {
+        var handler = Build(UserRole.RegularUser);
+
+        await SayAsync(handler, "نماد فعال سکه");
+
+        Assert.Empty(_orderApi.ActiveToggles);
+    }
+
     // ── who may run these ───────────────────────────────────────────────────────
 
     [Fact]

--- a/src/Wallet/Wallet.Tests/CurrenciesConstantSymbolsTests.cs
+++ b/src/Wallet/Wallet.Tests/CurrenciesConstantSymbolsTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.Configuration;
+using TallaEgg.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Config-driven symbol metadata — added so a new trading symbol needs a config block instead
+/// of a code change and a rebuild (see README's "Adding a trading symbol").
+///
+/// <para>
+/// These tests exercise <see cref="CurrenciesConstant.MergeWithConfiguration"/>, the pure
+/// function <see cref="CurrenciesConstant.Configure"/> wraps, rather than calling
+/// <c>Configure</c> itself. <c>CurrenciesConstant</c> holds its symbol catalog in shared static
+/// fields that every test in this process reads (<c>MarketModeTests</c>,
+/// <c>AutoQuoteCommandTests</c>, message-builder tests, ...), and xUnit runs test classes in
+/// parallel by default — mutating that shared state from a test would make unrelated tests
+/// flaky depending on what else happened to be running. Testing the pure merge instead proves
+/// the same logic without touching anything another test can see.
+/// </para>
+/// </summary>
+public class CurrenciesConstantSymbolsTests
+{
+    private static IConfiguration ConfigWithSymbols(string json)
+    {
+        var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        return new ConfigurationBuilder().AddJsonStream(stream).Build();
+    }
+
+    [Fact]
+    public void MergeWithConfiguration_AddsABrandNewSymbolNotInTheDefaults()
+    {
+        var defaults = new Dictionary<string, TradingPairInfo>();
+        var config = ConfigWithSymbols("""
+            { "Symbols": { "ETH/IRT": { "PersianName": "اتریوم/تومان", "MinQuantity": 0.01 } } }
+            """);
+
+        var merged = CurrenciesConstant.MergeWithConfiguration(defaults, config);
+
+        Assert.True(merged.ContainsKey("ETH/IRT"));
+        Assert.Equal("اتریوم/تومان", merged["ETH/IRT"].PersianName);
+        Assert.Equal(0.01m, merged["ETH/IRT"].MinQuantity);
+    }
+
+    /// <summary>Base/quote asset are derived from the key itself when the config block omits them.</summary>
+    [Fact]
+    public void MergeWithConfiguration_DerivesBaseAndQuoteAssetFromTheSymbolKey()
+    {
+        var defaults = new Dictionary<string, TradingPairInfo>();
+        var config = ConfigWithSymbols("""{ "Symbols": { "ETH/IRT": { "PersianName": "اتریوم/تومان" } } }""");
+
+        var merged = CurrenciesConstant.MergeWithConfiguration(defaults, config);
+
+        Assert.Equal("ETH", merged["ETH/IRT"].BaseAsset);
+        Assert.Equal("IRT", merged["ETH/IRT"].QuoteAsset);
+    }
+
+    /// <summary>
+    /// A config block for an already-known symbol overrides only the fields it sets — everything
+    /// else about that symbol's compiled default survives.
+    /// </summary>
+    [Fact]
+    public void MergeWithConfiguration_OverridesOnlyTheFieldsAConfigBlockSets()
+    {
+        var defaults = new Dictionary<string, TradingPairInfo>
+        {
+            ["MAUA/IRT"] = new TradingPairInfo
+            {
+                Symbol = "MAUA/IRT", BaseAsset = "MAUA", QuoteAsset = "IRT",
+                PersianName = "آبشده/تومان", MinQuantity = 0.1m, MaxQuantity = 1000m
+            }
+        };
+        var config = ConfigWithSymbols("""{ "Symbols": { "MAUA/IRT": { "MinQuantity": 0.5 } } }""");
+
+        var merged = CurrenciesConstant.MergeWithConfiguration(defaults, config);
+
+        Assert.Equal(0.5m, merged["MAUA/IRT"].MinQuantity);
+        // Untouched by the config block — the compiled default survives.
+        Assert.Equal("آبشده/تومان", merged["MAUA/IRT"].PersianName);
+        Assert.Equal(1000m, merged["MAUA/IRT"].MaxQuantity);
+    }
+
+    [Fact]
+    public void MergeWithConfiguration_WithNoSymbolsSection_LeavesTheDefaultsUnchanged()
+    {
+        var defaults = new Dictionary<string, TradingPairInfo>
+        {
+            ["MAUA/IRT"] = new TradingPairInfo { Symbol = "MAUA/IRT", PersianName = "آبشده/تومان" }
+        };
+        var config = ConfigWithSymbols("""{ "AllowedHosts": "*" }""");
+
+        var merged = CurrenciesConstant.MergeWithConfiguration(defaults, config);
+
+        Assert.Equal("آبشده/تومان", merged["MAUA/IRT"].PersianName);
+        Assert.Single(merged);
+    }
+
+    [Fact]
+    public void MergeWithConfiguration_BindsProviderInstrumentMappingForNerkhAndBrsApi()
+    {
+        var defaults = new Dictionary<string, TradingPairInfo>();
+        var config = ConfigWithSymbols("""
+            {
+              "Symbols": {
+                "ETH/IRT": {
+                  "PersianName": "اتریوم/تومان",
+                  "Nerkh": { "Path": "crypto/ETH", "Key": "ETH", "ConvertFromMesghal": false },
+                  "BrsApi": { "Array": "cryptocurrency", "Symbol": "ETH", "ConvertFromMesghal": false }
+                }
+              }
+            }
+            """);
+
+        var merged = CurrenciesConstant.MergeWithConfiguration(defaults, config);
+
+        // The provider classes read Symbols:{symbol}:Nerkh/BrsApi directly via IConfiguration
+        // (not through TradingPairInfo) — this just confirms the section round-trips through
+        // the same "Symbols" config the metadata comes from, at the path they read.
+        var section = config.GetSection("Symbols:ETH/IRT:Nerkh");
+        Assert.Equal("crypto/ETH", section["Path"]);
+        Assert.Equal("ETH", section["Key"]);
+    }
+
+    // ── ResolveSymbolByAlias — reads the compiled defaults only, never mutates shared state ──
+
+    [Fact]
+    public void ResolveSymbolByAlias_NoKeywordMeansGold()
+    {
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, CurrenciesConstant.ResolveSymbolByAlias(null));
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, CurrenciesConstant.ResolveSymbolByAlias(""));
+        Assert.Equal(CurrenciesConstant.MAUA_IRT, CurrenciesConstant.ResolveSymbolByAlias("   "));
+    }
+
+    [Fact]
+    public void ResolveSymbolByAlias_RecognisesTheCoinAndBitcoinKeywords()
+    {
+        Assert.Equal(CurrenciesConstant.SEKE_BAHAR_IRT, CurrenciesConstant.ResolveSymbolByAlias("سکه"));
+        Assert.Equal(CurrenciesConstant.BTC_IRT, CurrenciesConstant.ResolveSymbolByAlias("بیت"));
+        Assert.Equal(CurrenciesConstant.BTC_IRT, CurrenciesConstant.ResolveSymbolByAlias("بیتکوین"));
+    }
+
+    [Fact]
+    public void ResolveSymbolByAlias_ReturnsNullForAnUnknownKeyword()
+    {
+        Assert.Null(CurrenciesConstant.ResolveSymbolByAlias("نقره"));
+    }
+}

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -1,4 +1,5 @@
-﻿using TallaEgg.Core.DTOs;
+﻿using TallaEgg.Core;
+using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.Order;
@@ -101,6 +102,30 @@ public sealed class FakeOrderApiClient : IOrderApiClient
     {
         EnabledToggles.Add((symbol, isEnabled, updatedByUserId));
         return Task.FromResult(EnabledToggleResult);
+    }
+
+    // ── فعال/غیرفعال بودن نماد ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Defaults to the three symbols the platform actually seeds as active (see the
+    /// AddSymbolSettings migration) — matches a freshly deployed system, so tests written before
+    /// "active" moved to a database call don't all have to opt into a symbol being active just
+    /// to exercise unrelated behaviour. A test about activation/deactivation itself overrides
+    /// this explicitly.
+    /// </summary>
+    public List<string> ActiveSymbols { get; set; } =
+        [CurrenciesConstant.MAUA_IRT, CurrenciesConstant.SEKE_BAHAR_IRT, CurrenciesConstant.BTC_IRT];
+
+    public Task<List<string>> GetActiveSymbolsAsync() => Task.FromResult(ActiveSymbols);
+
+    /// <summary>Every activate/deactivate call asked for.</summary>
+    public List<(string Symbol, bool IsActive, Guid UpdatedByUserId)> ActiveToggles { get; } = [];
+    public (bool Success, string Message) ActiveToggleResult { get; set; } = (true, "انجام شد.");
+
+    public Task<(bool success, string message)> SetSymbolActiveAsync(string symbol, bool isActive, Guid updatedByUserId)
+    {
+        ActiveToggles.Add((symbol, isActive, updatedByUserId));
+        return Task.FromResult(ActiveToggleResult);
     }
 }
 

--- a/src/Wallet/Wallet.Tests/SymbolSettingsRepositoryTests.cs
+++ b/src/Wallet/Wallet.Tests/SymbolSettingsRepositoryTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Orders.Core;
+using Orders.Infrastructure;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// <see cref="SymbolSettingsRepository"/> against a real <see cref="OrdersDbContext"/> (SQLite
+/// in-memory) — the same pattern used elsewhere in this project for repository-level tests
+/// (<c>QuoteFillCounterpartyTests</c>, <c>MarketModeStartupValidatorTests</c>).
+/// </summary>
+public class SymbolSettingsRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public SymbolSettingsRepositoryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using var setup = NewContext();
+        setup.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private OrdersDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+    [Fact]
+    public async Task GetOrCreateAsync_CreatesAnInactiveRowTheFirstTime()
+    {
+        using var context = NewContext();
+        var repo = new SymbolSettingsRepository(context);
+
+        var settings = await repo.GetOrCreateAsync("SEKE_BAHAR/IRT");
+
+        Assert.False(settings.IsActive);
+        Assert.Equal("SEKE_BAHAR/IRT", settings.Symbol);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ReturnsTheSameRowOnASecondCall()
+    {
+        using var context = NewContext();
+        var repo = new SymbolSettingsRepository(context);
+
+        var first = await repo.GetOrCreateAsync("BTC/IRT");
+        first.SetActive(true, Guid.NewGuid());
+        await repo.SaveAsync(first);
+
+        var second = await repo.GetOrCreateAsync("BTC/IRT");
+
+        Assert.Equal(first.Id, second.Id);
+        Assert.True(second.IsActive);
+    }
+
+    [Fact]
+    public async Task GetActiveSymbolsAsync_OnlyReturnsSymbolsTurnedOn()
+    {
+        using var context = NewContext();
+        var repo = new SymbolSettingsRepository(context);
+
+        var maua = await repo.GetOrCreateAsync("MAUA/IRT");
+        maua.SetActive(true, Guid.NewGuid());
+        await repo.SaveAsync(maua);
+
+        var seke = await repo.GetOrCreateAsync("SEKE_BAHAR/IRT");
+        seke.SetActive(false, Guid.NewGuid());
+        await repo.SaveAsync(seke);
+
+        var active = await repo.GetActiveSymbolsAsync();
+
+        Assert.Contains("MAUA/IRT", active);
+        Assert.DoesNotContain("SEKE_BAHAR/IRT", active);
+    }
+
+    [Fact]
+    public async Task GetActiveSymbolsAsync_EmptyWhenNothingHasBeenActivated()
+    {
+        using var context = NewContext();
+        var repo = new SymbolSettingsRepository(context);
+
+        Assert.Empty(await repo.GetActiveSymbolsAsync());
+    }
+}

--- a/src/Wallet/Wallet.Tests/SymbolSettingsTests.cs
+++ b/src/Wallet/Wallet.Tests/SymbolSettingsTests.cs
@@ -1,0 +1,57 @@
+using Orders.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The admin-controlled row that decides whether a symbol is tradable at all — shown in the
+/// bot's symbol picker, eligible for auto-quote, usable for a manual quote. Everything else
+/// about a symbol lives in configuration (<c>TallaEgg.Core.CurrenciesConstant</c>); only this
+/// on/off switch needs to be a database row an admin can flip from inside the bot.
+/// </summary>
+public class SymbolSettingsTests
+{
+    /// <summary>
+    /// Starts inactive. A symbol newly defined in config must not become tradable the moment
+    /// someone asks about it — an admin has to explicitly turn it on.
+    /// </summary>
+    [Fact]
+    public void CreateDefault_StartsInactive()
+    {
+        var settings = SymbolSettings.CreateDefault("SEKE_BAHAR/IRT");
+
+        Assert.False(settings.IsActive);
+    }
+
+    [Fact]
+    public void CreateDefault_NormalizesTheSymbol()
+    {
+        var settings = SymbolSettings.CreateDefault("maua/irt");
+
+        Assert.Equal("MAUA/IRT", settings.Symbol);
+    }
+
+    [Fact]
+    public void SetActive_RecordsWhoChangedItAndWhen()
+    {
+        var settings = SymbolSettings.CreateDefault("BTC/IRT");
+        var admin = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        settings.SetActive(true, admin);
+
+        Assert.True(settings.IsActive);
+        Assert.Equal(admin, settings.UpdatedByUserId);
+        Assert.True(settings.UpdatedAt >= before);
+    }
+
+    [Fact]
+    public void SetActive_CanTurnItBackOff()
+    {
+        var settings = SymbolSettings.CreateDefault("BTC/IRT");
+        settings.SetActive(true, Guid.NewGuid());
+
+        settings.SetActive(false, Guid.NewGuid());
+
+        Assert.False(settings.IsActive);
+    }
+}


### PR DESCRIPTION
## Description
Architecture change requested in conversation: make adding a new trading symbol, and
activating/deactivating an existing one, as cheap as possible in time and code changes. Not tied
to a numbered GitHub issue.

## Changes Made
Full breakdown in the commit message. Summary:
- **Metadata → config**: `Symbols:{Base}/{Quote}` in `appsettings.global.json`, merged on top of
  compiled defaults (`CurrenciesConstant.MergeWithConfiguration`) for the three symbols traded
  today. A new key = new symbol, no code change. A process that never loads the config section
  (including CI, which has none) behaves exactly as before.
- **Active/inactive → database + bot command**: new `SymbolSettings` entity/repository/migration
  (mirrors `AutoQuoteSettings`), toggled by `نماد فعال [سکه|بیت]` / `نماد غیرفعال [...]` —
  immediate, no restart. Seeded active for the three live symbols so nothing regresses.
- Price providers (`NerkhPriceProvider`, `BrsApiPriceProvider`) fall back to
  `Symbols:{symbol}:Nerkh`/`BrsApi` config for any symbol outside their compiled switch.
- `AutoQuotePublisherService` and `BotHandler`'s three `AllTradingPairs.Where(IsActive)` call
  sites now go through `ISymbolSettingsRepository` / the new `/api/symbols/active` endpoint
  (the bot has no direct DB access, HTTP only).
- `BotHandlerAdmin.ResolveAdminQuoteSymbol` now reads each symbol's config-driven `Aliases`
  instead of a hardcoded switch.
- README gets an "Adding a trading symbol" section.

## Testing
- [x] Full solution build, 0 warnings, 0 errors.
- [x] `dotnet test` — 410/410 passing (388 existing + 22 new), stable across repeated runs.
  Merge-logic tests deliberately exercise the pure `MergeWithConfiguration` function rather than
  mutating `CurrenciesConstant`'s shared static state, since xUnit runs test classes in parallel
  and every other test in the assembly reads that state.
- [x] **Live, not mocked**, against the real database and real price APIs:
  - Migration applied cleanly against SQL Server Express; seeded the three live symbols, all
    active.
  - `GET /api/symbols/active` → all three. Deactivated `SEKE_BAHAR/IRT` via the API (what the bot
    command calls) → confirmed gone from the list; reactivated → confirmed back. No restart
    between either step.
  - Added a genuinely new symbol (24K gold, `GOLD24K/IRT`) to local config only — no code, no
    compiled default — restarted once, then activated it and enabled auto-quote through the same
    two API calls the bot commands use. Waited for a real publisher tick:
    `Auto-published quote for GOLD24K/IRT: buy 25,268,670, sell 25,395,330 (reference
    25,332,000)` — a real price fetched through the config-driven provider fallback. Deactivated
    and disabled it again afterward and removed the temporary config block.

## Deployment Notes
The `AddSymbolSettings` migration runs automatically at each service's next startup
(`MigrateAsync()`), same as every other migration in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)