### PR TITLE
feat(orders): add Abandoned status for permanently-failed outbox settlements

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -958,14 +958,18 @@ static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironm
 // delivery is a no-op rather than a double settlement.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Lists trades whose settlement never completed, newest first.
-app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db) =>
+/// Lists trades whose settlement never completed, newest first. Abandoned messages are
+/// excluded by default — an operator already reviewed and closed those — but stay
+/// queryable via includeAbandoned=true for reconciliation and audit.
+app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAbandoned = false) =>
 {
     try
     {
-        var stuck = await db.OutboxMessages
-            .AsNoTracking()
-            .Where(m => m.Status != OutboxMessageStatus.Completed)
+        var query = db.OutboxMessages.AsNoTracking().Where(m => m.Status != OutboxMessageStatus.Completed);
+        if (!includeAbandoned)
+            query = query.Where(m => m.Status != OutboxMessageStatus.Abandoned);
+
+        var stuck = await query
             .OrderByDescending(m => m.CreatedAt)
             .Select(m => new
             {
@@ -976,7 +980,9 @@ app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db) =>
                 m.RetryCount,
                 m.CreatedAt,
                 m.NextAttemptAt,
-                m.LastError
+                m.LastError,
+                m.AbandonReason,
+                m.AbandonedAt
             })
             .ToListAsync();
 
@@ -984,6 +990,7 @@ app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db) =>
         {
             Count = stuck.Count,
             FailedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Failed)),
+            AbandonedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Abandoned)),
             Items = stuck
         }, "فهرست تسویه‌های ناتمام"));
     }
@@ -1046,6 +1053,45 @@ app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
     catch (Exception ex)
     {
         Log.Error(ex, "Error re-driving all failed outbox messages");
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+});
+
+/// Closes a permanently-failed settlement an operator has reviewed and decided will never
+/// settle (e.g. its collateral was consumed by later activity). The record is kept, not
+/// deleted, so the trade stays reconcilable — it just stops showing up as actionable and can
+/// never be re-driven again. No compensating wallet action is taken: for this shop, settling
+/// such a trade is a manual, offline decision, and the reason recorded here is that note.
+app.MapPost("/api/outbox/{messageId}/abandon", async (Guid messageId, AbandonOutboxMessageRequest request, OrdersDbContext db) =>
+{
+    try
+    {
+        var message = await db.OutboxMessages.FirstOrDefaultAsync(m => m.Id == messageId);
+        if (message is null)
+            return Results.NotFound(ApiResponse<string>.Fail("پیام یافت نشد."));
+
+        message.MarkAbandoned(request.Reason);
+        await db.SaveChangesAsync();
+
+        Log.Information(
+            "Outbox message {MessageId} (trade {TradeId}) was abandoned by an operator: {Reason}",
+            message.Id, message.AggregateId, request.Reason);
+
+        return Results.Ok(ApiResponse<string>.Ok(message.AggregateId.ToString(),
+            "معامله رها شد و دیگر برای تسویه پردازش نمی‌شود."));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+    catch (InvalidOperationException ex)
+    {
+        // Raised when the message is not in an abandonable state (only Failed qualifies).
+        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Error abandoning outbox message {MessageId}", messageId);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
 });
@@ -1150,6 +1196,12 @@ public record CancelOrderRequest(
     /// Optional reason for cancellation
     /// </summary>
     string? Reason = null);
+
+/// <summary>
+/// Request model for abandoning a permanently-failed outbox message (issue #39). The reason
+/// is mandatory — abandoning is an audited operator decision, not a silent drop.
+/// </summary>
+public record AbandonOutboxMessageRequest(string Reason);
 
 /// <summary>
 /// Request model for notifying the matching engine about a new order

--- a/src/Order/Orders.Core/OutboxMessage.cs
+++ b/src/Order/Orders.Core/OutboxMessage.cs
@@ -7,7 +7,15 @@ public enum OutboxMessageStatus
 {
     Pending = 0,
     Completed = 1,
-    Failed = 2
+    Failed = 2,
+
+    /// <summary>
+    /// A Failed message an operator has reviewed and decided will never settle (issue #39) —
+    /// e.g. its collateral was consumed by later activity, or it predates a rule that now
+    /// correctly refuses it. Terminal: never picked up by the processor and never re-driven,
+    /// but kept (not deleted) so the record survives for reconciliation and audit.
+    /// </summary>
+    Abandoned = 3
 }
 
 /// <summary>
@@ -48,6 +56,12 @@ public class OutboxMessage
 
     /// <summary>Last error message from a failed attempt, for diagnostics.</summary>
     public string? LastError { get; private set; }
+
+    /// <summary>The operator's reason for abandoning this message. Null unless <see cref="Status"/> is <see cref="OutboxMessageStatus.Abandoned"/>.</summary>
+    public string? AbandonReason { get; private set; }
+
+    /// <summary>When the message was abandoned. Null unless <see cref="Status"/> is <see cref="OutboxMessageStatus.Abandoned"/>.</summary>
+    public DateTime? AbandonedAt { get; private set; }
 
     // EF Core
     private OutboxMessage() { }
@@ -127,5 +141,31 @@ public class OutboxMessage
         RetryCount = 0;
         NextAttemptAt = DateTime.UtcNow;
         ProcessedAt = null;
+    }
+
+    /// <summary>
+    /// Records that an operator has reviewed a permanently-failed message and decided it will
+    /// never settle — e.g. its collateral no longer covers the trade, or it predates a rule
+    /// that now correctly refuses it (issue #39). A reason is mandatory: this is an audited
+    /// decision, not a silent drop, and the record is kept rather than deleted so the trade
+    /// stays reconcilable.
+    ///
+    /// Only a Failed message can be abandoned, for the same reason only a Failed message can
+    /// be re-driven: a Pending one hasn't exhausted its retries yet, and a Completed one
+    /// already settled. Once Abandoned, <see cref="ResetForRetry"/> refuses it exactly like it
+    /// already refuses a Completed message — abandoning is terminal.
+    /// </summary>
+    public void MarkAbandoned(string reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("An abandon reason is required.", nameof(reason));
+        if (Status != OutboxMessageStatus.Failed)
+            throw new InvalidOperationException(
+                $"Only a failed message can be abandoned; this message is {Status}.");
+
+        Status = OutboxMessageStatus.Abandoned;
+        AbandonReason = reason;
+        AbandonedAt = DateTime.UtcNow;
+        NextAttemptAt = null;
     }
 }

--- a/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
@@ -21,6 +21,8 @@ public class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage
         builder.Property(m => m.RetryCount).IsRequired();
         builder.Property(m => m.NextAttemptAt);
         builder.Property(m => m.LastError).HasMaxLength(2000);
+        builder.Property(m => m.AbandonReason).HasMaxLength(2000);
+        builder.Property(m => m.AbandonedAt);
 
         // Hot-path query for the background processor: pending messages that are due.
         builder.HasIndex(m => new { m.Status, m.NextAttemptAt });

--- a/src/Order/Orders.Infrastructure/Migrations/20260826041110_AddOutboxAbandonedStatus.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260826041110_AddOutboxAbandonedStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260826041110_AddOutboxAbandonedStatus")]
+    partial class AddOutboxAbandonedStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260826041110_AddOutboxAbandonedStatus.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260826041110_AddOutboxAbandonedStatus.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutboxAbandonedStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AbandonReason",
+                table: "OutboxMessages",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AbandonedAt",
+                table: "OutboxMessages",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AbandonReason",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "AbandonedAt",
+                table: "OutboxMessages");
+        }
+    }
+}

--- a/src/Wallet/Wallet.Tests/OutboxDueSelectionTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxDueSelectionTests.cs
@@ -161,6 +161,27 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
+    /// پیام رهاشده (issue #39) هم باید کنار گذاشته شود — دقیقاً به همان دلیل پیام
+    /// <c>Failed</c>: برداشتنش یعنی تصمیم آگاهانهٔ اپراتور («این هرگز تسویه نمی‌شود») را
+    /// دور می‌زند.
+    /// </summary>
+    [Fact]
+    public async Task AnAbandonedMessage_IsSkipped()
+    {
+        var (messageId, _) = Seed(arrange: m =>
+        {
+            for (var i = 0; i < MaxRetries; i++)
+                m.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+            m.MarkAbandoned("collateral consumed by later activity");
+        });
+
+        await RunProcessorAsync();
+
+        Assert.Empty(_wallet.SettledTradeIds);
+        Assert.Equal(OutboxMessageStatus.Abandoned, (await ReloadAsync(messageId)).Status);
+    }
+
+    /// <summary>
     /// پیام تکمیل‌شده دوباره فرستاده نمی‌شود. تسویه تکرارپذیر است، پس این ایمنی است نه
     /// درستی — ولی هر تحویل مجدد یک فراخوانی HTTP بیهوده به سرویس کیف پول است.
     /// </summary>

--- a/src/Wallet/Wallet.Tests/OutboxMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/OutboxMessageTests.cs
@@ -91,4 +91,57 @@ public class OutboxMessageTests
 
         Assert.Throws<InvalidOperationException>(() => message.ResetForRetry());
     }
+
+    // ── abandon (issue #39 follow-up) ───────────────────────────────────────────
+
+    [Fact]
+    public void MarkAbandoned_RecordsTheReasonAndTimestamp()
+    {
+        var message = FailedMessage();
+
+        message.MarkAbandoned("collateral consumed by later activity");
+
+        Assert.Equal(OutboxMessageStatus.Abandoned, message.Status);
+        Assert.Equal("collateral consumed by later activity", message.AbandonReason);
+        Assert.NotNull(message.AbandonedAt);
+        Assert.Null(message.NextAttemptAt); // never picked up by the processor again
+    }
+
+    [Fact]
+    public void MarkAbandoned_RequiresANonEmptyReason()
+    {
+        var message = FailedMessage();
+
+        Assert.Throws<ArgumentException>(() => message.MarkAbandoned(""));
+        Assert.Throws<ArgumentException>(() => message.MarkAbandoned("   "));
+    }
+
+    /// <summary>
+    /// Only a Failed message can be abandoned — a Pending one hasn't exhausted its retries,
+    /// and a Completed one already settled and has nothing to abandon.
+    /// </summary>
+    [Fact]
+    public void MarkAbandoned_RefusesAMessageThatIsNotFailed()
+    {
+        var pending = NewMessage();
+        Assert.Throws<InvalidOperationException>(() => pending.MarkAbandoned("no reason"));
+
+        var completed = NewMessage();
+        completed.MarkCompleted();
+        Assert.Throws<InvalidOperationException>(() => completed.MarkAbandoned("no reason"));
+    }
+
+    /// <summary>
+    /// Abandoning is terminal: it must be refused exactly like re-driving a Completed
+    /// message is refused, so an abandoned trade can never be silently retried.
+    /// </summary>
+    [Fact]
+    public void ResetForRetry_RefusesAnAbandonedMessage()
+    {
+        var message = FailedMessage();
+        message.MarkAbandoned("will never settle");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => message.ResetForRetry());
+        Assert.Contains("Abandoned", ex.Message);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `OutboxMessageStatus.Abandoned` and `OutboxMessage.MarkAbandoned(reason)` — closes the gap #39 flagged: a permanently-failed settlement had no way to be marked "reviewed, will never settle" without deleting the row and losing the audit trail.
- `POST /api/outbox/{id}/abandon` performs the transition (mandatory reason, only from `Failed`); `GET /api/outbox/unsettled` excludes abandoned messages by default but keeps them queryable via `?includeAbandoned=true`.
- Abandoning is terminal: `ResetForRetry`/redrive refuses an abandoned message exactly like it already refuses a completed one, and the background processor's pending-message query already skips it (same as `Failed`).
- No compensating wallet action — per the issue's stated policy, settling such a trade for this shop is a manual, offline decision; the reason field records that note.

## Testing
- `dotnet test` — 442 passed, 0 failed (5 new tests: `MarkAbandoned_*`, `ResetForRetry_RefusesAnAbandonedMessage`, `AnAbandonedMessage_IsSkipped`).
- Verified live against the dev SQL Server DB: migration applied cleanly, abandoned a real stuck message via the new endpoint, confirmed it disappears from the default `unsettled` listing and reappears with `includeAbandoned=true`, and confirmed redrive is correctly refused afterward.

## Note
Verifying this surfaced 897 pre-existing `Failed` messages in the dev DB, all predating the wallet lazy-creation fix from earlier today — they're now abandonable one-by-one via the new endpoint, but I haven't bulk-cleaned them since that's a data decision, not part of this feature.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)