### PR TITLE
docs: record the business rules that keep being mistaken for defects

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -60,6 +60,30 @@ SQL Server and keeps it alive for a chosen number of minutes.
   which each service applies at startup. `create_table.sql` at the repo root is an early artifact
   describing a single table that no longer matches the model — it is not the schema.
 
+## Business rules that look like bugs
+
+Each of these has been mistaken for a defect at least once, including by an audit. None of them
+is one. Confirmed with the product owner on 6 Shahrivar 1405.
+
+- **The market maker may go arbitrarily negative, on any asset, with no ceiling.** Its account
+  currently sits far below zero in IRT and holds no `CREDIT_IRT` ledger. That negative balance
+  *is* the shop's book — what customers are owed — and the market maker manages the exposure
+  themselves. A balance check that treats it as an overdraft is wrong. There is no alerting on
+  it yet; that gap is tracked in #124.
+- **Commission is deliberately zero.** `FeeBuyer`, `FeeSeller`, `MakerFee` and `TakerFee` are
+  `0.00` on every trade by design. The market maker's revenue is the spread between the published
+  buy and sell prices, not commission. Fee code is therefore dormant, not dead — do not delete it
+  as unused.
+- **Credit is cross-asset, not per-asset.** `ValidateCreditAndBalanceAsync` lets credit
+  denominated in the quote currency back a base-asset position (`creditQuote / price`) and vice
+  versa. A customer holding only `CREDIT_MAUA` can legitimately drive their IRT balance negative.
+  Any per-asset invariant would reject trades the business intends to allow — see the retracted
+  N-1 finding in `docs/operations/RE_AUDIT_2026-08.md`.
+- **`Wallet.LockBalance` enforces no balance rule, and must not.** The credit ceiling for asset
+  `A` lives in a separate wallet row keyed `CREDIT_A`, so a single-asset entity cannot evaluate
+  the invariant. The check belongs where both rows are visible. The commented-out guard in that
+  method is wrong code, correctly disabled.
+
 ## Configuration
 
 All services and the bot read one shared file, `config/appsettings.global.json`, found by walking
@@ -67,8 +91,8 @@ up from the content root. Each reads its own section under `Services:{Applicatio
 flattened into the root of its configuration. Per-project `appsettings.json` files are not the
 source of truth.
 
-**This file must never be committed** — it holds live credentials and the repo is public. It is
-tracked today, which is a known defect (issue #33).
+**This file must never be committed** — it holds live credentials and the repo is public. It has
+been untracked since #33; only `config/appsettings.global.example.json` belongs in git.
 
 Missing configuration fails at startup rather than falling back to a default, so a service that
 will not start is usually telling you exactly which key is missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,15 @@ The rules that get skipped most often:
   `TallaEgg.TelegramBot` — that one is not in the solution and will not start.
 - **Dates shown to users are Jalali at a fixed +03:30 offset**, formatted through
   `PersianFormat`. Storage stays Gregorian UTC; the two are unrelated.
-- **Credit is per-asset.** Every tradable asset gets a `CREDIT_<ASSET>` ledger — see
-  `CurrenciesConstant.CreditAssetFor`. It is a ceiling the spot balance may go negative against,
-  so a balance check must constrain `balance + credit`, never `balance` alone. Note that
-  `Wallet.LockBalance` itself enforces nothing; the guard lives in the caller
-  (`ValidateCreditAndBalanceAsync`), so a new call path inherits no protection by default.
+- **Credit is per-asset in storage, but cross-asset in effect.** Every tradable asset gets a
+  `CREDIT_<ASSET>` ledger — see `CurrenciesConstant.CreditAssetFor`. `ValidateCreditAndBalanceAsync`
+  then lets credit in one currency back a position in the other, so a customer holding only
+  `CREDIT_MAUA` can legitimately drive their IRT balance negative. A balance check must constrain
+  `balance + credit` across both sides, never `balance` alone, and never per-asset in isolation.
+- **`Wallet.LockBalance` enforces no balance rule, and must not.** The ceiling lives in a separate
+  wallet row, so a single-asset entity cannot see it; the check belongs in the caller. The
+  commented-out guard there is wrong code, correctly disabled.
+- **Two things that look like bugs and are not:** the market maker may go arbitrarily negative
+  with no ceiling (that balance is the shop's book — alerting is #124), and commission is
+  deliberately `0.00` on every trade because the revenue model is the spread. Fee code is dormant,
+  not dead. Fuller list in [`AGENT.md`](AGENT.md) under "Business rules that look like bugs".


### PR DESCRIPTION
**Branch Name**: `docs/record-business-rules`
**Linked Issues**: files #124 · context for #35, #36

---

## Description

The August re-audit filed two findings that turned out to be correct behaviour (N-1 and N-2, both
retracted). Both failed the same way: **the rule they violated was never written down**, so the
code was read against an assumed model instead of the real one.

This writes the real one down. Documentation only.

---

## Type of Change

- [x] Documentation (docs/comments only)

---

## Changes Made

**`AGENT.md`** — new section "Business rules that look like bugs", covering the four that have
actually produced a wrong conclusion:

| Rule | Why it reads as a bug |
|---|---|
| The market maker may go arbitrarily negative on any asset, no ceiling | Looks like an unguarded overdraft. It is the shop's book — what customers are owed. Alerting tracked in #124. |
| Commission is deliberately `0.00` on every trade | Looks like broken fee wiring. Revenue is the spread. **Fee code is dormant, not dead — do not delete it as unused during cleanup.** |
| Credit is cross-asset, not per-asset | A customer holding only `CREDIT_MAUA` can legitimately drive IRT negative. A per-asset invariant would reject trades the business intends to allow. |
| `Wallet.LockBalance` enforces no balance rule, and must not | The ceiling lives in a separate `CREDIT_A` wallet row that a single-asset entity cannot see. The commented-out guard is wrong code, correctly disabled. |

**`CLAUDE.md`** — the short form, since it loads every session and is where the wrong assumption
would otherwise be made again. Its credit entry was also incomplete: it described the per-asset
*storage* without the cross-asset *evaluation*, which is the half that matters when writing a
balance check.

**`AGENT.md`** — also corrects the same stale claim already fixed in `CLAUDE.md`:
`config/appsettings.global.json` has been untracked since #33, not "tracked today".

---

## Where this came from

A review of the logs and database after a round of manual trading, on 6 Shahrivar 1405. All four
rules were confirmed with the product owner.

**The review found no defects.** Recording it here because it is the evidence behind the rules:

| Check | Result |
|---|---|
| Each wallet's balance vs its own trade history | exact match, all three accounts |
| Conservation across the system | MAUA = 0, IRT = 0 |
| Last transaction `BallanceAfter` vs wallet balance | matches on all 8 wallets |
| `LockedBalance` residue (#52) | zero everywhere |
| Orders in non-terminal states | none — 12/12 Completed, 0 remaining |
| Outbox messages | 6/6 Completed, no Pending/Failed/Abandoned |
| Self-matches (#45) | zero |
| Orphan trades / trades without outbox | zero |
| API service logs | zero ERR, zero WRN across all three |

One rejected trade in the logs was verified correct: the customer had no balance and no credit at
that moment; their credit was granted 16 seconds later, after which their trades succeeded.

---

## Testing Completed

No source changes. Nothing to build or run.

---

## Security Checklist

- [x] No secrets or credentials
- [x] No customer identifiers, phone numbers or Telegram IDs reproduced in the docs
- [x] Balance figures referenced only in general terms, not as a customer-linked record

---

## Breaking Changes?

- [x] No breaking changes

---

## Why this matters before the cleanup pass

The next task is removing dead code and stale comments. Two of these rules exist precisely to stop
that pass from deleting something live — the dormant fee code, and the commented-out guard in
`LockBalance`, which reads like debris and is a deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
