### PR TITLE
feat(orders,bot): per-symbol wallet balance + profit/loss (issue #93)

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -359,6 +359,13 @@ namespace TallaEgg.TelegramBot
             switch (msgText)
             {
                 case BotBtns.BtnMainMenu:
+                case BotBtns.BtnBack:
+                    // Checked ahead of the default branch's order-flow routing on purpose: a
+                    // customer stuck in "waiting_for_amount"/"waiting_for_price" (no quote, a
+                    // typo, changed their mind) previously had this typed as an invalid amount
+                    // or price instead of as a way out, because default's state check ran
+                    // before this text was ever compared against a button label.
+                    _conversations.Clear(telegramId);
                     await ShowMainMenuAsync(chatId);
                     break;
 
@@ -463,9 +470,19 @@ namespace TallaEgg.TelegramBot
 
                     await _messenger.DeleteAsync(chatId, message.Id);
 
+                    // A bare ReplyKeyboardRemove left the customer typing into a text-only
+                    // prompt with no way out except knowing to type "🔙 بازگشت" from memory —
+                    // the BtnBack case in HandleMainMenuAsync's switch handles the tap/text
+                    // itself, but only if there is a button to tap.
                     await _messenger.SendAsync(chatId,
                                                  $"لطفاً مقدار را وارد کنید.",
-                                                 replyMarkup: new ReplyKeyboardRemove());
+                                                 replyMarkup: new ReplyKeyboardMarkup(new[]
+                                                 {
+                                                     new KeyboardButton[] { new KeyboardButton(BotBtns.BtnBack) }
+                                                 })
+                                                 {
+                                                     ResizeKeyboard = true
+                                                 });
 
                     break;
 
@@ -506,6 +523,14 @@ namespace TallaEgg.TelegramBot
                         assetConversation.State = "waiting_for_select_side";
 
                         TallaEgg.Core.DTOs.ApiResponse<BestPricesDto> apiResponse = await _orderApi.GetBestPricesAsync(asset);
+
+                        // Both prices come from the same published Quote (issue #48) — always
+                        // both present or both absent — so either one missing means there is no
+                        // quote for this symbol at all, not merely a one-sided book.
+                        var hasQuote = apiResponse is { Success: true, Data: not null }
+                            && apiResponse.Data.BestBidPrice.HasValue
+                            && apiResponse.Data.BestAskPrice.HasValue;
+
                         if (apiResponse != null && apiResponse.Success)
                         {
                             await _messenger.DeleteAsync(chatId, message.Id);
@@ -513,23 +538,38 @@ namespace TallaEgg.TelegramBot
                             await _messenger.SendAsync(chatId, BestPricesMessage.Build(
                                 apiResponse.Data.BestBidPrice, apiResponse.Data.BestAskPrice, asset));
 
-                            // Stored for the market-order path (HandleOrderTypeSelectionAsync),
-                            // which feeds this straight into HandleOrderPriceInputAsync — the same
-                            // place a manually-typed limit price lands. That method only divides a
-                            // gold price back down from per-mesghal to per-gram, so gold's stored
-                            // value must already be per-mesghal here; every other symbol has no
-                            // such internal/display split and is stored as-is.
-                            var isGold = asset == CurrenciesConstant.MAUA_IRT;
-                            assetConversation.BestBidPrice = isGold
-                                ? apiResponse.Data.BestBidPrice * CurrenciesConstant.GramsPerMesghal
-                                : apiResponse.Data.BestBidPrice;
-                            assetConversation.BestAskPrice = isGold
-                                ? apiResponse.Data.BestAskPrice * CurrenciesConstant.GramsPerMesghal
-                                : apiResponse.Data.BestAskPrice;
+                            if (hasQuote)
+                            {
+                                // Stored for the market-order path (HandleOrderTypeSelectionAsync),
+                                // which feeds this straight into HandleOrderPriceInputAsync — the same
+                                // place a manually-typed limit price lands. That method only divides a
+                                // gold price back down from per-mesghal to per-gram, so gold's stored
+                                // value must already be per-mesghal here; every other symbol has no
+                                // such internal/display split and is stored as-is.
+                                var isGold = asset == CurrenciesConstant.MAUA_IRT;
+                                assetConversation.BestBidPrice = isGold
+                                    ? apiResponse.Data.BestBidPrice * CurrenciesConstant.GramsPerMesghal
+                                    : apiResponse.Data.BestBidPrice;
+                                assetConversation.BestAskPrice = isGold
+                                    ? apiResponse.Data.BestAskPrice * CurrenciesConstant.GramsPerMesghal
+                                    : apiResponse.Data.BestAskPrice;
+                            }
                         }
 
-                        await _messenger.SendSpotSideMenuKeyboard(chatId);
-
+                        // Only the dealer/market path is a dead end without a quote — it never
+                        // asks for a price, so with no quote it has nothing to trade on. The
+                        // order-book (limit) path is unaffected: it asks the customer for a
+                        // price itself and never depended on GetBestPricesAsync succeeding.
+                        if (hasQuote || assetConversation.OrderType != OrderType.Market)
+                        {
+                            await _messenger.SendSpotSideMenuKeyboard(chatId);
+                        }
+                        else
+                        {
+                            _conversations.Clear(telegramId);
+                            await _messenger.SendAsync(chatId, BotMsgs.MsgNoQuoteForSymbol);
+                            await ShowMainMenuAsync(chatId);
+                        }
                     }
                     // Both branches activate or bar an account, and neither checked who was
                     // asking. Callback data is not a secret — it is client-side text that any
@@ -629,7 +669,7 @@ namespace TallaEgg.TelegramBot
                             await _messenger.EditTextAsync(
                                 chatId: callbackQuery.Message.Chat.Id,
                                 messageId: callbackQuery.Message.MessageId,
-                                text: QuoteHistoryHandler.BuildQuoteHistoryAsync(quotePageResult, quotePage, isAdmin),
+                                text: QuoteHistoryHandler.BuildQuoteHistoryAsync(quotePageResult, quotePage, isAdmin, symbol),
                                 replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(quotePageResult, quotePage, symbol));
 
                             await _messenger.AnswerCallbackAsync(callbackQuery.Id);
@@ -810,7 +850,7 @@ namespace TallaEgg.TelegramBot
             {
                 var page = await _orderApi.GetQuoteHistoryAsync(symbol, pageNumber: 1, pageSize: 1);
 
-                await _messenger.SendAsync(chatId, QuoteHistoryHandler.BuildQuoteHistoryAsync(page, currentPage: 1, isAdmin: true));
+                await _messenger.SendAsync(chatId, QuoteHistoryHandler.BuildQuoteHistoryAsync(page, currentPage: 1, isAdmin: true, symbol));
             }
         }
 
@@ -836,7 +876,7 @@ namespace TallaEgg.TelegramBot
 
                 await _messenger.SendAsync(
                     chatId,
-                    QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin),
+                    QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin, symbol),
                     replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(page, 1, symbol));
             }
         }
@@ -933,7 +973,13 @@ namespace TallaEgg.TelegramBot
             {
                 if (res.Data.Any())
                 {
-                    await _messenger.SendAsync(chatId, WalletBalanceMessage.Build(res.Data));
+                    // A failed positions fetch must not block the balance screen the customer
+                    // actually asked for -- WalletBalanceMessage treats a null positions
+                    // argument as "no P&L data available" and still renders the balances.
+                    var positionsRes = await _orderApi.GetPositionsAsync(userId);
+                    var positions = positionsRes.Success ? positionsRes.Data : null;
+
+                    await _messenger.SendAsync(chatId, WalletBalanceMessage.Build(res.Data, positions));
 
                 }
                 else
@@ -1232,7 +1278,13 @@ namespace TallaEgg.TelegramBot
                     : string.Format(BotMsgs.MsgEnterPrice, PersianFormat.Symbol(orderState.Asset));
 
                 await _messenger.SendAsync(chatId, pricePrompt,
-                 replyMarkup: new ReplyKeyboardRemove());
+                 replyMarkup: new ReplyKeyboardMarkup(new[]
+                 {
+                     new KeyboardButton[] { new KeyboardButton(BotBtns.BtnBack) }
+                 })
+                 {
+                     ResizeKeyboard = true
+                 });
             }
             else if (orderState.OrderType == OrderType.Market)
             {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/IOrderApiClient.cs
@@ -63,4 +63,9 @@ public interface IOrderApiClient
 
     /// <summary>فعال/غیرفعال کردن یک نماد.</summary>
     Task<(bool success, string message)> SetSymbolActiveAsync(string symbol, bool isActive, Guid updatedByUserId);
+
+    // ── سود و زیان (issue #93) ───────────────────────────────────────────────────
+
+    /// <summary>موقعیت و سود/زیان کاربر در همهٔ نمادهایی که تا امروز معامله کرده.</summary>
+    Task<ApiResponse<PositionsResponseDto>> GetPositionsAsync(Guid userId);
 }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -748,6 +748,54 @@ public class OrderApiClient : IOrderApiClient
             return ApiResponse<bool>.Fail($"خطا در ارتباط با سرور: {ex.Message}");
         }
     }
+
+    public async Task<ApiResponse<PositionsResponseDto>> GetPositionsAsync(Guid userId)
+    {
+        var uri = $"{_baseUrl}/positions/user/{userId}";
+
+        try
+        {
+            using var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead);
+            var payload = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Order API returned {StatusCode} for user {UserId} positions. Payload: {Payload}",
+                    (int)response.StatusCode, userId, payload);
+
+                return ApiResponse<PositionsResponseDto>.Fail("دریافت سود و زیان ناموفق بود");
+            }
+
+            var result = JsonConvert.DeserializeObject<ApiResponse<PositionsResponseDto>>(payload);
+            if (result is null)
+            {
+                _logger.LogError("Order API returned an invalid positions payload for user {UserId}. Payload: {Payload}", userId, payload);
+                return ApiResponse<PositionsResponseDto>.Fail("پاسخ نامعتبر از سرویس سفارشات دریافت شد.");
+            }
+
+            return result;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogError(ex, "Order API request timed out while fetching positions for user {UserId}", userId);
+            return ApiResponse<PositionsResponseDto>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Order API communication error while fetching positions for user {UserId}", userId);
+            return ApiResponse<PositionsResponseDto>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            _logger.LogError(ex, "Order API returned invalid JSON while fetching positions for user {UserId}", userId);
+            return ApiResponse<PositionsResponseDto>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while fetching positions for user {UserId}", userId);
+            return ApiResponse<PositionsResponseDto>.Fail($"خطای غیرمنتظره: {ex.Message}");
+        }
+    }
 }
 
 public class OrderResponse

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -195,6 +195,13 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// <summary>{0} = نام فارسی دارایی همراه واحد آن</summary>
         public const string MsgEnterQuantity = "مقدار {0} را وارد کنید:";
 
+        /// <summary>
+        /// وقتی هیچ مظنه‌ای برای نماد انتخاب‌شده منتشر نشده — ادامهٔ مسیر (پرسیدن مقدار)
+        /// فقط به یک شکست تضمین‌شده در مرحلهٔ بعد می‌رسید، چون قیمتی برای ثبت سفارش وجود
+        /// ندارد. باید همین‌جا متوقف شود، نه بعد از گرفتن مقدار از کاربر.
+        /// </summary>
+        public const string MsgNoQuoteForSymbol = "در حال حاضر قیمتی برای این نماد منتشر نشده. لطفاً کمی بعد دوباره تلاش کنید.";
+
         // ── نمایش موجودی ────────────────────────────────────────────────────────────
 
         public const string MsgBalanceHeader = "💰 موجودی حساب شما\n\n";
@@ -219,6 +226,33 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// نکرده). {0} = مبلغ اعتبار با واحد
         /// </summary>
         public const string MsgBalanceCreditLine = "   💳 اعتبار: {0}\n";
+
+        // ── سود و زیان (issue #93) ───────────────────────────────────────────────────
+        // فقط وقتی نمایش داده می‌شود که موقعیت باز باشد (Quantity != 0) یا سود/زیان
+        // تحقق‌یافته‌ای وجود داشته باشد — نمادی که کاربر هنوز رویش معامله‌ای نکرده هیچ‌کدام
+        // از این خطوط را ندارد.
+
+        /// <summary>{0} = میانگین قیمت خرید با واحد (تومان)</summary>
+        public const string MsgBalanceAverageCost = "   میانگین قیمت خرید: {0}\n";
+
+        /// <summary>{0} = ارزش فعلی موقعیت با واحد (تومان)</summary>
+        public const string MsgBalanceCurrentValue = "   ارزش فعلی: {0}\n";
+
+        /// <summary>سود/زیان تحقق‌نیافته (موقعیت باز، بر اساس قیمت خرید ادمین). {0} = مبلغ با واحد</summary>
+        public const string MsgBalanceUnrealizedGain = "   📈 سود تحقق‌نیافته: {0}\n";
+        public const string MsgBalanceUnrealizedLoss = "   📉 زیان تحقق‌نیافته: {0}\n";
+
+        /// <summary>سود/زیان تحقق‌یافته (از معاملات بسته‌شده). {0} = مبلغ با واحد</summary>
+        public const string MsgBalanceRealizedGain = "   ✅ سود تحقق‌یافته: {0}\n";
+        public const string MsgBalanceRealizedLoss = "   ❌ زیان تحقق‌یافته: {0}\n";
+
+        /// <summary>وقتی مظنه‌ای برای محاسبهٔ سود/زیان تحقق‌نیافته منتشر نشده. موقعیت باز است ولی قابل ارزش‌گذاری نیست.</summary>
+        public const string MsgBalanceNoQuoteForUnrealized = "   سود/زیان تحقق‌نیافته: قیمتی برای این نماد منتشر نشده\n";
+
+        /// <summary>{0} = مجموع سود/زیان (تحقق‌یافته + تحقق‌نیافته) روی همهٔ نمادها، با واحد</summary>
+        public const string MsgBalanceTotalPnlGain = "\n📊 مجموع سود و زیان شما: 📈 {0} سود\n";
+        public const string MsgBalanceTotalPnlLoss = "\n📊 مجموع سود و زیان شما: 📉 {0} زیان\n";
+        public const string MsgBalanceTotalPnlNone = "\n📊 مجموع سود و زیان شما: بدون تغییر\n";
 
         public const string MsgBalanceFooter = "\nبرای افزایش اعتبار با طلافروشی خود تماس بگیرید.";
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -213,6 +213,13 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// </summary>
         public const string MsgBalanceDebtNote = "   ⚠️ بدهی شما: {0}\n";
 
+        /// <summary>
+        /// اعتبار همان نماد، اگر ادمین برایش شارژ کرده باشد — حتی وقتی خودِ کیف‌پول آن
+        /// دارایی هنوز ساخته نشده (کاربری که اعتبار گرفته ولی هنوز آن نماد را معامله
+        /// نکرده). {0} = مبلغ اعتبار با واحد
+        /// </summary>
+        public const string MsgBalanceCreditLine = "   💳 اعتبار: {0}\n";
+
         public const string MsgBalanceFooter = "\nبرای افزایش اعتبار با طلافروشی خود تماس بگیرید.";
 
         /// <summary>{0} = دلیل خطا</summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
@@ -141,6 +141,10 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
                new[]
                {
                     new[] { new KeyboardButton(BotBtns.BtnTradeHistory), new KeyboardButton(BotBtns.BtnQuoteHistory)},
+                    // ادمین طرف مقابل هر معاملهٔ مظنه‌ای است، پس همین صفحهٔ موجودی سود و
+                    // زیان خودِ فروشگاه را هم نشان می‌دهد (issue #93) -- بدون هیچ منطق
+                    // جداگانه‌ای، چون از دید سرویس ادمین هم فقط یک شناسهٔ کاربری دیگر است.
+                    new[] { new KeyboardButton(BotBtns.BtnWalletsBalance)},
                     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
                }
                             )

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Extensions/Telegram/Keyboards.cs
@@ -119,7 +119,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Extensions.Telegram
             var keyboard = new ReplyKeyboardMarkup(
                 new[]
                {
-                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory)},
+                    new[] { new KeyboardButton(BotBtns.BtnTradeHistory), new KeyboardButton(BotBtns.BtnWalletsBalance)},
                     new[] { new KeyboardButton(BotBtns.BtnMainMenu)},
                })
             {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/QuoteHistoryHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/QuoteHistoryHandler.cs
@@ -42,10 +42,16 @@ public static class QuoteHistoryHandler
     /// buy at. One row of data, two readings — labelling it for only one audience is how the
     /// buyer/seller inversion keeps reappearing in this product.
     /// </param>
-    public static string BuildQuoteHistoryAsync(PagedResult<QuoteDto> page, int currentPage, bool isAdmin)
+    /// <param name="symbol">
+    /// Named in the empty-history message specifically — callers (<c>ShowLatestQuoteAsync</c>,
+    /// <c>ShowQuoteHistory</c>) send one message per symbol in a loop, so an admin seeing
+    /// several bare "هنوز مظنه‌ای منتشر نشده است." rows in a row had no way to tell which
+    /// symbols were missing a quote and which one (if any) actually had one.
+    /// </param>
+    public static string BuildQuoteHistoryAsync(PagedResult<QuoteDto> page, int currentPage, bool isAdmin, string symbol)
     {
         if (page is null || !page.Items.Any())
-            return "هنوز مظنه‌ای منتشر نشده است.";
+            return $"هنوز مظنه‌ای برای {PersianFormat.Symbol(symbol)} منتشر نشده است.";
 
         var sb = new StringBuilder();
         sb.AppendLine($"📋 تاریخچهٔ مظنه‌ها — صفحهٔ {PersianFormat.Number(currentPage)} از {PersianFormat.Number(page.TotalPages)}");

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using TallaEgg.Core;
+using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Utilties;
 
@@ -19,14 +20,19 @@ namespace TallaEgg.TelegramBot.Infrastructure.Messages;
 /// they owe -5,000,000, or that they owe nothing at all.
 ///
 /// This is also the only place a customer can see their debt, which is the gap issue #61 is
-/// about on the shop's side.
+/// about on the shop's side. It is also, with <paramref name="positions"/> below, where they
+/// see whether that debt is buying them a winning position (issue #93 part B) — the same
+/// screen answers "what do I have" and "what did it make or lose me", since a balance number
+/// alone answers neither on its own.
 /// </summary>
 public static class WalletBalanceMessage
 {
-    public static string Build(IEnumerable<WalletDTO> wallets)
+    public static string Build(IEnumerable<WalletDTO> wallets, PositionsResponseDto? positions = null)
     {
         var walletList = wallets as IReadOnlyCollection<WalletDTO> ?? wallets.ToList();
         var byAsset = walletList.ToDictionary(w => w.Asset, w => w, StringComparer.OrdinalIgnoreCase);
+        var positionsBySymbol = positions?.Positions.ToDictionary(p => p.Symbol, p => p, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, PositionDto>(StringComparer.OrdinalIgnoreCase);
 
         var sb = new StringBuilder();
         sb.Append(BotMsgs.MsgBalanceHeader);
@@ -46,17 +52,24 @@ public static class WalletBalanceMessage
         {
             var wallet = byAsset.GetValueOrDefault(asset) ?? new WalletDTO { Asset = asset };
             var creditWallet = byAsset.GetValueOrDefault(CurrenciesConstant.CreditAssetFor(asset));
-            AppendSection(sb, wallet, creditWallet);
+            var symbol = CurrenciesConstant.AllTradingPairs
+                .FirstOrDefault(p => string.Equals(p.BaseAsset, asset, StringComparison.OrdinalIgnoreCase))?.Symbol;
+            var position = symbol is not null ? positionsBySymbol.GetValueOrDefault(symbol) : null;
+
+            AppendSection(sb, wallet, creditWallet, position);
         }
 
         if (byAsset.TryGetValue(CurrenciesConstant.Toman, out var toman))
-            AppendSection(sb, toman, creditWallet: null);
+            AppendSection(sb, toman, creditWallet: null, position: null);
+
+        if (positions is not null)
+            sb.Append(FormatTotalPnl(positions.TotalPnl));
 
         sb.Append(BotMsgs.MsgBalanceFooter);
         return sb.ToString();
     }
 
-    private static void AppendSection(StringBuilder sb, WalletDTO wallet, WalletDTO? creditWallet)
+    private static void AppendSection(StringBuilder sb, WalletDTO wallet, WalletDTO? creditWallet, PositionDto? position)
     {
         var code = wallet.Asset;
         var unit = PersianFormat.Unit(code);
@@ -79,8 +92,69 @@ public static class WalletBalanceMessage
                 $"{PersianFormat.Amount(-wallet.Balance, code)} {unit}"));
         }
 
+        AppendPositionLines(sb, position, code);
+
         sb.AppendLine();
     }
+
+    /// <summary>
+    /// Nothing here if the customer has never traded this symbol at all (no <see cref="PositionDto"/>)
+    /// and has no closed history in it either — a symbol they only hold via a direct credit
+    /// grant, say, has nothing to report yet.
+    /// </summary>
+    private static void AppendPositionLines(StringBuilder sb, PositionDto? position, string baseAssetCode)
+    {
+        if (position is null)
+            return;
+
+        var isGold = string.Equals(baseAssetCode, CurrenciesConstant.Maua, StringComparison.OrdinalIgnoreCase);
+
+        if (position.Quantity != 0)
+        {
+            if (position.AverageCost.HasValue)
+                sb.Append(string.Format(BotMsgs.MsgBalanceAverageCost, FormatTomanPerUnit(position.AverageCost.Value, isGold)));
+
+            if (position.MarkPrice.HasValue)
+            {
+                var currentValue = position.Quantity * position.MarkPrice.Value;
+                sb.Append(string.Format(BotMsgs.MsgBalanceCurrentValue, FormatToman(currentValue)));
+            }
+
+            if (position.UnrealizedPnl.HasValue)
+                sb.Append(FormatPnlLine(position.UnrealizedPnl.Value, BotMsgs.MsgBalanceUnrealizedGain, BotMsgs.MsgBalanceUnrealizedLoss));
+            else
+                sb.Append(BotMsgs.MsgBalanceNoQuoteForUnrealized);
+        }
+
+        if (position.RealizedPnl != 0)
+            sb.Append(FormatPnlLine(position.RealizedPnl, BotMsgs.MsgBalanceRealizedGain, BotMsgs.MsgBalanceRealizedLoss));
+    }
+
+    /// <summary>A gain and a loss never share a label — a bare signed number reads as an error the same way a raw negative balance does.</summary>
+    private static string FormatPnlLine(decimal pnl, string gainTemplate, string lossTemplate) =>
+        pnl >= 0
+            ? string.Format(gainTemplate, FormatToman(pnl))
+            : string.Format(lossTemplate, FormatToman(-pnl));
+
+    private static string FormatTotalPnl(decimal totalPnl) =>
+        totalPnl switch
+        {
+            0m => BotMsgs.MsgBalanceTotalPnlNone,
+            > 0m => string.Format(BotMsgs.MsgBalanceTotalPnlGain, FormatToman(totalPnl)),
+            _ => string.Format(BotMsgs.MsgBalanceTotalPnlLoss, FormatToman(-totalPnl))
+        };
+
+    private static string FormatToman(decimal amount) =>
+        $"{PersianFormat.Amount(amount, CurrenciesConstant.Toman)} {PersianFormat.Unit(CurrenciesConstant.Toman)}";
+
+    /// <summary>
+    /// Gold is quoted internally per gram but shown per mesghal everywhere else a price
+    /// appears in the bot (see <c>BestPricesMessage</c>, order confirmations, trade/quote
+    /// history) — a per-unit price here must follow the same convention or it reads as a
+    /// different, much lower price than the one the customer actually agreed to.
+    /// </summary>
+    private static string FormatTomanPerUnit(decimal pricePerUnit, bool isGold) =>
+        FormatToman(isGold ? pricePerUnit * CurrenciesConstant.GramsPerMesghal : pricePerUnit);
 
     private static bool IsToman(string asset) =>
         string.Equals(asset, CurrenciesConstant.Toman, StringComparison.OrdinalIgnoreCase);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Messages/WalletBalanceMessage.cs
@@ -1,11 +1,16 @@
 using System.Text;
+using TallaEgg.Core;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Utilties;
 
 namespace TallaEgg.TelegramBot.Infrastructure.Messages;
 
 /// <summary>
-/// Builds the customer's balance screen (issue #65).
+/// Builds the customer's balance screen (issue #65), grouped per symbol rather than as a
+/// flat wallet list (issue #93 part A) — a customer asking "what's my wallet" means what
+/// they hold of each tradable asset, with that asset's own credit ceiling alongside it, not
+/// an undifferentiated row per underlying wallet record (which would show "اعتبار آبشده" as
+/// its own unrelated-looking section instead of as a line under "آبشده").
 ///
 /// Extracted because it is the only message in the bot that has a branch in it: a negative
 /// available balance is normal under the credit model — the customer traded on credit — but
@@ -20,32 +25,68 @@ public static class WalletBalanceMessage
 {
     public static string Build(IEnumerable<WalletDTO> wallets)
     {
+        var walletList = wallets as IReadOnlyCollection<WalletDTO> ?? wallets.ToList();
+        var byAsset = walletList.ToDictionary(w => w.Asset, w => w, StringComparer.OrdinalIgnoreCase);
+
         var sb = new StringBuilder();
         sb.Append(BotMsgs.MsgBalanceHeader);
 
-        foreach (var wallet in wallets)
+        // Every base asset the customer has any footprint in — either they hold or have
+        // traded it directly, or an admin extended credit against it even if they never
+        // did. A credit-only customer must still see that credit; dropping it here would
+        // hide real spending power. Symbols first, Toman (cash) last: "my wallet" means
+        // what they hold of each tradable asset, not their spending cash.
+        var baseAssets = walletList
+            .Select(w => w.Asset)
+            .Where(a => !IsToman(a) && !IsCredit(a))
+            .Concat(walletList.Select(w => w.Asset).Where(IsCredit).Select(BaseAssetOfCredit))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var asset in baseAssets)
         {
-            var code = wallet.Asset;
-            var unit = PersianFormat.Unit(code);
-
-            // The Persian asset name, never the latin code: the customer chose "طلای آبشده",
-            // not "MAUA".
-            sb.Append(string.Format(BotMsgs.MsgBalanceRow,
-                PersianFormat.Asset(code),
-                $"{PersianFormat.Amount(wallet.Balance, code)} {unit}",
-                $"{PersianFormat.Amount(wallet.LockedBalance, code)} {unit}"));
-
-            if (wallet.Balance < 0)
-            {
-                // Negated so the customer reads "you owe 5,000,000", not "-5,000,000".
-                sb.Append(string.Format(BotMsgs.MsgBalanceDebtNote,
-                    $"{PersianFormat.Amount(-wallet.Balance, code)} {unit}"));
-            }
-
-            sb.AppendLine();
+            var wallet = byAsset.GetValueOrDefault(asset) ?? new WalletDTO { Asset = asset };
+            var creditWallet = byAsset.GetValueOrDefault(CurrenciesConstant.CreditAssetFor(asset));
+            AppendSection(sb, wallet, creditWallet);
         }
+
+        if (byAsset.TryGetValue(CurrenciesConstant.Toman, out var toman))
+            AppendSection(sb, toman, creditWallet: null);
 
         sb.Append(BotMsgs.MsgBalanceFooter);
         return sb.ToString();
     }
+
+    private static void AppendSection(StringBuilder sb, WalletDTO wallet, WalletDTO? creditWallet)
+    {
+        var code = wallet.Asset;
+        var unit = PersianFormat.Unit(code);
+
+        // The Persian asset name, never the latin code: the customer chose "طلای آبشده",
+        // not "MAUA".
+        sb.Append(string.Format(BotMsgs.MsgBalanceRow,
+            PersianFormat.Asset(code),
+            $"{PersianFormat.Amount(wallet.Balance, code)} {unit}",
+            $"{PersianFormat.Amount(wallet.LockedBalance, code)} {unit}"));
+
+        if (creditWallet is { Balance: > 0 })
+            sb.Append(string.Format(BotMsgs.MsgBalanceCreditLine,
+                $"{PersianFormat.Amount(creditWallet.Balance, code)} {unit}"));
+
+        if (wallet.Balance < 0)
+        {
+            // Negated so the customer reads "you owe 5,000,000", not "-5,000,000".
+            sb.Append(string.Format(BotMsgs.MsgBalanceDebtNote,
+                $"{PersianFormat.Amount(-wallet.Balance, code)} {unit}"));
+        }
+
+        sb.AppendLine();
+    }
+
+    private static bool IsToman(string asset) =>
+        string.Equals(asset, CurrenciesConstant.Toman, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsCredit(string asset) =>
+        asset.StartsWith("CREDIT_", StringComparison.OrdinalIgnoreCase);
+
+    private static string BaseAssetOfCredit(string creditAsset) => creditAsset["CREDIT_".Length..];
 }

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -130,6 +130,7 @@ builder.Services.AddScoped<IQuoteRepository, QuoteRepository>();
 builder.Services.AddScoped<Orders.Application.Services.MarketModeProvider>();
 builder.Services.AddScoped<Orders.Application.Services.QuoteFillService>();
 builder.Services.AddScoped<Orders.Application.Services.MarketModeStartupValidator>();
+builder.Services.AddScoped<Orders.Application.Services.PositionService>();
 
 // Outbox processor: reliably delivers trade settlements to the Wallet service.
 builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();
@@ -697,6 +698,32 @@ app.MapGet("/api/trades/user/{userId}", async (
 .WithTags("Trades")
 .Produces<ApiResponse<PagedResult<TradeHistoryDto>>>(200)
 .Produces(400);
+
+/// <summary>
+/// موقعیت و سود/زیان یک کاربر در تمام نمادهایی که تا امروز معامله کرده (issue #93). همان
+/// endpoint برای ادمین/SuperAdmin هم استفاده می‌شود — او هم طرف مقابل هر معاملهٔ مظنه‌ای
+/// است، پس سود/زیان فروشگاه چیزی جز همین محاسبه با شناسهٔ کاربریِ خودِ ادمین نیست.
+/// </summary>
+app.MapGet("/api/positions/user/{userId}", async (
+    Guid userId,
+    Orders.Application.Services.PositionService positionService) =>
+{
+    try
+    {
+        var positions = await positionService.GetPositionsAsync(userId);
+        return Results.Ok(ApiResponse<PositionsResponseDto>.Ok(positions, "سود و زیان دریافت شد"));
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Error computing positions for user {UserId}", userId);
+        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
+    }
+})
+.WithName("GetUserPositions")
+.WithSummary("دریافت موقعیت و سود/زیان کاربر در همهٔ نمادها")
+.WithTags("Positions")
+.Produces<ApiResponse<PositionsResponseDto>>(200)
+.Produces(500);
 
 /// <summary>
 /// دریافت سفارشات فعال کاربر

--- a/src/Order/Orders.Application/Services/PositionService.cs
+++ b/src/Order/Orders.Application/Services/PositionService.cs
@@ -1,0 +1,75 @@
+using Orders.Core;
+using TallaEgg.Core.DTOs.Order;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// A participant's position and profit/loss across every symbol they have ever traded
+/// (issue #93). Runs identically for a customer or for the SuperAdmin/house account — the
+/// house is just another party on every dealer trade, so its P&amp;L needs no separate logic,
+/// only calling this with its own user id.
+/// </summary>
+public class PositionService
+{
+    private readonly ITradeRepository _tradeRepository;
+    private readonly IQuoteRepository _quoteRepository;
+
+    public PositionService(ITradeRepository tradeRepository, IQuoteRepository quoteRepository)
+    {
+        _tradeRepository = tradeRepository;
+        _quoteRepository = quoteRepository;
+    }
+
+    public async Task<PositionsResponseDto> GetPositionsAsync(Guid userId)
+    {
+        var buyTrades = await _tradeRepository.GetTradesByBuyerUserIdAsync(userId);
+        var sellTrades = await _tradeRepository.GetTradesBySellerUserIdAsync(userId);
+
+        // Buyer/seller are mutually exclusive per trade (self-matching is refused elsewhere),
+        // so this concat cannot double-count a trade.
+        var bySymbol = buyTrades.Select(t => (Trade: t, IsBuyer: true))
+            .Concat(sellTrades.Select(t => (Trade: t, IsBuyer: false)))
+            .GroupBy(x => x.Trade.Symbol, StringComparer.OrdinalIgnoreCase);
+
+        var response = new PositionsResponseDto();
+
+        foreach (var group in bySymbol)
+        {
+            var legs = group.Select(x => new PositionTradeLeg(
+                x.Trade.CreatedAt,
+                x.IsBuyer ? x.Trade.Quantity : -x.Trade.Quantity,
+                x.Trade.Price,
+                x.IsBuyer ? x.Trade.FeeBuyer : x.Trade.FeeSeller));
+
+            var result = PositionCalculator.Calculate(legs);
+
+            // The buy price is the honest mark: it is what this participant would actually
+            // receive selling right now. Using the sell price would flatter every long
+            // position (and understate every short) by the spread.
+            var quote = await _quoteRepository.GetActiveAsync(group.Key);
+            var markPrice = quote?.BuyPrice;
+
+            decimal? unrealizedPnl = result.RemainingQuantity == 0
+                ? 0m
+                : markPrice.HasValue && result.AverageCost.HasValue
+                    ? result.RemainingQuantity * (markPrice.Value - result.AverageCost.Value)
+                    : null; // flat's the only case a missing quote doesn't block an answer
+
+            response.Positions.Add(new PositionDto
+            {
+                Symbol = group.Key,
+                Quantity = result.RemainingQuantity,
+                AverageCost = result.AverageCost,
+                MarkPrice = markPrice,
+                RealizedPnl = result.RealizedPnl,
+                UnrealizedPnl = unrealizedPnl
+            });
+
+            response.TotalRealizedPnl += result.RealizedPnl;
+            response.TotalUnrealizedPnl += unrealizedPnl ?? 0m;
+        }
+
+        response.Positions = response.Positions.OrderBy(p => p.Symbol, StringComparer.OrdinalIgnoreCase).ToList();
+        return response;
+    }
+}

--- a/src/Order/Orders.Core/PositionCalculator.cs
+++ b/src/Order/Orders.Core/PositionCalculator.cs
@@ -1,0 +1,99 @@
+namespace Orders.Core;
+
+/// <summary>
+/// One trade from a single participant's point of view, stripped down to what FIFO
+/// matching needs. A buy is a positive <see cref="SignedQuantity"/>, a sell negative — the
+/// caller (which knows whether this participant was the trade's buyer or seller) does that
+/// translation; this type has no notion of "buyer"/"seller" itself.
+/// </summary>
+public readonly record struct PositionTradeLeg(DateTime OccurredAt, decimal SignedQuantity, decimal Price, decimal Fee);
+
+/// <summary>
+/// The result of matching one participant's trades in one symbol.
+/// <see cref="RemainingQuantity"/> is signed: positive is a long (net bought) position,
+/// negative a short (net sold, credit-backed) position, zero is flat.
+/// <see cref="AverageCost"/> is null when flat — there is no cost basis for nothing held.
+/// </summary>
+public readonly record struct PositionResult(
+    decimal RealizedPnl,
+    decimal RemainingQuantity,
+    decimal? AverageCost,
+    decimal TotalFees);
+
+/// <summary>
+/// Matches a participant's trades in one symbol FIFO — oldest lot closed first — to produce
+/// realized P&amp;L and the cost basis of whatever remains open (issue #93).
+///
+/// <para>
+/// <b>Why FIFO, not weighted average:</b> a deliberate choice (not a default), because it
+/// gives a more familiar audit trail — "which specific purchase did this sale close" — even
+/// though it costs more to compute than a running average.
+/// </para>
+///
+/// <para>
+/// <b>Long and short use the same formula.</b> An open lot is just a signed quantity at a
+/// price; closing one — a sell against a long lot, or a buy against a short lot — realizes
+/// <c>closedQty * (exitPrice - lotPrice) * sign(lotQty)</c>. For a long lot that is the
+/// familiar "sold higher than bought = profit"; for a short lot the sign flip makes "bought
+/// back lower than sold = profit" fall out of the identical line, so a credit-backed short
+/// position (issue #61, #93's acceptance criteria) needs no separate branch.
+/// </para>
+///
+/// <para>
+/// <b>Fees are expensed at trade time, not capitalized into the lot.</b> Every trade's fee
+/// (read from the <c>Trade</c> row, never assumed zero — see issue #35) reduces realized
+/// P&amp;L in the period it was paid, whether that trade opened or closed a lot. This is the
+/// simpler of two defensible treatments — the alternative, folding a fee into the lot's cost
+/// basis so it is only recognized when that lot eventually closes, is arguably more correct
+/// but adds real complexity for a scenario that cannot happen yet (fees are hardcoded to
+/// zero today; #35 is what would turn them on). Revisit this once fees are real.
+/// </para>
+/// </summary>
+public static class PositionCalculator
+{
+    public static PositionResult Calculate(IEnumerable<PositionTradeLeg> legs)
+    {
+        var ordered = legs.OrderBy(l => l.OccurredAt).ToList();
+
+        // FIFO queue of open lots, oldest first. A lot's sign marks long (bought, awaiting a
+        // sell) vs short (sold, awaiting a buy-back).
+        var lots = new List<(decimal Quantity, decimal Price)>();
+
+        var realizedPnl = 0m;
+        var totalFees = 0m;
+
+        foreach (var leg in ordered)
+        {
+            totalFees += leg.Fee;
+            realizedPnl -= leg.Fee;
+
+            var remaining = leg.SignedQuantity;
+
+            while (remaining != 0 && lots.Count > 0 && Math.Sign(lots[0].Quantity) != Math.Sign(remaining))
+            {
+                var (lotQuantity, lotPrice) = lots[0];
+                var closedQuantity = Math.Min(Math.Abs(remaining), Math.Abs(lotQuantity));
+
+                realizedPnl += closedQuantity * (leg.Price - lotPrice) * Math.Sign(lotQuantity);
+
+                var remainingLotQuantity = lotQuantity - Math.Sign(lotQuantity) * closedQuantity;
+                if (remainingLotQuantity == 0)
+                    lots.RemoveAt(0);
+                else
+                    lots[0] = (remainingLotQuantity, lotPrice);
+
+                remaining -= Math.Sign(remaining) * closedQuantity;
+            }
+
+            if (remaining != 0)
+                lots.Add((remaining, leg.Price));
+        }
+
+        var remainingQuantity = lots.Sum(l => l.Quantity);
+        decimal? averageCost = remainingQuantity == 0
+            ? null
+            : lots.Sum(l => l.Quantity * l.Price) / remainingQuantity;
+
+        return new PositionResult(realizedPnl, remainingQuantity, averageCost, totalFees);
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/PositionDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/PositionDto.cs
@@ -1,0 +1,38 @@
+namespace TallaEgg.Core.DTOs.Order
+{
+    /// <summary>
+    /// One participant's position and profit/loss in a single symbol (issue #93).
+    /// </summary>
+    public class PositionDto
+    {
+        public string Symbol { get; set; } = "";
+
+        /// <summary>Signed: positive is long (net bought), negative is short (net sold, credit-backed), zero is flat.</summary>
+        public decimal Quantity { get; set; }
+
+        /// <summary>FIFO cost basis of <see cref="Quantity"/>. Null when flat -- there is nothing to have a cost basis.</summary>
+        public decimal? AverageCost { get; set; }
+
+        /// <summary>The active quote's buy price -- what this participant would receive selling right now. Null if no quote is published.</summary>
+        public decimal? MarkPrice { get; set; }
+
+        /// <summary>Realized profit/loss from every closed portion of every trade in this symbol, fees included.</summary>
+        public decimal RealizedPnl { get; set; }
+
+        /// <summary>Unrealized profit/loss on <see cref="Quantity"/> at <see cref="MarkPrice"/>. Null when either is unavailable.</summary>
+        public decimal? UnrealizedPnl { get; set; }
+    }
+
+    /// <summary>
+    /// A participant's profit/loss across every symbol they have ever traded, plus the total
+    /// (issue #93). Every symbol here quotes against Toman, so summing across symbols is a
+    /// meaningful single number, not an apples-to-oranges total.
+    /// </summary>
+    public class PositionsResponseDto
+    {
+        public List<PositionDto> Positions { get; set; } = new();
+        public decimal TotalRealizedPnl { get; set; }
+        public decimal TotalUnrealizedPnl { get; set; }
+        public decimal TotalPnl => TotalRealizedPnl + TotalUnrealizedPnl;
+    }
+}

--- a/src/Wallet/Wallet.Tests/AnnounceQuoteButtonTests.cs
+++ b/src/Wallet/Wallet.Tests/AnnounceQuoteButtonTests.cs
@@ -80,14 +80,20 @@ public class AnnounceQuoteButtonTests
         Assert.DoesNotContain(_messenger.Texts, t => t.Contains(BotMsgs.MsgSelectAsset));
     }
 
+    /// <summary>
+    /// One "no quote yet" message per symbol without one, each naming which symbol it is
+    /// about — several bare, identical rows in a row previously left an operator with no way
+    /// to tell which symbols were missing a quote and which one (if any) actually had one.
+    /// </summary>
     [Fact]
-    public async Task AnOperatorWithNoPublishedQuoteIsToldSo()
+    public async Task AnOperatorWithNoPublishedQuoteIsToldSoPerSymbol()
     {
         var handler = Build(UserRole.Admin);
 
         await PressAsync(handler);
 
-        Assert.Contains(_messenger.Texts, t => t.Contains("هنوز مظنه‌ای منتشر نشده است"));
+        Assert.Contains(_messenger.Texts, t => t.Contains("هنوز مظنه‌ای") && t.Contains("آبشده"));
+        Assert.Contains(_messenger.Texts, t => t.Contains("هنوز مظنه‌ای") && t.Contains("بیت‌کوین"));
     }
 
     /// <summary>

--- a/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
@@ -1,4 +1,5 @@
 ﻿using TallaEgg.Core;
+using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Utilties;
 using TallaEgg.TelegramBot.Infrastructure;
@@ -171,6 +172,161 @@ public class BalanceAndPriceMessageTests
         ]);
 
         Assert.DoesNotContain("اعتبار:", text);
+    }
+
+    // ── profit and loss (issue #93 part B) ──────────────────────────────────────
+
+    private static PositionDto Position(
+        string symbol, decimal quantity, decimal? averageCost, decimal? markPrice,
+        decimal realizedPnl, decimal? unrealizedPnl) => new()
+    {
+        Symbol = symbol,
+        Quantity = quantity,
+        AverageCost = averageCost,
+        MarkPrice = markPrice,
+        RealizedPnl = realizedPnl,
+        UnrealizedPnl = unrealizedPnl
+    };
+
+    private static PositionsResponseDto Positions(params PositionDto[] positions) => new()
+    {
+        Positions = positions.ToList(),
+        TotalRealizedPnl = positions.Sum(p => p.RealizedPnl),
+        TotalUnrealizedPnl = positions.Sum(p => p.UnrealizedPnl ?? 0m)
+    };
+
+    /// <summary>No positions argument at all -- the positions API call failed or was skipped. The balance screen from part A must still render exactly as before.</summary>
+    [Fact]
+    public void WithNoPositionsArgument_TheScreenIsUnchangedFromPartA()
+    {
+        var text = WalletBalanceMessage.Build([Wallet(CurrenciesConstant.Maua, 10m)]);
+
+        Assert.DoesNotContain("سود", text);
+        Assert.DoesNotContain("زیان", text);
+    }
+
+    /// <summary>A symbol the customer holds a wallet for but has no position data on (e.g. only ever received it via a direct credit) gets no P&amp;L lines.</summary>
+    [Fact]
+    public void ASymbolWithNoPositionData_ShowsNoPnlLines()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Maua, 10m)],
+            Positions()); // no entries at all
+
+        Assert.DoesNotContain("میانگین قیمت خرید", text);
+        Assert.DoesNotContain("ارزش فعلی", text);
+    }
+
+    [Fact]
+    public void AnOpenLongPositionInProfit_ShowsAverageCostCurrentValueAndAGain()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 2m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, quantity: 2m, averageCost: 1_000_000m,
+                markPrice: 1_200_000m, realizedPnl: 0m, unrealizedPnl: 400_000m)));
+
+        Assert.Contains(PersianFormat.Amount(1_000_000m, CurrenciesConstant.Toman), text); // average cost
+        Assert.Contains(PersianFormat.Amount(2_400_000m, CurrenciesConstant.Toman), text); // current value = qty * mark
+        Assert.Contains("📈 سود تحقق‌نیافته", text);
+        Assert.Contains(PersianFormat.Amount(400_000m, CurrenciesConstant.Toman), text);
+        Assert.DoesNotContain("📉", text);
+    }
+
+    [Fact]
+    public void AnOpenPositionAtALoss_IsLabelledAsALossNotANegativeGain()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 2m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, quantity: 2m, averageCost: 1_000_000m,
+                markPrice: 800_000m, realizedPnl: 0m, unrealizedPnl: -400_000m)));
+
+        var lossLine = text.Split('\n').Single(l => l.Contains("زیان تحقق‌نیافته"));
+        Assert.Contains(PersianFormat.Amount(400_000m, CurrenciesConstant.Toman), lossLine); // shown positive, under the loss label
+        Assert.DoesNotContain("-", lossLine);
+        Assert.DoesNotContain("📈 سود تحقق‌نیافته", text);
+    }
+
+    /// <summary>Gold's average cost is stored per gram internally but must display per mesghal, matching every other price the bot shows (BestPricesMessage, order confirmations, ...).</summary>
+    [Fact]
+    public void ForGold_AverageCostIsConvertedToPerMesghal()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Maua, 5m)],
+            Positions(Position(CurrenciesConstant.MAUA_IRT, quantity: 5m, averageCost: 1_000_000m,
+                markPrice: null, realizedPnl: 0m, unrealizedPnl: null)));
+
+        Assert.Contains(PersianFormat.Amount(1_000_000m * CurrenciesConstant.GramsPerMesghal, CurrenciesConstant.Toman), text);
+    }
+
+    /// <summary>An open position with no published quote can't be valued -- must say so, not silently omit the line or show a stale/zero number.</summary>
+    [Fact]
+    public void AnOpenPositionWithNoQuote_SaysSoInsteadOfShowingNothing()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 2m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, quantity: 2m, averageCost: 1_000_000m,
+                markPrice: null, realizedPnl: 0m, unrealizedPnl: null)));
+
+        Assert.Contains("قیمتی برای این نماد منتشر نشده", text);
+        Assert.DoesNotContain("ارزش فعلی", text);
+    }
+
+    /// <summary>A flat position (fully closed) shows realized P&amp;L but no average-cost/current-value lines -- there is nothing open to value.</summary>
+    [Fact]
+    public void AFlatPositionWithRealizedGain_ShowsOnlyTheRealizedLine()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 0m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, quantity: 0m, averageCost: null,
+                markPrice: 1_200_000m, realizedPnl: 300_000m, unrealizedPnl: 0m)));
+
+        Assert.Contains("✅ سود تحقق‌یافته", text);
+        Assert.Contains(PersianFormat.Amount(300_000m, CurrenciesConstant.Toman), text);
+        Assert.DoesNotContain("میانگین قیمت خرید", text);
+        Assert.DoesNotContain("ارزش فعلی", text);
+    }
+
+    [Fact]
+    public void ARealizedLossIsLabelledAsALoss()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 0m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, quantity: 0m, averageCost: null,
+                markPrice: null, realizedPnl: -150_000m, unrealizedPnl: 0m)));
+
+        Assert.Contains("❌ زیان تحقق‌یافته", text);
+        Assert.Contains(PersianFormat.Amount(150_000m, CurrenciesConstant.Toman), text);
+    }
+
+    [Fact]
+    public void TheTotalAcrossAllSymbols_IsShownAtTheBottom()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 0m), Wallet(CurrenciesConstant.Maua, 5m)],
+            new PositionsResponseDto
+            {
+                Positions =
+                [
+                    Position(CurrenciesConstant.BTC_IRT, 0m, null, null, 300_000m, 0m),
+                    Position(CurrenciesConstant.MAUA_IRT, 5m, 100m, 120m, 0m, 100m)
+                ],
+                TotalRealizedPnl = 300_000m,
+                TotalUnrealizedPnl = 100m
+            });
+
+        Assert.Contains("مجموع سود و زیان", text);
+        Assert.Contains(PersianFormat.Amount(300_100m, CurrenciesConstant.Toman), text);
+        Assert.Contains("📈", text);
+    }
+
+    [Fact]
+    public void ZeroTotalPnl_IsReportedAsNoChangeRatherThanAsAGainOrLoss()
+    {
+        var text = WalletBalanceMessage.Build(
+            [Wallet(CurrenciesConstant.Btc, 0m)],
+            Positions(Position(CurrenciesConstant.BTC_IRT, 0m, null, null, 0m, 0m)));
+
+        Assert.Contains("بدون تغییر", text);
     }
 
     // ── best market prices ──────────────────────────────────────────────────────

--- a/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/BalanceAndPriceMessageTests.cs
@@ -100,6 +100,79 @@ public class BalanceAndPriceMessageTests
         Assert.DoesNotContain("{", text);
     }
 
+    // ── per-symbol grouping (issue #93 part A) ──────────────────────────────────
+
+    /// <summary>
+    /// Toman is spending cash, not a traded position — it belongs after the symbols a
+    /// customer actually holds, not interleaved with them by wallet-record order.
+    /// </summary>
+    [Fact]
+    public void TomanIsShownLast_AfterEveryTradedSymbol()
+    {
+        var text = WalletBalanceMessage.Build([
+            Wallet(CurrenciesConstant.Toman, 1_000_000m),
+            Wallet(CurrenciesConstant.Btc, 0.01m),
+            Wallet(CurrenciesConstant.Maua, 10m)
+        ]);
+
+        var tomanIndex = text.IndexOf(PersianFormat.Asset(CurrenciesConstant.Toman), StringComparison.Ordinal);
+        var btcIndex = text.IndexOf(PersianFormat.Asset(CurrenciesConstant.Btc), StringComparison.Ordinal);
+        var mauaIndex = text.IndexOf(PersianFormat.Asset(CurrenciesConstant.Maua), StringComparison.Ordinal);
+
+        Assert.True(tomanIndex > btcIndex && tomanIndex > mauaIndex,
+            "Toman must come after every traded symbol, not among them");
+    }
+
+    /// <summary>
+    /// A symbol's credit ceiling is shown as a line under that symbol's own section, not as
+    /// an unrelated-looking row for "اعتبار آبشده" — a customer reading the wallet screen
+    /// should see gold's credit next to gold, not somewhere else in the list.
+    /// </summary>
+    [Fact]
+    public void ASymbolsCredit_IsShownUnderThatSymbolNotAsItsOwnRow()
+    {
+        var text = WalletBalanceMessage.Build([
+            Wallet(CurrenciesConstant.Maua, 10m),
+            Wallet(CurrenciesConstant.CreditAssetFor(CurrenciesConstant.Maua), 240m)
+        ]);
+
+        var mauaSection = text[text.IndexOf(PersianFormat.Asset(CurrenciesConstant.Maua), StringComparison.Ordinal)..];
+        Assert.Contains(PersianFormat.Amount(240m, CurrenciesConstant.Maua), mauaSection);
+
+        // "اعتبار آبشده" (the credit currency's own Persian name) must never appear as its
+        // own bullet — only merged into gold's section via the "اعتبار:" sub-line.
+        Assert.DoesNotContain(PersianFormat.Asset(CurrenciesConstant.CreditAssetFor(CurrenciesConstant.Maua)), text);
+    }
+
+    /// <summary>
+    /// A customer can have credit against an asset they have never actually held or traded
+    /// (an admin extended it in advance). Dropping the credit line because there is no base
+    /// wallet yet would hide real spending power from the one person it matters most to.
+    /// </summary>
+    [Fact]
+    public void CreditWithNoUnderlyingWallet_IsStillShown()
+    {
+        var text = WalletBalanceMessage.Build([
+            Wallet(CurrenciesConstant.CreditAssetFor(CurrenciesConstant.Btc), 0.5m)
+        ]);
+
+        Assert.Contains(PersianFormat.Asset(CurrenciesConstant.Btc), text);
+        Assert.Contains(PersianFormat.Amount(0.5m, CurrenciesConstant.Btc), text);
+        Assert.Contains(PersianFormat.Amount(0m, CurrenciesConstant.Btc), text); // the synthesised zero balance
+    }
+
+    /// <summary>Zero credit is not worth a line — every wallet has a CREDIT_ record once touched once.</summary>
+    [Fact]
+    public void ZeroCredit_ShowsNoCreditLine()
+    {
+        var text = WalletBalanceMessage.Build([
+            Wallet(CurrenciesConstant.Maua, 10m),
+            Wallet(CurrenciesConstant.CreditAssetFor(CurrenciesConstant.Maua), 0m)
+        ]);
+
+        Assert.DoesNotContain("اعتبار:", text);
+    }
+
     // ── best market prices ──────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
+++ b/src/Wallet/Wallet.Tests/BotConversationFlowTests.cs
@@ -9,6 +9,7 @@ using TallaEgg.TelegramBot.Infrastructure;
 using TallaEgg.TelegramBot.Infrastructure.Conversations;
 using Wallet.Tests.Fakes;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Wallet.Tests;
 
@@ -357,5 +358,119 @@ public class BotConversationFlowTests
     {
         Assert.True(_conversations.TryGet(TelegramId, out var conversation), "no conversation in flight");
         return conversation;
+    }
+
+    // ── no quote published (market path) ────────────────────────────────────────
+
+    /// <summary>
+    /// The dealer/market path never asks for a price, so with no quote published there is
+    /// nothing to trade on. Continuing to ask for an amount used to lead the customer into a
+    /// guaranteed failure one step later ("خطا در دریافت بهترین قیمت بازار") instead of
+    /// telling them up front. Hit live: "دریافت مظنه" on a symbol nobody had published a
+    /// price for yet.
+    /// </summary>
+    [Fact]
+    public async Task WithNoQuotePublished_TheMarketPathStopsBeforeAskingForAnAmount()
+    {
+        _orderApi.ActiveQuote = null;
+
+        await SayAsync(BotBtns.BtnSpotMarket);
+        await TapAsync($"asset_{Gold}");
+
+        Assert.Contains(_messenger.Texts, t => t.Contains(BotMsgs.MsgNoQuoteForSymbol));
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("لطفاً مقدار را وارد کنید"));
+    }
+
+    [Fact]
+    public async Task WithNoQuotePublished_TheMarketPathLeavesNoConversationInFlight()
+    {
+        _orderApi.ActiveQuote = null;
+
+        await SayAsync(BotBtns.BtnSpotMarket);
+        await TapAsync($"asset_{Gold}");
+
+        Assert.False(_conversations.TryGet(TelegramId, out _), "a stale conversation should not survive a stop");
+    }
+
+    /// <summary>
+    /// The limit (order-book) path is unaffected by a missing quote — it never depended on
+    /// one, since it asks the customer for a price itself. Only the market path is a dead
+    /// end without a quote.
+    /// </summary>
+    [Fact]
+    public async Task WithNoQuotePublished_TheLimitPathStillAsksForAnAmount()
+    {
+        _orderApi.ActiveQuote = null;
+
+        await SayAsync(BotBtns.BtnSpotCreateOrder);
+        await TapAsync($"asset_{Gold}");
+
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains(BotMsgs.MsgNoQuoteForSymbol));
+    }
+
+    // ── the back button always escapes ──────────────────────────────────────────
+
+    /// <summary>
+    /// A customer stuck typing into "waiting_for_amount" (no quote, a typo, changed their
+    /// mind) previously had no way out except knowing the exact literal text to send, and
+    /// even that text was parsed as an invalid amount rather than recognised as a command —
+    /// there was no button at all on this prompt.
+    /// </summary>
+    [Fact]
+    public async Task TappingBackWhileEnteringAnAmount_ClearsTheConversationInsteadOfBeingParsedAsAnAmount()
+    {
+        PublishQuote();
+        await SayAsync(BotBtns.BtnSpotMarket);
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(InlineCallBackData.buy_spot);
+
+        await SayAsync(BotBtns.BtnBack);
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("منوی اصلی"));
+        Assert.False(_conversations.TryGet(TelegramId, out _), "back must clear the in-flight conversation");
+    }
+
+    [Fact]
+    public async Task TappingBackWhileEnteringAPrice_ClearsTheConversationInsteadOfBeingParsedAsAPrice()
+    {
+        _orderApi.ActiveQuote = null;
+        await SayAsync(BotBtns.BtnSpotCreateOrder);
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(InlineCallBackData.buy_spot);
+        await SayAsync("2.5"); // a valid amount, which advances the state to waiting_for_price
+
+        await SayAsync(BotBtns.BtnBack);
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("منوی اصلی"));
+        Assert.False(_conversations.TryGet(TelegramId, out _), "back must clear the in-flight conversation");
+    }
+
+    [Fact]
+    public async Task TheAmountPromptOffersABackButton()
+    {
+        PublishQuote();
+        await SayAsync(BotBtns.BtnSpotMarket);
+        await TapAsync($"asset_{Gold}");
+
+        await TapAsync(InlineCallBackData.buy_spot);
+
+        var prompt = _messenger.Sent.Last();
+        var keyboard = Assert.IsType<ReplyKeyboardMarkup>(prompt.ReplyMarkup);
+        Assert.Contains(keyboard.Keyboard.SelectMany(row => row), b => b.Text == BotBtns.BtnBack);
+    }
+
+    [Fact]
+    public async Task ThePricePromptOffersABackButton()
+    {
+        _orderApi.ActiveQuote = null;
+        await SayAsync(BotBtns.BtnSpotCreateOrder);
+        await TapAsync($"asset_{Gold}");
+        await TapAsync(InlineCallBackData.buy_spot);
+
+        await SayAsync("2.5");
+
+        var prompt = _messenger.Sent.Last();
+        var keyboard = Assert.IsType<ReplyKeyboardMarkup>(prompt.ReplyMarkup);
+        Assert.Contains(keyboard.Keyboard.SelectMany(row => row), b => b.Text == BotBtns.BtnBack);
     }
 }

--- a/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
+++ b/src/Wallet/Wallet.Tests/Fakes/BotTestDoubles.cs
@@ -57,8 +57,25 @@ public sealed class FakeOrderApiClient : IOrderApiClient
         return Task.FromResult((true, "ok"));
     }
 
-    public Task<ApiResponse<BestPricesDto>> GetBestPricesAsync(string symbol) =>
-        Task.FromResult(ApiResponse<BestPricesDto>.Ok(new BestPricesDto(), "ok"));
+    /// <summary>
+    /// Mirrors the real dealer-mode best-prices endpoint, which derives bid/ask from the
+    /// active quote when there is no resting order book: present and matching the requested
+    /// symbol gives real prices, anything else (no quote, or a different symbol) gives the
+    /// "nothing published" shape a customer sees when dealer mode has no price for them.
+    /// </summary>
+    public Task<ApiResponse<BestPricesDto>> GetBestPricesAsync(string symbol)
+    {
+        var quote = ActiveQuote is not null && string.Equals(ActiveQuote.Symbol, symbol, StringComparison.OrdinalIgnoreCase)
+            ? ActiveQuote
+            : null;
+
+        return Task.FromResult(ApiResponse<BestPricesDto>.Ok(new BestPricesDto
+        {
+            Symbol = symbol,
+            BestBidPrice = quote?.BuyPrice,
+            BestAskPrice = quote?.SellPrice
+        }, "ok"));
+    }
 
     public Task<ApiResponse<PagedResult<OrderHistoryDto>>> GetUserOrdersAsync(Guid userId, int pageNumber = 1, int pageSize = 10) =>
         throw new NotSupportedException(nameof(GetUserOrdersAsync));
@@ -127,6 +144,13 @@ public sealed class FakeOrderApiClient : IOrderApiClient
         ActiveToggles.Add((symbol, isActive, updatedByUserId));
         return Task.FromResult(ActiveToggleResult);
     }
+
+    // ── سود و زیان (issue #93) ───────────────────────────────────────────────────
+
+    public ApiResponse<PositionsResponseDto> PositionsResult { get; set; } =
+        ApiResponse<PositionsResponseDto>.Ok(new PositionsResponseDto(), "ok");
+
+    public Task<ApiResponse<PositionsResponseDto>> GetPositionsAsync(Guid userId) => Task.FromResult(PositionsResult);
 }
 
 /// <summary>Answers with one known, approved customer.</summary>

--- a/src/Wallet/Wallet.Tests/PositionCalculatorTests.cs
+++ b/src/Wallet/Wallet.Tests/PositionCalculatorTests.cs
@@ -1,0 +1,179 @@
+using Orders.Core;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// The FIFO position/P&amp;L engine (issue #93), tested independently of the DB and the
+/// service that will feed it real trades — this is pure arithmetic and should be pinned
+/// down as such.
+/// </summary>
+public class PositionCalculatorTests
+{
+    private static PositionTradeLeg Buy(decimal qty, decimal price, decimal fee = 0m, int daysAgo = 0) =>
+        new(DateTime.UtcNow.AddDays(-daysAgo), qty, price, fee);
+
+    private static PositionTradeLeg Sell(decimal qty, decimal price, decimal fee = 0m, int daysAgo = 0) =>
+        new(DateTime.UtcNow.AddDays(-daysAgo), -qty, price, fee);
+
+    [Fact]
+    public void NoTrades_IsFlatWithNoRealizedPnlAndNoCostBasis()
+    {
+        var result = PositionCalculator.Calculate([]);
+
+        Assert.Equal(0m, result.RealizedPnl);
+        Assert.Equal(0m, result.RemainingQuantity);
+        Assert.Null(result.AverageCost);
+        Assert.Equal(0m, result.TotalFees);
+    }
+
+    [Fact]
+    public void ASingleBuyThenAMatchingSell_RealizesTheFullGain()
+    {
+        var result = PositionCalculator.Calculate([
+            Buy(10m, 100m, daysAgo: 2),
+            Sell(10m, 150m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(500m, result.RealizedPnl); // 10 * (150 - 100)
+        Assert.Equal(0m, result.RemainingQuantity);
+        Assert.Null(result.AverageCost);
+    }
+
+    [Fact]
+    public void ASingleBuyThenAMatchingSellAtALoss_RealizesTheLossAsNegative()
+    {
+        var result = PositionCalculator.Calculate([
+            Buy(10m, 150m, daysAgo: 2),
+            Sell(10m, 100m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(-500m, result.RealizedPnl);
+    }
+
+    /// <summary>
+    /// The case FIFO and weighted-average actually disagree on: the sell closes the OLDER
+    /// lot first, so the remainder held is priced at the newer lot's cost, not a blended
+    /// average of both.
+    /// </summary>
+    [Fact]
+    public void SeveralBuysAtDifferentPricesThenAPartialSell_ClosesTheOldestLotFirst()
+    {
+        var result = PositionCalculator.Calculate([
+            Buy(5m, 100m, daysAgo: 3),
+            Buy(3m, 110m, daysAgo: 2),
+            Sell(6m, 150m, daysAgo: 1)
+        ]);
+
+        // Closes all 5 of the first lot (gain 5*50=250) plus 1 of the second (gain 1*40=40).
+        Assert.Equal(290m, result.RealizedPnl);
+
+        // 2 units left over from the second (110) lot -- not a blended average of 100 and 110.
+        Assert.Equal(2m, result.RemainingQuantity);
+        Assert.Equal(110m, result.AverageCost);
+    }
+
+    /// <summary>
+    /// A remaining position spanning multiple still-open lots of the same sign is averaged
+    /// across them -- this is the one place a weighted mean legitimately appears, for the
+    /// leftover, not as the costing method itself.
+    /// </summary>
+    [Fact]
+    public void MultipleOpenLotsRemaining_AreAveragedTogether()
+    {
+        var result = PositionCalculator.Calculate([
+            Buy(3m, 100m, daysAgo: 2),
+            Buy(5m, 120m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(0m, result.RealizedPnl); // nothing closed yet
+        Assert.Equal(8m, result.RemainingQuantity);
+        Assert.Equal((3m * 100m + 5m * 120m) / 8m, result.AverageCost);
+    }
+
+    /// <summary>
+    /// A credit-backed short: selling before ever holding the asset. The same formula that
+    /// handles a long position must produce the correct sign here without a special case.
+    /// </summary>
+    [Fact]
+    public void ASellWithNoPriorPosition_OpensAShort()
+    {
+        var result = PositionCalculator.Calculate([
+            Sell(4m, 100m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(-4m, result.RemainingQuantity); // negative: short
+        Assert.Equal(100m, result.AverageCost);
+        Assert.Equal(0m, result.RealizedPnl); // nothing closed yet
+    }
+
+    [Fact]
+    public void CoveringAShortAtALowerPrice_RealizesAGain()
+    {
+        var result = PositionCalculator.Calculate([
+            Sell(4m, 100m, daysAgo: 2),  // short 4 @ 100
+            Buy(4m, 60m, daysAgo: 1)     // covers at a lower price -- a gain for the short
+        ]);
+
+        Assert.Equal(160m, result.RealizedPnl); // 4 * (100 - 60)
+        Assert.Equal(0m, result.RemainingQuantity);
+    }
+
+    [Fact]
+    public void CoveringAShortAtAHigherPrice_RealizesALoss()
+    {
+        var result = PositionCalculator.Calculate([
+            Sell(4m, 100m, daysAgo: 2),
+            Buy(4m, 130m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(-120m, result.RealizedPnl); // 4 * (100 - 130)
+    }
+
+    /// <summary>
+    /// A buy larger than the open short first covers it (realizing P&amp;L), then the
+    /// remainder opens a fresh long lot -- crossing through flat, not two disconnected
+    /// positions.
+    /// </summary>
+    [Fact]
+    public void ABuyThatOvershootsAnOpenShort_ClosesItThenOpensALong()
+    {
+        var result = PositionCalculator.Calculate([
+            Sell(4m, 100m, daysAgo: 2),   // short 4 @ 100
+            Buy(6m, 80m, daysAgo: 1)      // covers 4 (gain) and opens a new long of 2 @ 80
+        ]);
+
+        Assert.Equal(80m, result.RealizedPnl); // 4 * (100 - 80)
+        Assert.Equal(2m, result.RemainingQuantity);
+        Assert.Equal(80m, result.AverageCost);
+    }
+
+    /// <summary>Fees are read per trade and expensed immediately, never assumed to be zero (#35).</summary>
+    [Fact]
+    public void FeesReduceRealizedPnlAndAreTotalledSeparately()
+    {
+        var result = PositionCalculator.Calculate([
+            Buy(10m, 100m, fee: 5m, daysAgo: 2),
+            Sell(10m, 150m, fee: 7m, daysAgo: 1)
+        ]);
+
+        Assert.Equal(500m - 12m, result.RealizedPnl); // gain minus both fees
+        Assert.Equal(12m, result.TotalFees);
+    }
+
+    [Fact]
+    public void TradesAreMatchedInChronologicalOrder_RegardlessOfInputOrder()
+    {
+        // Same trades as the "closes the oldest lot first" case, but handed to the
+        // calculator out of order -- OccurredAt must be what determines FIFO order, not
+        // the order the caller happened to enumerate them in.
+        var result = PositionCalculator.Calculate([
+            Sell(6m, 150m, daysAgo: 1),
+            Buy(3m, 110m, daysAgo: 2),
+            Buy(5m, 100m, daysAgo: 3)
+        ]);
+
+        Assert.Equal(290m, result.RealizedPnl);
+        Assert.Equal(2m, result.RemainingQuantity);
+        Assert.Equal(110m, result.AverageCost);
+    }
+}

--- a/src/Wallet/Wallet.Tests/PositionServiceTests.cs
+++ b/src/Wallet/Wallet.Tests/PositionServiceTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core.Enums.Order;
+
+namespace Wallet.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="PositionService"/> against real (SQLite-backed)
+/// <see cref="TradeRepository"/> and <see cref="QuoteRepository"/> — the FIFO arithmetic
+/// itself is pinned down in <c>PositionCalculatorTests</c>; this covers wiring trades and
+/// the active quote into that engine correctly (issue #93).
+///
+/// Every trade here is between "the customer" and "the house" — the dealer/admin side of
+/// every quote-fill trade. Several tests deliberately query positions for the house's own
+/// user id instead of the customer's, to prove the same service needs no special-casing to
+/// produce the shop's own P&amp;L: it is just another participant's trades.
+/// </summary>
+public class PositionServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly OrdersDbContext _context;
+    private readonly PositionService _service;
+
+    private readonly Guid _customerId = Guid.NewGuid();
+    private readonly Guid _houseId = Guid.NewGuid();
+
+    private const string Symbol = "MAUA/IRT";
+
+    public PositionServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+        _context = new OrdersDbContext(options);
+        _context.Database.EnsureCreated();
+
+        _service = new PositionService(
+            new TradeRepository(_context),
+            new QuoteRepository(_context, NullLogger<QuoteRepository>.Instance));
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private Order SeedOrder(Guid userId, OrderSide side, decimal qty, decimal price, string symbol)
+    {
+        var order = Order.CreateMakerOrder(symbol, qty, price, userId, side, TradingType.Spot);
+        order.Confirm();
+        _context.Orders.Add(order);
+        _context.SaveChanges();
+        return order;
+    }
+
+    /// <summary>Seeds one trade between the customer and the house, on whichever side is asked for.</summary>
+    private void SeedTrade(bool customerIsBuyer, decimal qty, decimal price, DateTime createdAt,
+        decimal feeBuyer = 0m, decimal feeSeller = 0m, string symbol = Symbol)
+    {
+        var buyerId = customerIsBuyer ? _customerId : _houseId;
+        var sellerId = customerIsBuyer ? _houseId : _customerId;
+
+        var buyOrder = SeedOrder(buyerId, OrderSide.Buy, qty, price, symbol);
+        var sellOrder = SeedOrder(sellerId, OrderSide.Sell, qty, price, symbol);
+
+        var trade = Trade.Create(
+            buyOrder.Id, sellOrder.Id, buyOrder.Id, sellOrder.Id,
+            symbol, price, qty, qty * price,
+            buyerId, sellerId, buyerId, sellerId,
+            feeBuyer: feeBuyer, feeSeller: feeSeller);
+
+        // Trade.Create stamps CreatedAt = UtcNow; FIFO order depends on it, so tests need
+        // control over it the same way AtomicMatchRoleTests controls Order.CreatedAt.
+        typeof(Trade).GetProperty(nameof(Trade.CreatedAt))!.SetValue(trade, createdAt);
+
+        _context.Trades.Add(trade);
+        _context.SaveChanges();
+    }
+
+    private void SeedQuote(decimal buyPrice, decimal sellPrice, string symbol = Symbol)
+    {
+        var quote = Quote.Publish(symbol, buyPrice, sellPrice, _houseId);
+        _context.Quotes.Add(quote);
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task ACustomerWithNoTrades_HasNoPositions()
+    {
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        Assert.Empty(result.Positions);
+        Assert.Equal(0m, result.TotalRealizedPnl);
+        Assert.Equal(0m, result.TotalUnrealizedPnl);
+    }
+
+    [Fact]
+    public async Task ABuyThenAMatchingSell_RealizesTheGainAndLeavesNoOpenPosition()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 5m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-2));
+        SeedTrade(customerIsBuyer: false, qty: 5m, price: 150m, createdAt: DateTime.UtcNow.AddDays(-1));
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        var position = Assert.Single(result.Positions);
+        Assert.Equal(Symbol, position.Symbol);
+        Assert.Equal(0m, position.Quantity);
+        Assert.Null(position.AverageCost);
+        Assert.Equal(250m, position.RealizedPnl); // 5 * (150 - 100)
+        Assert.Equal(0m, position.UnrealizedPnl);
+        Assert.Equal(250m, result.TotalRealizedPnl);
+    }
+
+    [Fact]
+    public async Task AnOpenPosition_IsMarkedAgainstTheActiveQuotesBuyPrice()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 10m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-1));
+        SeedQuote(buyPrice: 120m, sellPrice: 125m);
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        var position = Assert.Single(result.Positions);
+        Assert.Equal(10m, position.Quantity);
+        Assert.Equal(100m, position.AverageCost);
+        Assert.Equal(120m, position.MarkPrice); // the buy price -- what selling now would pay, not the sell price
+        Assert.Equal(200m, position.UnrealizedPnl); // 10 * (120 - 100)
+    }
+
+    [Fact]
+    public async Task AnOpenPositionWithNoPublishedQuote_HasNoComputableUnrealizedPnl()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 10m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-1));
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        var position = Assert.Single(result.Positions);
+        Assert.Null(position.MarkPrice);
+        Assert.Null(position.UnrealizedPnl);
+        Assert.Equal(0m, result.TotalUnrealizedPnl); // a missing quote must not corrupt the total
+    }
+
+    [Fact]
+    public async Task ACreditBackedShortPosition_ProducesTheCorrectSign()
+    {
+        SeedTrade(customerIsBuyer: false, qty: 4m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-1)); // customer sells short
+        SeedQuote(buyPrice: 70m, sellPrice: 75m); // price fell after shorting -- a gain
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        var position = Assert.Single(result.Positions);
+        Assert.Equal(-4m, position.Quantity);
+        Assert.Equal(100m, position.AverageCost);
+        Assert.Equal(70m, position.MarkPrice);
+        Assert.Equal(120m, position.UnrealizedPnl); // -4 * (70 - 100)
+    }
+
+    [Fact]
+    public async Task FeesAreReadFromTheTradeRecord_NotAssumedZero()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 5m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-2), feeBuyer: 5m);
+        SeedTrade(customerIsBuyer: false, qty: 5m, price: 150m, createdAt: DateTime.UtcNow.AddDays(-1), feeSeller: 7m);
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        var position = Assert.Single(result.Positions);
+        Assert.Equal(250m - 12m, position.RealizedPnl);
+    }
+
+    [Fact]
+    public async Task TotalsSumAcrossEveryTradedSymbol()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 5m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-4));
+        SeedTrade(customerIsBuyer: false, qty: 5m, price: 150m, createdAt: DateTime.UtcNow.AddDays(-3)); // +250 realized, MAUA/IRT
+
+        SeedTrade(customerIsBuyer: true, qty: 1m, price: 900_000_000m, createdAt: DateTime.UtcNow.AddDays(-2), symbol: "BTC/IRT");
+        SeedTrade(customerIsBuyer: false, qty: 1m, price: 800_000_000m, createdAt: DateTime.UtcNow.AddDays(-1), symbol: "BTC/IRT"); // -100,000,000 realized, BTC/IRT
+
+        var result = await _service.GetPositionsAsync(_customerId);
+
+        Assert.Equal(2, result.Positions.Count);
+        Assert.Equal(250m - 100_000_000m, result.TotalRealizedPnl);
+    }
+
+    /// <summary>
+    /// The house is just the other side of every one of the customer's trades above. Its
+    /// realized P&amp;L must be the exact mirror image -- proving the service needs no
+    /// separate "admin" code path, only the admin's own user id.
+    /// </summary>
+    [Fact]
+    public async Task TheHousesOwnPositions_AreTheExactMirrorOfTheCustomers()
+    {
+        SeedTrade(customerIsBuyer: true, qty: 5m, price: 100m, createdAt: DateTime.UtcNow.AddDays(-2));
+        SeedTrade(customerIsBuyer: false, qty: 5m, price: 150m, createdAt: DateTime.UtcNow.AddDays(-1));
+
+        var customerResult = await _service.GetPositionsAsync(_customerId);
+        var houseResult = await _service.GetPositionsAsync(_houseId);
+
+        Assert.Equal(customerResult.TotalRealizedPnl, -houseResult.TotalRealizedPnl);
+    }
+}

--- a/src/Wallet/Wallet.Tests/QuoteHistoryMessageTests.cs
+++ b/src/Wallet/Wallet.Tests/QuoteHistoryMessageTests.cs
@@ -55,7 +55,7 @@ public class QuoteHistoryMessageTests
     [Fact]
     public void ForAnAdmin_TheBuyPriceIsLabelledAsTheirOwnPurchase()
     {
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true, Gold);
 
         Assert.Contains("شما می‌خرید", text);
         Assert.Contains("شما می‌فروشید", text);
@@ -68,7 +68,7 @@ public class QuoteHistoryMessageTests
     [Fact]
     public void ForACustomer_TheAdminsBuyPriceIsTheirSellPrice()
     {
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false, Gold);
 
         Assert.Contains("قیمت فروش شما", text);
         Assert.Contains("قیمت خرید شما", text);
@@ -84,8 +84,8 @@ public class QuoteHistoryMessageTests
     {
         var page = OnePage(Quote());
 
-        var adminText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true);
-        var customerText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false);
+        var adminText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true, Gold);
+        var customerText = QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false, Gold);
 
         Assert.NotEqual(adminText, customerText);
     }
@@ -96,8 +96,8 @@ public class QuoteHistoryMessageTests
     {
         var page = OnePage(Quote());
 
-        Assert.Contains("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true));
-        Assert.DoesNotContain("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false));
+        Assert.Contains("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: true, Gold));
+        Assert.DoesNotContain("حاشیه", QuoteHistoryHandler.BuildQuoteHistoryAsync(page, 1, isAdmin: false, Gold));
     }
 
     // ── units ───────────────────────────────────────────────────────────────────
@@ -112,7 +112,7 @@ public class QuoteHistoryMessageTests
     [InlineData(false)]
     public void PricesAreConvertedToPerMesghal(bool isAdmin)
     {
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin, Gold);
 
         Assert.Contains("هر مثقال", text);
         Assert.Contains(Fa(BuyPerGram * CurrenciesConstant.GramsPerMesghal), text);
@@ -124,7 +124,7 @@ public class QuoteHistoryMessageTests
     [Fact]
     public void TheMarginIsQuotedPerMesghal_MatchingThePricesAboveIt()
     {
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: true, Gold);
 
         var expected = (SellPerGram - BuyPerGram) * CurrenciesConstant.GramsPerMesghal;
 
@@ -144,8 +144,8 @@ public class QuoteHistoryMessageTests
     {
         var replaced = Quote(isActive: false, deactivatedAt: new DateTime(2026, 7, 30, 11, 34, 0, DateTimeKind.Utc));
 
-        var activeText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false);
-        var replacedText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false);
+        var activeText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false, Gold);
+        var replacedText = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false, Gold);
 
         Assert.Contains("مظنهٔ فعال", activeText);
         Assert.DoesNotContain("مظنهٔ فعال", replacedText);
@@ -157,8 +157,8 @@ public class QuoteHistoryMessageTests
     {
         var replaced = Quote(isActive: false, deactivatedAt: new DateTime(2026, 7, 30, 11, 34, 0, DateTimeKind.Utc));
 
-        Assert.Contains("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false));
-        Assert.DoesNotContain("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false));
+        Assert.Contains("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(replaced), 1, isAdmin: false, Gold));
+        Assert.DoesNotContain("پایان", QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote()), 1, isAdmin: false, Gold));
     }
 
     // ── edges ───────────────────────────────────────────────────────────────────
@@ -168,15 +168,34 @@ public class QuoteHistoryMessageTests
     {
         var empty = new PagedResult<QuoteDto> { Items = new List<QuoteDto>(), TotalCount = 0, PageNumber = 1, PageSize = 5 };
 
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(empty, 1, isAdmin: false);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(empty, 1, isAdmin: false, Gold);
 
-        Assert.Contains("هنوز مظنه‌ای منتشر نشده", text);
+        Assert.Contains("هنوز مظنه‌ای", text);
+    }
+
+    /// <summary>
+    /// ShowLatestQuoteAsync/ShowQuoteHistory send one "no quote yet" message per symbol in a
+    /// loop (issue: an admin tapping «اعلام مظنه» saw several bare "هنوز مظنه‌ای منتشر نشده
+    /// است." rows with no way to tell which symbols they were about). The message must name
+    /// the symbol so each row is self-contained.
+    /// </summary>
+    [Fact]
+    public void AnEmptyHistory_NamesWhichSymbolHasNoQuote()
+    {
+        var empty = new PagedResult<QuoteDto> { Items = new List<QuoteDto>(), TotalCount = 0, PageNumber = 1, PageSize = 5 };
+
+        var goldText = QuoteHistoryHandler.BuildQuoteHistoryAsync(empty, 1, isAdmin: true, Gold);
+        var btcText = QuoteHistoryHandler.BuildQuoteHistoryAsync(empty, 1, isAdmin: true, CurrenciesConstant.BTC_IRT);
+
+        Assert.Contains(TallaEgg.Core.Utilties.PersianFormat.Symbol(Gold), goldText);
+        Assert.Contains(TallaEgg.Core.Utilties.PersianFormat.Symbol(CurrenciesConstant.BTC_IRT), btcText);
+        Assert.NotEqual(goldText, btcText);
     }
 
     [Fact]
     public void NoUnfilledPlaceholderSurvives()
     {
-        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote(), Quote(isActive: false)), 1, isAdmin: true);
+        var text = QuoteHistoryHandler.BuildQuoteHistoryAsync(OnePage(Quote(), Quote(isActive: false)), 1, isAdmin: true, Gold);
 
         Assert.DoesNotContain("{", text);
     }


### PR DESCRIPTION
## Summary
Both parts of issue #93.

**Part A** — wires the previously-unreachable wallet balance screen into the customer accounting menu, reshaped from a flat per-wallet-record list into one section per traded symbol (with that symbol's CREDIT_ ceiling merged in, Toman shown last as cash).

**Part B** — profit/loss on the same screen:
- `PositionCalculator` (Orders.Core): a pure FIFO engine — long and short positions share one formula, so a credit-backed short needs no special case. Fees are read from the `Trade` row, never assumed zero (#35).
- `PositionService` + `GET /api/positions/user/{userId}`: per-symbol realized/unrealized P&L, marked against the active quote's buy price (what selling right now would actually pay). Totals sum safely across symbols since everything quotes against Toman. The same service runs unmodified for the SuperAdmin/house account — it's just another trade participant.
- Bot: each traded symbol's section now shows average cost, current value, and P&L; an overall total sits at the bottom. Wired into both the customer and admin accounting menus.

**Also fixes two order-flow dead ends** found live while retesting on the wiped dev DB:
- The market/dealer path advanced to "enter an amount" even with no quote published, guaranteeing a failure one step later. Now it stops immediately with a clear message (the limit/order-book path is unaffected — it never needed a quote).
- The amount/price prompts removed the keyboard entirely; even typing "🔙 بازگشت" was parsed as an invalid amount instead of recognised as a way out. The button is now shown on both prompts and is checked ahead of state-based routing everywhere, not just there.
- Bonus: "هنوز مظنه‌ای منتشر نشده است" (admin's «اعلام مظنه» / quote history) now names which symbol it's about.

## Testing
- `dotnet test` — 483 passed, 0 failed.
- Verified live on the fully-wiped dev DB (all three per-service databases dropped and recreated from migrations): several real trades, clean logs across all three backend services, zero unsettled outbox messages, zero stuck orders.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)