### PR TITLE
refactor(core,users): translate comments to English and remove instructional scaffolding

### DIFF
--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Mvc;
@@ -42,7 +42,7 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
-// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+// Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
@@ -51,33 +51,33 @@ if (urls is { Length: > 0 })
     builder.WebHost.UseUrls(urls);
 }
 
-// تنظیم اتصال به دیتابیس SQL Server (در appsettings.json هم می‌توان قرار داد)
+// SQL Server connection.
 builder.Services.AddDbContext<OrdersDbContext>(options =>
     options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
         b => b.MigrationsAssembly("TallaEgg.Api")));
 
-// تنظیم اتصال به دیتابیس اصلی TallaEgg
+// Connection to the main TallaEgg database.
 // builder.Services.AddDbContext<TallaEggDbContext>(options =>
 //     options.UseSqlServer(builder.Configuration.GetConnectionString("TallaEggDb") ??
 //         "Server=localhost;Database=TallaEgg;Trusted_Connection=True;TrustServerCertificate=True;",
 //         b => b.MigrationsAssembly("TallaEgg.Api")));
 
-// فقط سرویس‌های مربوط به Orders و Price ثبت شوند
+// Only the Orders and Price services are registered.
 builder.Services.AddScoped<IOrderRepository, OrderRepository>();
 //builder.Services.AddScoped<IOrderService, OrderService>();
-// CreateOrderCommandHandler و CreateTakerOrderCommandHandler حذف شدند: هر دو کلاس
-// کاملاً خالی بودند (تمام بدنه کامنت شده) ولی در DI ثبت می‌شدند.
+// CreateOrderCommandHandler and CreateTakerOrderCommandHandler were removed: both classes were
+// entirely empty, with their whole bodies commented out, yet they were still registered in DI.
 
-// سرویس‌های مربوط به Symbols
+// Symbol services.
 // builder.Services.AddScoped<ISymbolRepository, SymbolRepository>();
 // builder.Services.AddScoped<ISymbolService, SymbolService>();
 
-// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+// CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.
 builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddTallaEggErrorHandling();
 
-// پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
+// Serilog: log to rolling files and the console.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
@@ -89,7 +89,7 @@ var app = builder.Build();
 
 app.UseTallaEggErrorHandling();
 
-// تنظیم CORS
+// Apply the CORS policy.
 app.UseTallaEggCors();
 
 static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironment environment, string fileName)

--- a/src/TallaEgg/TallaEgg.Core/ApiKeyAuthenticationHandler.cs
+++ b/src/TallaEgg/TallaEgg.Core/ApiKeyAuthenticationHandler.cs
@@ -26,7 +26,7 @@ namespace TallaEgg.Core
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            // چک کردن Header
+            // Check the header.
             if (!Request.Headers.ContainsKey("X-API-Key"))
             {
                 return Task.FromResult(AuthenticateResult.Fail("Missing API Key"));

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -1,17 +1,17 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace TallaEgg.Core
 {
     public class CurrenciesConstant
     {
-        // 🔹 ثابت‌ها برای استفاده راحت در کد
+        // Convenience constants.
         public const string Maua = "MAUA";
 
         /// <summary>
-        /// واحد پول سیستم: تومان (IRT).
-        /// عمداً IRR (ریال) نیست — تمام مبالغ ذخیره‌شده در دیتابیس به تومان هستند
-        /// (قیمت‌ها به تومان وارد می‌شوند و هیچ تبدیل ریال/تومانی در کد وجود ندارد).
-        /// استفاده از IRR در گذشته باعث ابهام شده بود که عدد ذخیره‌شده ریال است یا تومان.
+        /// The system's currency unit: Toman (IRT).
+        /// Deliberately not IRR (rial) — every amount stored in the database is in toman, prices are
+        /// entered in toman, and no rial/toman conversion exists anywhere in the code. Using IRR in
+        /// the past made it ambiguous whether a stored figure was rials or tomans.
         /// </summary>
         public const string Toman = "IRT";
 
@@ -22,12 +22,12 @@ namespace TallaEgg.Core
         public const string Btc = "BTC";
 
         /// <summary>
-        /// وزن یک مثقال به گرم. قیمت‌ها توسط کاربر و مدیر بر حسب «هر مثقال» وارد
-        /// می‌شوند و برای ذخیره‌سازی به «هر گرم» تبدیل می‌شوند.
+        /// The weight of one mesghal in grams. Users and admins enter prices per mesghal, and they
+        /// are converted to per gram for storage.
         /// </summary>
         public const decimal GramsPerMesghal = 4.3318m;
 
-        // 🔹 ثابت‌های جفت‌های معاملاتی
+        // Trading-pair constants.
         public const string BTC_IRT = "BTC/IRT";
         public const string MAUA_IRT = "MAUA/IRT";
         public const string SEKE_BAHAR_IRT = "SEKE_BAHAR/IRT";
@@ -177,7 +177,7 @@ namespace TallaEgg.Core
                     IsTradable = true
                 };
 
-                // One credit ledger per tradable asset (issue: multi-symbol شارژ, see the
+                // One credit ledger per tradable asset (issue: multi-symbol top-up, see the
                 // conversation that added this) — same ceiling concept CREDIT_MAUA already was,
                 // generalized instead of staying a MAUA-only special case.
                 var creditCode = CreditAssetFor(pair.BaseAsset);
@@ -194,40 +194,39 @@ namespace TallaEgg.Core
             return map;
         }
 
-        // 🔹 مجموعه‌ای از اطلاعات ارزها
+        // The currency catalogue.
         public static List<CurrencyInfo> AllCurrencies => _currencies.Values.ToList();
 
-        // 🔹 مجموعه‌ای از اطلاعات جفت‌های معاملاتی
+        // The trading-pair catalogue.
         public static List<TradingPairInfo> AllTradingPairs => _pairs.Values.ToList();
 
-        // 🔹 دریافت کد همه ارزها (با فرمت اصلی)
+        // All currency codes, in their canonical form.
         public static List<string> GetAllCodes() =>
             _currencies.Values.Select(c => c.Code).ToList();
 
-        // 🔹 گرفتن مشخصات ارز (case-insensitive)
+        // Look up a currency, case-insensitively.
         public static CurrencyInfo GetCurrencyInfo(string code) =>
             _currencies.TryGetValue(code, out var info) ? info : null;
 
-        // 🔹 بررسی معتبر بودن ارز (case-insensitive)
+        // Whether a currency code is valid, case-insensitively.
         public static bool IsValidCurrency(string code) =>
             _currencies.ContainsKey(code);
 
         /// <summary>
-        /// گرد کردن یک مبلغ به دقت واقعی همان دارایی (مثلاً تومان: بدون اعشار، آبشده: دو رقم).
+        /// Rounds an amount to that asset's real precision — toman has no decimals, melted gold has two.
         ///
-        /// این متد باید در هر جایی که مبلغی محاسبه می‌شود صدا زده شود — به‌ویژه
-        /// «مقدار × قیمت» — چون نتیجهٔ آن ضرب تا ۱۸ رقم اعشار پیش می‌رود در حالی که
-        /// ستون‌های دیتابیس decimal(28,8) هستند. اگر مقدارِ قفل‌شده و مقدارِ تسویه‌شده
-        /// با دقت‌های متفاوت محاسبه شوند، پس از پایان سفارش یک باقی‌ماندهٔ کوچک در
-        /// LockedBalance جا می‌ماند که در سیستم مالی یک نشتی تدریجی است.
+        /// Call this wherever an amount is computed — above all for quantity x price, whose result
+        /// runs to 18 decimal places while the database columns are decimal(28,8). If the locked
+        /// amount and the settled amount are computed at different precisions, a small residue is
+        /// left in LockedBalance once the order ends, which in a financial system is a slow leak.
         ///
-        /// از MidpointRounding.ToEven استفاده نمی‌کنیم؛ AwayFromZero رفتار مورد انتظار
-        /// در محاسبات مالی است.
+        /// MidpointRounding.ToEven is not used; AwayFromZero is the expected behaviour in financial
+        /// arithmetic.
         /// </summary>
         public static decimal RoundToCurrencyPrecision(decimal amount, string assetCode)
         {
             var info = GetCurrencyInfo(assetCode);
-            // اگر دارایی ناشناخته بود، مقدار را دست‌نخورده برمی‌گردانیم تا رفتار موجود نشکند.
+            // An unknown asset returns the amount untouched, so existing behaviour is not broken.
             if (info is null)
                 return amount;
 
@@ -235,10 +234,10 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// گرد کردن مبلغ به دقت دارایی، همیشه <b>رو به بالا</b>.
+        /// Rounds an amount to the asset's precision, always <b>up</b>.
         ///
-        /// برای مبلغی استفاده می‌شود که به‌عنوان وثیقه قفل می‌شود. با گرد کردن به بالا،
-        /// مقدار قفل‌شده هرگز کمتر از ارزش واقعی سفارش نیست.
+        /// Used for the amount locked as collateral. Rounding up means the locked amount is never
+        /// less than the order's real value.
         /// </summary>
         public static decimal CeilingToCurrencyPrecision(decimal amount, string assetCode)
         {
@@ -250,22 +249,23 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// گرد کردن مبلغ به دقت دارایی، همیشه <b>رو به پایین</b>.
+        /// Rounds an amount to the asset's precision, always <b>down</b>.
         ///
-        /// برای مبلغی استفاده می‌شود که در هر معامله از وثیقه مصرف می‌گردد.
+        /// Used for the amount each trade consumes from the collateral.
         ///
-        /// چرا جهت‌ها عمداً مخالف هم انتخاب شده‌اند (issue #52): مبلغ قفل یک بار برای کل
-        /// سفارش حساب می‌شود و مصرف در هر fill جداگانه. اگر هر دو با AwayFromZero گرد
-        /// شوند، مجموعِ مصرف‌ها می‌تواند از مقدار قفل‌شده بیشتر شود و گاردِ «وثیقهٔ کافی
-        /// نیست» یک معاملهٔ کاملاً معتبر را رد کند.
+        /// Why the directions are deliberately opposite (issue #52): the lock is computed once for
+        /// the whole order while consumption is computed per fill. If both rounded AwayFromZero, the
+        /// consumptions could sum to more than the locked amount and the "insufficient collateral"
+        /// guard would refuse a perfectly valid trade.
         ///
-        /// با «قفل رو به بالا، مصرف رو به پایین» این نابرابری همیشه برقرار است:
+        /// With "lock up, consume down", this inequality always holds:
         ///
-        ///     Σ Floor(qᵢ × pᵢ) ≤ Σ qᵢ×pᵢ ≤ Σ qᵢ × p_سقف ≤ Q × p_سقف ≤ Ceiling(Q × p_سقف)
+        ///     sum Floor(qi x pi) <= sum qi x pi <= sum qi x p_max <= Q x p_max <= Ceiling(Q x p_max)
         ///
-        /// یعنی «مجموع مصرف ≤ مقدار قفل‌شده» یک تضمین ریاضی است، نه یک احتمال — و به
-        /// یکسان بودن قیمت fillها هم وابسته نیست، چون خریدار هرگز بیش از قیمت سقف
-        /// سفارش خودش پرداخت نمی‌کند. اختلاف باقی‌مانده هنگام تکمیل یا لغو آزاد می‌شود.
+        /// So "total consumed <= amount locked" is a mathematical guarantee rather than a
+        /// probability, and it does not depend on the fills sharing a price, since a buyer never pays
+        /// more than their own order's limit. The leftover difference is released on completion or
+        /// cancellation.
         /// </summary>
         public static decimal FloorToCurrencyPrecision(decimal amount, string assetCode)
         {
@@ -284,45 +284,45 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// دقت ذخیره‌سازی قیمت سفارش. ستون Orders.Price از نوع decimal(18,2) است.
+        /// The storage precision of an order price. The Orders.Price column is decimal(18,2).
         /// </summary>
         public const int OrderPriceDecimalPlaces = 2;
 
         /// <summary>
-        /// گرد کردن قیمت به همان دقتی که ستون دیتابیس می‌تواند نگه دارد.
+        /// Rounds a price to the precision the database column can actually hold.
         ///
-        /// چرا لازم است: قیمت مثقال بر ۴٫۳۳۱۸ تقسیم می‌شود و نتیجه تا ۲۸ رقم اعشار ادامه
-        /// دارد (مثلاً ۷۹٬۰۰۰٬۰۰۰ ÷ ۴٫۳۳۱۸ = ۱۸۲۳۷۲۲۲٫۴۰۱۷۷۲۹…). مبلغِ قفل‌شده از همان
-        /// مقدارِ کاملِ حافظه حساب می‌شد، ولی خودِ قیمت هنگام ذخیره در ستون به دو رقم
-        /// اعشار گرد می‌شد و تسویه بعداً همان مقدار گردشده را از دیتابیس می‌خواند. دو
-        /// طرفِ یک تساوی با دو قیمتِ متفاوت حساب می‌شدند و اختلافش تا ابد در
-        /// LockedBalance می‌ماند (issue #52).
+        /// Why it is needed: a mesghal price is divided by 4.3318 and the result runs to 28 decimal
+        /// places — 79,000,000 / 4.3318 = 18237222.4017729..., for example. The locked amount was
+        /// computed from that full in-memory value, while the price itself was rounded to two
+        /// decimals on the way into the column, and settlement later read the rounded value back.
+        /// Two sides of one equation were computed from two different prices, and the difference
+        /// stayed in LockedBalance forever (issue #52).
         ///
-        /// با گرد کردن در ورودی، قفل و تسویه هر دو از یک عدد استفاده می‌کنند و
-        /// «مبلغ قفل‌شده» از روی خودِ سفارش ذخیره‌شده قابل بازمحاسبه می‌شود.
+        /// Rounding on the way in means the lock and settlement use the same number, and the locked
+        /// amount becomes recomputable from the stored order alone.
         ///
-        /// عمداً به PriceDecimalPlaces جفت معاملاتی تکیه نمی‌کنیم: برای MAUA/IRT مقدار
-        /// آن صفر است در حالی که ستون دو رقم اعشار نگه می‌دارد. گرد کردن به صفر، دقت
-        /// قیمت را از ۰٫۰۱ به ۱ تومان بر گرم تغییر می‌داد که یک تصمیم کسب‌وکاری است نه
-        /// یک رفع باگ. مرجع اینجا ستون است، چون همان چیزی است که واقعاً محدود می‌کند.
+        /// Deliberately not keyed off the pair's PriceDecimalPlaces: for MAUA/IRT that is zero while
+        /// the column holds two decimals. Rounding to zero would change price precision from 0.01 to
+        /// 1 toman per gram, which is a business decision rather than a bug fix. The column is the
+        /// authority here, because it is what actually constrains the value.
         /// </summary>
         public static decimal RoundOrderPrice(decimal price) =>
             Math.Round(price, OrderPriceDecimalPlaces, MidpointRounding.AwayFromZero);
 
-        /// <summary>گرفتن مشخصات جفت معاملاتی (case-insensitive). اگر پیدا نشود null.</summary>
+        /// <summary>Looks up a trading pair, case-insensitively. Returns null if there is no match.</summary>
         public static TradingPairInfo? GetTradingPairInfo(string symbol) =>
             symbol is not null && _pairs.TryGetValue(symbol, out var info) ? info : null;
 
         /// <summary>
-        /// نام فارسی ارز برای نمایش به کاربر. اگر ارز ناشناس باشد خود کد برگردانده می‌شود.
+        /// The currency's Persian display name. Unknown currencies fall back to the code itself.
         /// </summary>
         public static string GetPersianName(string code) =>
             GetCurrencyInfo(code)?.PersianName ?? code;
 
         /// <summary>
-        /// ورودی کاربر را به کد ارز تبدیل می‌کند. هم کد لاتین («IRT») و هم نام فارسی
-        /// («تومان») پذیرفته می‌شود، تا مدیر مجبور نباشد کد انگلیسی به خاطر بسپارد.
-        /// اگر ورودی به هیچ ارزی نخورد، null برمی‌گردد.
+        /// Converts user input into a currency code. Accepts both the Latin code ("IRT") and the
+        /// Persian name ("تومان"), so an admin need not memorise the English code. Returns null if
+        /// the input matches no currency.
         /// </summary>
         public static string? ResolveCurrencyCode(string? input)
         {
@@ -331,20 +331,20 @@ namespace TallaEgg.Core
 
             var trimmed = input.Trim();
 
-            // ابتدا تطبیق با کد ارز
+            // First, match against the currency code.
             if (_currencies.TryGetValue(trimmed, out var byCode))
                 return byCode.Code;
 
-            // سپس تطبیق با نام فارسی کامل
+            // Then against the full Persian name.
             var byName = _currencies.Values.FirstOrDefault(c =>
                 string.Equals(c.PersianName, trimmed, StringComparison.OrdinalIgnoreCase));
 
             if (byName is not null)
                 return byName.Code;
 
-            // در نهایت کلیدواژهٔ کوتاه («سکه»، «بیت») — همان فهرستی که دستورهای مظنه از آن
-            // استفاده می‌کنند (TradingPairInfo.Aliases)، تا مدیر مجبور نباشد برای هر دستور
-            // اسم متفاوتی به خاطر بسپارد.
+            // Finally the short keyword ("سکه", "بیت") — the same list the quote commands use,
+            // TradingPairInfo.Aliases, so an admin does not have to remember a different name per
+            // command.
             var bySymbolAlias = ResolveSymbolByAlias(trimmed);
             if (bySymbolAlias is not null)
                 return GetTradingPairInfo(bySymbolAlias)?.BaseAsset;
@@ -353,12 +353,12 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// فهرست نام‌های فارسی ارزهای قابل‌تایپ برای نمایش در پیام خطا (به‌جای کدهای لاتین).
+        /// The typeable Persian currency names, for use in an error message instead of Latin codes.
         ///
-        /// نسخهٔ CREDIT_ هر دارایی عمداً حذف شده: دستورهای «ش»/«د» خودشان همیشه پیشوند
-        /// CREDIT_ را اضافه می‌کنند، پس اگر ادمین «اعتبار آبشده» را مستقیم تایپ کند نتیجه یک
-        /// کد دوبار-پیشونددار بی‌معنا («CREDIT_CREDIT_MAUA») می‌شود — این فهرست برای جلوگیری
-        /// از همان تایپ است، نه تشویق آن.
+        /// Each asset's CREDIT_ variant is deliberately excluded: the top-up and withdraw commands
+        /// always add the CREDIT_ prefix themselves, so an admin typing the credit name directly
+        /// would produce a meaningless double-prefixed code ("CREDIT_CREDIT_MAUA"). This list exists
+        /// to prevent that input, not to invite it.
         /// </summary>
         public static string GetPersianNamesList() =>
             string.Join("، ", _currencies.Values
@@ -366,9 +366,8 @@ namespace TallaEgg.Core
                 .Select(c => c.PersianName));
 
         /// <summary>
-        /// نام فارسی جفت معاملاتی برای نمایش به کاربر (مثل «آبشده/تومان»).
-        /// اگر جفت ناشناس باشد، از نام فارسی دو طرف ساخته می‌شود تا هیچ‌وقت
-        /// نماد لاتین در متن فارسی نمایش داده نشود.
+        /// The trading pair's Persian display name. An unknown pair is composed from both sides'
+        /// Persian names, so a Latin symbol is never shown inside Persian text.
         /// </summary>
         public static string GetPersianSymbolName(string symbol)
         {
@@ -384,12 +383,11 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// یک نماد را از روی کلیدواژهٔ فارسی دستورهای ادمین («سکه»، «بیت») برمی‌گرداند —
-        /// از <see cref="TradingPairInfo.Aliases"/> هر نماد می‌خواند، پس اضافه‌کردن یک
-        /// نماد جدید با کلیدواژهٔ خودش نیازی به تغییر این متد ندارد. کلیدواژهٔ خالی یعنی
-        /// آبشده — عادت ادمین از قبل از وجود این نمادهای دیگر. کلیدواژه‌ای که به هیچ
-        /// نمادی نمی‌خورد null برمی‌گرداند، تا فراخوان بتواند «کلیدواژه‌ای داده نشده» را
-        /// از «کلیدواژهٔ ناشناخته» تشخیص دهد.
+        /// Resolves a symbol from the Persian keyword used in admin commands ("سکه", "بیت"), reading
+        /// each symbol's <see cref="TradingPairInfo.Aliases"/>, so adding a new symbol with its own
+        /// keyword needs no change here. An empty keyword means melted gold — the admin habit from
+        /// before these other symbols existed. A keyword matching no symbol returns null, so the
+        /// caller can tell "no keyword given" apart from "unknown keyword".
         /// </summary>
         public static string? ResolveSymbolByAlias(string? keyword)
         {
@@ -418,43 +416,43 @@ namespace TallaEgg.Core
 
     public class TradingPairInfo
     {
-        /// <summary>نماد جفت معاملاتی (مثل BTC/USDT)</summary>
+        /// <summary>Pair symbol, for example MAUA/IRT.</summary>
         public string Symbol { get; set; } = string.Empty;
 
-        /// <summary>دارایی پایه (مثل BTC)</summary>
+        /// <summary>Base asset, for example MAUA.</summary>
         public string BaseAsset { get; set; } = string.Empty;
 
-        /// <summary>دارایی نقل‌قول (مثل USDT)</summary>
+        /// <summary>Quote asset, for example IRT.</summary>
         public string QuoteAsset { get; set; } = string.Empty;
 
-        /// <summary>نام فارسی</summary>
+        /// <summary>Persian display name.</summary>
         public string PersianName { get; set; } = string.Empty;
 
-        /// <summary>حداقل مقدار قابل معامله</summary>
+        /// <summary>Minimum tradable quantity.</summary>
         public decimal MinQuantity { get; set; }
 
-        /// <summary>حداکثر مقدار قابل معامله</summary>
+        /// <summary>Maximum tradable quantity.</summary>
         public decimal MaxQuantity { get; set; }
 
-        /// <summary>تعداد اعشار قیمت</summary>
+        /// <summary>Price decimal places.</summary>
         public int PriceDecimalPlaces { get; set; }
 
-        /// <summary>تعداد اعشار مقدار</summary>
+        /// <summary>Quantity decimal places.</summary>
         public int QuantityDecimalPlaces { get; set; }
 
-        /// <summary>حداقل ارزش معامله</summary>
+        /// <summary>Minimum trade value.</summary>
         public decimal MinNotional { get; set; }
 
-        /// <summary>نام فارسی دارایی پایه به‌تنهایی (مثل «آبشده»)</summary>
+        /// <summary>Persian name of the base asset on its own, for example "آبشده".</summary>
         public string BaseAssetPersianName { get; set; } = string.Empty;
 
-        /// <summary>واحد نمایش دارایی پایه (مثل «گرم» یا «سکه»)</summary>
+        /// <summary>Display unit for the base asset, for example "گرم" or "سکه".</summary>
         public string BaseUnit { get; set; } = string.Empty;
 
-        /// <summary>تعداد اعشار دارایی پایه، برای گرد کردن مبالغ (CurrenciesConstant.RoundToCurrencyPrecision)</summary>
+        /// <summary>Base-asset decimal places, used when rounding amounts via CurrenciesConstant.RoundToCurrencyPrecision.</summary>
         public int BaseDecimalPlaces { get; set; }
 
-        /// <summary>کلیدواژه‌های فارسی که دستورهای ادمین در بات برای این نماد می‌پذیرند (مثل «سکه»)</summary>
+        /// <summary>Persian keywords the bot's admin commands accept for this symbol, for example "سکه".</summary>
         public List<string> Aliases { get; set; } = new();
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/ApiResponse.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/ApiResponse.cs
@@ -30,20 +30,20 @@ namespace TallaEgg.Core.DTOs
         }
 
         /// <summary>
-        /// ایجاد پاسخ برای موارد پیدا نشدن (404 Not Found)
+        /// Builds a 404 Not Found response.
         /// </summary>
-        /// <param name="message">پیام توضیحی</param>
-        /// <returns>پاسخ API با وضعیت عدم موفقیت</returns>
+        /// <param name="message">Explanatory message.</param>
+        /// <returns>An unsuccessful API response.</returns>
         public static ApiResponse<T> NotFound(string message = "آیتم مورد نظر یافت نشد")
         {
             return new ApiResponse<T>(false, message, default);
         }
 
         /// <summary>
-        /// ایجاد پاسخ برای خطاهای سرور (500 Internal Server Error)
+        /// Builds a 500 Internal Server Error response.
         /// </summary>
-        /// <param name="message">پیام خطا</param>
-        /// <returns>پاسخ API با وضعیت عدم موفقیت</returns>
+        /// <param name="message">Error message.</param>
+        /// <returns>An unsuccessful API response.</returns>
         public static ApiResponse<T> Error(string message = "خطای داخلی سرور")
         {
             return new ApiResponse<T>(false, message, default);

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -27,12 +27,12 @@ namespace TallaEgg.Core.DTOs.Order
     }
     /// <summary>
     /// Unified order creation request for all order types
-    /// درخواست واحد ایجاد سفارش برای تمام انواع سفارشات
+    /// A single order-creation request covering every order type.
     /// </summary>
     public class OrderDto
     {
         /// <summary>
-        /// شناسه کاربر
+        /// User id.
         /// </summary>
         [Required(ErrorMessage = "شناسه کاربر الزامی است")]
         public Guid Id { get; set; }
@@ -40,7 +40,7 @@ namespace TallaEgg.Core.DTOs.Order
         [JsonPropertyName("symbol")]
         public string Asset { get; set; } = "";
         /// <summary>
-        /// نماد دارایی (مثل BTC، ETH)
+        /// Asset symbol.
         /// alias
         /// </summary>
         [Required(ErrorMessage = "نماد دارایی الزامی است")]
@@ -53,7 +53,7 @@ namespace TallaEgg.Core.DTOs.Order
         }
 
         /// <summary>
-        /// مقدار سفارش
+        /// Order quantity.
         /// alias
         /// </summary>
         [Required(ErrorMessage = "مقدار سفارش الزامی است")]
@@ -67,7 +67,7 @@ namespace TallaEgg.Core.DTOs.Order
         [JsonPropertyName("quantity")]
         public decimal Amount { get; set; }
         /// <summary>
-        /// قیمت (برای سفارشات محدود - اختیاری برای سفارشات بازار)
+        /// Price. Required for limit orders, optional for market orders.
         /// </summary>
         public decimal Price { get; set; }
         public Guid UserId { get; set; }
@@ -89,11 +89,11 @@ namespace TallaEgg.Core.DTOs.Order
         public OrderType OrderType { get; set; }
         public string Symbol { get; set; } = string.Empty;
         /// <summary>
-        /// بهترین قیمت خرید (بالاترین قیمت پیشنهادی خریداران)
+        /// Best bid: the highest price buyers are offering.
         /// </summary>
         public decimal? BestBidPrice { get; set; }    // بهترین قیمت خرید (بالاترین قیمت پیشنهادی خریداران)
         /// <summary>
-        /// بهترین قیمت فروش (پایین‌ترین قیمت پیشنهادی فروشندگان)
+        /// Best ask: the lowest price sellers are offering.
         /// </summary>
         public decimal? BestAskPrice { get; set; }    // بهترین قیمت فروش (پایین‌ترین قیمت پیشنهادی فروشندگان)
         public decimal? BidVolume { get; set; }       // حجم موجود در بهترین قیمت خرید
@@ -104,19 +104,19 @@ namespace TallaEgg.Core.DTOs.Order
 
     /// <summary>
     /// Response DTO for canceling active orders
-    /// DTO پاسخ برای کنسل کردن سفارشات فعال
+    /// Response DTO for cancelling active orders.
     /// </summary>
     public class CancelActiveOrdersResponseDto
     {
         /// <summary>
         /// Number of orders that were cancelled
-        /// تعداد سفارشاتی که کنسل شدند
+        /// How many orders were cancelled.
         /// </summary>
         public int CancelledCount { get; set; }
     }
 
     /// <summary>
-    /// DTO برای نمایش تاریخچه معاملات کاربر
+    /// DTO for displaying a user's trade history.
     /// </summary>
     public class TradeHistoryDto
     {
@@ -138,95 +138,95 @@ namespace TallaEgg.Core.DTOs.Order
     }
 
     /// <summary>
-    /// DTO برای اطلاعات تطبیق معامله
+    /// DTO carrying the details of a matched trade.
     /// </summary>
     /// <remarks>
-    /// این DTO شامل تمام اطلاعات لازم برای اطلاع‌رسانی موفقیت‌آمیز تطبیق سفارشات است
+    /// Holds everything needed to notify both sides that their orders matched.
     /// </remarks>
     public class TradeMatchNotificationDto
     {
         /// <summary>
-        /// شناسه یکتای معامله
+        /// Trade id.
         /// </summary>
         public Guid TradeId { get; set; }
 
         /// <summary>
-        /// شناسه سفارش خریدار
+        /// Buy order id.
         /// </summary>
         public Guid BuyOrderId { get; set; }
 
         /// <summary>
-        /// شناسه کاربر خریدار
+        /// User id. خریدار
         /// </summary>
         public Guid BuyerUserId { get; set; }
 
         /// <summary>
-        /// شناسه سفارش فروشنده
+        /// Sell order id.
         /// </summary>
         public Guid SellOrderId { get; set; }
 
         /// <summary>
-        /// شناسه کاربر فروشنده
+        /// User id. فروشنده
         /// </summary>
         public Guid SellerUserId { get; set; }
 
         /// <summary>
-        /// نماد دارایی (مثل BTC/USDT، MAUA/IRT)
+        /// Trading symbol, for example MAUA/IRT.
         /// </summary>
         public string Asset { get; set; } = string.Empty;
 
         /// <summary>
-        /// قیمت تطبیق معامله
+        /// The price the trade matched at.
         /// </summary>
         public decimal Price { get; set; }
 
         /// <summary>
-        /// حجم تطبیق یافته در این معامله
+        /// The quantity matched in this trade.
         /// </summary>
         public decimal MatchedVolume { get; set; }
 
         /// <summary>
-        /// تاریخ و زمان انجام معامله
+        /// When the trade executed.
         /// </summary>
         public DateTime TradeDateTime { get; set; }
 
         /// <summary>
-        /// درصد تکمیل شده سفارش خریدار
+        /// Percentage of the buy order filled.
         /// </summary>
         public decimal BuyOrderCompletionPercentage { get; set; }
 
         /// <summary>
-        /// درصد باقی‌مانده سفارش خریدار
+        /// Percentage of the buy order remaining.
         /// </summary>
         public decimal BuyOrderRemainingPercentage { get; set; }
 
         /// <summary>
-        /// درصد تکمیل شده سفارش فروشنده
+        /// Percentage of the sell order filled.
         /// </summary>
         public decimal SellOrderCompletionPercentage { get; set; }
 
         /// <summary>
-        /// درصد باقی‌مانده سفارش فروشنده
+        /// Percentage of the sell order remaining.
         /// </summary>
         public decimal SellOrderRemainingPercentage { get; set; }
 
         /// <summary>
-        /// حجم کل سفارش خریدار
+        /// Total quantity of the buy order.
         /// </summary>
         public decimal BuyOrderTotalVolume { get; set; }
 
         /// <summary>
-        /// حجم باقی‌مانده سفارش خریدار
+        /// Remaining quantity of the buy order.
         /// </summary>
         public decimal BuyOrderRemainingVolume { get; set; }
 
         /// <summary>
-        /// حجم کل سفارش فروشنده
+        /// Total quantity of the sell order.
         /// </summary>
         public decimal SellOrderTotalVolume { get; set; }
 
         /// <summary>
-        /// حجم باقی‌مانده سفارش فروشنده
+        /// Remaining quantity of the sell order.
         /// </summary>
         public decimal SellOrderRemainingVolume { get; set; }
     }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/QuoteDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/QuoteDto.cs
@@ -1,28 +1,28 @@
-using TallaEgg.Core.Enums.Order;
+﻿using TallaEgg.Core.Enums.Order;
 
 namespace TallaEgg.Core.DTOs.Order
 {
-    // نگاشت از موجودیت Quote عمداً اینجا نیست: این DTO بین سرویس‌ها مشترک است و
-    // TallaEgg.Core نباید به مدل دامنهٔ سرویس سفارش‌ها وابسته شود. نگاشت در همان لایه‌ای
-    // انجام می‌شود که هر دو را می‌شناسد.
+    // Mapping from the Quote entity is deliberately not here: this DTO is shared between services
+    // and TallaEgg.Core must not depend on the Orders service's domain model. The mapping lives in
+    // the layer that knows both.
 
     /// <summary>
-    /// مظنهٔ منتشرشدهٔ ادمین، برای انتقال بین سرویس‌ها و ربات.
+    /// The admin's published quote, for transport between the services and the bot.
     ///
-    /// قیمت‌ها بر حسب واحد پایه‌اند (تومان بر گرم). تبدیل به مثقال فقط در لایهٔ ربات و
-    /// هنگام نمایش انجام می‌شود — همان‌جا که کاربر عدد را وارد و مشاهده می‌کند. اگر تبدیل
-    /// در چند لایه پخش شود، همان ابهامی ساخته می‌شود که پیش‌تر باعث شد معلوم نباشد یک عدد
-    /// «بر گرم» است یا «بر مثقال».
+    /// Prices are per base unit, toman per gram. Conversion to mesghal happens only in the bot layer
+    /// at display time, where the user enters and reads the number. Spreading the conversion across
+    /// layers recreates the ambiguity that previously made it unclear whether a figure was per gram
+    /// or per mesghal.
     /// </summary>
     public class QuoteDto
     {
         public Guid Id { get; set; }
         public string Symbol { get; set; } = string.Empty;
 
-        /// <summary>قیمتی که ادمین می‌خرد — مشتری با این قیمت می‌فروشد.</summary>
+        /// <summary>The price the admin buys at — the price at which the customer sells.</summary>
         public decimal BuyPrice { get; set; }
 
-        /// <summary>قیمتی که ادمین می‌فروشد — مشتری با این قیمت می‌خرد.</summary>
+        /// <summary>The price the admin sells at — the price at which the customer buys.</summary>
         public decimal SellPrice { get; set; }
 
         public DateTime PublishedAt { get; set; }
@@ -37,7 +37,7 @@ namespace TallaEgg.Core.DTOs.Order
         public DateTime? DeactivatedAt { get; set; }
     }
 
-    /// <summary>درخواست انتشار مظنه توسط ادمین. قیمت‌ها بر حسب واحد پایه (تومان بر گرم).</summary>
+    /// <summary>An admin's request to publish a quote. Prices are per base unit, toman per gram.</summary>
     public record PublishQuoteRequest(
         string Symbol,
         decimal BuyPrice,
@@ -45,10 +45,11 @@ namespace TallaEgg.Core.DTOs.Order
         Guid PublishedByUserId);
 
     /// <summary>
-    /// درخواست پذیرش مظنه توسط مشتری.
+    /// A customer's request to fill a quote.
     ///
-    /// عمداً قیمت ندارد: قیمت از مظنهٔ منتشرشده خوانده می‌شود. اگر مشتری قیمت می‌فرستاد،
-    /// باید بررسی می‌شد که با مظنه بخواند — یک قاعدهٔ اضافی که راهی برای اشتباه باز می‌کرد.
+    /// Deliberately carries no price: the price is read from the published quote. If the customer
+    /// sent one, it would have to be validated against the quote — an extra rule that opens a way to
+    /// get it wrong.
     /// </summary>
     public record AcceptQuoteRequest(
         Guid UserId,

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/TradeDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/TradeDto.cs
@@ -8,7 +8,7 @@ namespace TallaEgg.Core.DTOs.Order
 {
 
     /// <summary>
-    /// DTO معامله برای پاسخ
+    /// Trade DTO used in responses.
     /// </summary>
     public class TradeDto
     {

--- a/src/TallaEgg/TallaEgg.Core/Enums/Order/MarketMode.cs
+++ b/src/TallaEgg/TallaEgg.Core/Enums/Order/MarketMode.cs
@@ -1,27 +1,27 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace TallaEgg.Core.Enums.Order
 {
     /// <summary>
-    /// نحوهٔ کارکرد بازار برای یک نماد.
+    /// How the market operates for a symbol.
     ///
-    /// هر دو حالت به یک <c>Trade</c> ختم می‌شوند و از یک مسیر تسویه عبور می‌کنند، پس
-    /// می‌توانند کنار هم وجود داشته باشند: یک نماد در حالت Dealer و نماد دیگر در حالت
-    /// OrderBook. تاریخچه و گزارش‌ها برای هر دو یکسان‌اند چون داده‌شان یکی است.
+    /// Both modes end in the same <c>Trade</c> and go through the same settlement path, so they can
+    /// coexist: one symbol in Dealer mode and another in OrderBook mode. History and reporting are
+    /// identical for both, because the underlying data is the same.
     /// </summary>
     public enum MarketMode
     {
         /// <summary>
-        /// فقط ادمین مظنه می‌دهد و مشتری‌ها روی همان مظنه معامله می‌کنند؛ مشتری با مشتری
-        /// معامله نمی‌کند. مدل فعلی کسب‌وکار: طلافروش قیمت می‌دهد و مشتریانش با او معامله
-        /// می‌کنند.
+        /// Only the admin quotes, and customers trade against that quote; customers never trade with
+        /// each other. This is the current business model: the gold shop names a price and its
+        /// customers deal with the shop.
         /// </summary>
         [Description("مظنه‌ای")]
         Dealer = 0,
 
         /// <summary>
-        /// دفتر سفارش نظیربه‌نظیر: مشتری‌ها سفارش می‌گذارند و با یکدیگر تطبیق می‌خورند.
-        /// وقتی نقدینگی واقعی وجود داشته باشد این حالت فعال می‌شود.
+        /// A peer-to-peer order book: customers place orders and match against each other. This mode
+        /// becomes useful once there is real liquidity.
         /// </summary>
         [Description("دفتر سفارش")]
         OrderBook = 1

--- a/src/TallaEgg/TallaEgg.Core/Enums/Order/OrderRole.cs
+++ b/src/TallaEgg/TallaEgg.Core/Enums/Order/OrderRole.cs
@@ -3,27 +3,27 @@
 namespace TallaEgg.Core.Enums.Order
 {
     /// <summary>
-    /// نقش سفارش در بازار
+    /// The order's role in the market.
     /// Order Liquidity Role
     /// </summary>
     public enum OrderRole
     {
         /// <summary>
-        /// سفارش نقدینگی فراهم می‌کند (در Order Book منتظر)
+        /// The order provides liquidity: it rests in the order book.
         /// Liquidity Provider
         /// </summary>
         [Description("تامین‌کننده نقدینگی")]
         Maker = 0,
 
         /// <summary>
-        /// سفارش نقدینگی مصرف می‌کند (فوری اجرا شد)
+        /// The order consumes liquidity: it executed immediately.
         /// Liquidity Consumer
         /// </summary>
         [Description("مصرف‌کننده نقدینگی")]
         Taker = 1,
 
         /// <summary>
-        /// سفارش هم نقدینگی مصرف و هم فراهم کرد (ترکیبی)
+        /// The order both consumed and provided liquidity.
         /// </summary>
         [Description("ترکیبی")]
         Mixed = 2

--- a/src/TallaEgg/TallaEgg.Core/Enums/Order/TradingType.cs
+++ b/src/TallaEgg/TallaEgg.Core/Enums/Order/TradingType.cs
@@ -1,9 +1,9 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace TallaEgg.Core.Enums.Order
 {
     /// <summary>
-    /// بازاری که سفارش در آن ثبت می‌شود.
+    /// The market an order is placed in.
     ///
     /// فعلاً فقط نقدی. مقدار Futures حذف شد چون هرگز ست نمی‌شد ولی موتور تطبیق هم آن را
     /// نادیده می‌گرفت: یک سفارش آتی بی‌صدا با سفارش نقدی تطبیق می‌خورد. یک مقدار enum که

--- a/src/TallaEgg/TallaEgg.Core/Enums/User/UserRole.cs
+++ b/src/TallaEgg/TallaEgg.Core/Enums/User/UserRole.cs
@@ -7,7 +7,7 @@
         Admin = 2,          // مدیر
         SuperAdmin = 3,      // مدیر ارشد
         /// <summary>
-        /// با رگولار یوزر چه فرقی دارد؟؟؟؟
+        /// TODO: unclear how this differs from a regular user.
         /// </summary>
         User
     }

--- a/src/TallaEgg/TallaEgg.Core/Enums/Wallet/WalletType.cs
+++ b/src/TallaEgg/TallaEgg.Core/Enums/Wallet/WalletType.cs
@@ -1,74 +1,63 @@
-namespace TallaEgg.Core.Enums.Wallet
+﻿namespace TallaEgg.Core.Enums.Wallet
 {
     /// <summary>
-    /// انواع کیف پول در سیستم
+    /// The wallet types the system recognises.
     /// </summary>
     public enum WalletType
     {
         /// <summary>
-        /// کیف پول نقدی - برای معاملات فوری
-        /// موجودی قابل برداشت فوری
+        /// Spot wallet, for immediate trading. Its balance can be withdrawn straight away.
         /// </summary>
         Spot = 1,
 
         /// <summary>
-        /// کیف پول اعتباری - اعتبار اعطایی از طرف صرافی
-        /// موجودی قابل استفاده برای معامله اما غیرقابل برداشت
-        /// بازپرداخت از طریق معاملات یا واریز نقدی
+        /// Credit wallet: credit extended by the exchange. Usable for trading but not withdrawable,
+        /// and repaid through trades or a cash deposit.
         /// </summary>
         Credit = 2,
 
         /// <summary>
-        /// کیف پول مارجین - برای معاملات اهرمی
-        /// امکان معامله با وثیقه و استفاده از اعتبار
+        /// Margin wallet, for leveraged trading against collateral and credit.
         /// </summary>
         Margin = 3,
 
         /// <summary>
-        /// کیف پول آتی - برای قراردادهای آتی
-        /// معاملات با تاریخ سررسید
+        /// Futures wallet, for dated contracts.
         /// </summary>
         Futures = 4,
 
         /// <summary>
-        /// کیف پول سپرده‌گذاری - برای کسب درآمد
-        /// موجودی قفل شده با بازده ثابت
+        /// Savings wallet: balance locked at a fixed return.
         /// </summary>
         Savings = 5,
 
         /// <summary>
-        /// کیف پول استیکینگ - برای شبکه‌های proof-of-stake
-        /// قفل موجودی برای دریافت پاداش شبکه
+        /// Staking wallet for proof-of-stake networks: balance locked to earn network rewards.
         /// </summary>
         Staking = 6,
 
         /// <summary>
-        /// کیف پول P2P - برای معاملات مستقیم کاربر به کاربر
-        /// اسکرو موقت برای معاملات امن
+        /// P2P wallet for direct user-to-user trading, acting as temporary escrow.
         /// </summary>
         P2P = 7,
 
         /// <summary>
-        /// کیف پول DeFi - برای پروتکل‌های غیرمتمرکز
-        /// اتصال به پروتکل‌های خارجی
+        /// DeFi wallet, connecting to external decentralised protocols.
         /// </summary>
         DeFi = 8,
 
         /// <summary>
-        /// کیف پول مسدود شده - برای موجودی‌های در حال بررسی
-        /// دسترسی محدود یا موقتاً غیرفعال
+        /// Blocked wallet, for balances under review: restricted or temporarily disabled.
         /// </summary>
         Locked = 9,
 
         /// <summary>
-        /// کیف پول پاداش - برای امتیازات و جوایز
-        /// موجودی حاصل از برنامه‌های وفاداری و ارجاع
+        /// Rewards wallet, holding balance earned from loyalty and referral programmes.
         /// </summary>
         Reward = 10,
 
         /// <summary>
-        /// کیف پول ضمانت - برای نگهداری وثیقه
-        /// موجودی قفل شده به عنوان تضمین معاملات
+        /// Guarantee wallet, holding balance locked as security for trades.
         /// </summary>
         Collateral = 11
     }

--- a/src/TallaEgg/TallaEgg.Core/Responses/Order/CreateOrderResponse.cs
+++ b/src/TallaEgg/TallaEgg.Core/Responses/Order/CreateOrderResponse.cs
@@ -1,62 +1,62 @@
-using TallaEgg.Core.DTOs.Order;
+﻿using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 
 namespace TallaEgg.Core.Responses.Order;
 
 /// <summary>
-/// پاسخ ایجاد سفارش واحد
+/// Response to a single order-creation request.
 /// </summary>
 public class CreateOrderResponse
 {
     /// <summary>
-    /// اطلاعات سفارش ایجاد شده
+    /// The created order.
     /// </summary>
     public OrderHistoryDto Order { get; set; } = null!;
 
     /// <summary>
-    /// معاملات اجرا شده (در صورت تطبیق فوری)
+    /// Trades executed, if the order matched immediately.
     /// </summary>
     public List<TradeDto> ExecutedTrades { get; set; } = new();
 
     /// <summary>
-    /// نقش سفارش: Maker، Taker یا Mixed
+    /// The order's role: maker, taker or mixed.
     /// </summary>
     public OrderRole Role { get; set; }
 
     /// <summary>
-    /// پیام توضیحی برای کاربر
+    /// A message for the user.
     /// </summary>
     public string Message { get; set; } = string.Empty;
 
     /// <summary>
-    /// آیا سفارش فوری اجرا شد؟
+    /// Whether the order executed immediately.
     /// </summary>
     public bool IsExecutedImmediately => ExecutedTrades.Any();
 
     /// <summary>
-    /// مقدار اجرا شده
+    /// Quantity executed.
     /// </summary>
     public decimal ExecutedQuantity => ExecutedTrades.Sum(t => t.Quantity);
 
     /// <summary>
-    /// مقدار باقی‌مانده در Order Book
+    /// Quantity still resting in the order book.
     /// </summary>
     public decimal RemainingQuantity => Order.Amount - ExecutedQuantity;
 
     /// <summary>
-    /// درصد اجرا شده
+    /// Percentage executed.
     /// </summary>
     public decimal ExecutionPercentage => Order.Amount > 0 ? (ExecutedQuantity / Order.Amount) * 100 : 0;
 
     /// <summary>
-    /// متوسط قیمت اجرا شده
+    /// Average execution price.
     /// </summary>
     public decimal AverageExecutedPrice => ExecutedTrades.Any() 
         ? ExecutedTrades.Sum(t => t.Price * t.Quantity) / ExecutedTrades.Sum(t => t.Quantity) 
         : 0;
 
     /// <summary>
-    /// کل کارمزد پرداخت شده
+    /// Total fees paid.
     /// </summary>
     public decimal TotalFeesPaid => ExecutedTrades.Sum(t => t.FeeBuyer + t.FeeSeller);
 }

--- a/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
@@ -215,7 +215,6 @@ namespace TallaEgg.Core.Services
 
         //        //            using (var fileStream = File.OpenRead(filePath))
         //        //{
-        //        //	// درست ش.د
         //        //	var fileName = File.ReadAllText(filePath);
         //        //	var fileContent = new StreamContent(fileStream);
 

--- a/src/TallaEgg/TallaEgg.Core/Utilties/PersianFormat.cs
+++ b/src/TallaEgg/TallaEgg.Core/Utilties/PersianFormat.cs
@@ -1,40 +1,39 @@
 ﻿namespace TallaEgg.Core.Utilties
 {
     /// <summary>
-    /// قالب‌بندی اعداد و متن برای پیام‌های فارسی ربات.
+    /// Number and text formatting for the bot's Persian messages.
     ///
-    /// دو مسئله را حل می‌کند:
-    /// ۱. ارقام لاتین (123) در متن فارسی → به ارقام فارسی (۱۲۳) تبدیل می‌شوند تا پیام
-    ///    کاملاً فارسی باشد.
-    /// ۲. به‌هم‌ریختگی راست‌به‌چپ: وقتی یک قطعه متن چپ‌به‌راست (عدد با جداکننده،
-    ///    شماره کارت، شماره نسخه) داخل جملهٔ فارسی قرار می‌گیرد، الگوریتم دوسویهٔ
-    ///    یونیکد ترتیب نمایش را جابه‌جا می‌کند. با قرار دادن نشانگر RLM دور آن قطعه،
-    ///    نمایش تثبیت می‌شود.
+    /// It solves two problems:
+    /// 1. Latin digits (123) inside Persian text are converted to Persian digits, so the message
+    ///    reads as entirely Persian.
+    /// 2. Bidirectional reordering: when a left-to-right run — a separated number, a card number, a
+    ///    version string — sits inside a Persian sentence, the Unicode bidi algorithm reorders it
+    ///    on screen. Isolating that run pins the display order.
     /// </summary>
     public static class PersianFormat
     {
-        // این سه نویسه نامرئی‌اند و در ویرایشگر دیده نمی‌شوند. کد یونیکدشان در توضیح هر
-        // کدام نوشته شده و تست PersianDateTimeTests مقدارشان را می‌سنجد، چون خرابیِ ناشی
-        // از یک کپی‌وپیست اشتباه در متن برنامه اصلاً به چشم نمی‌آید.
-        /// <summary>نشانگر راست‌به‌چپ (Right-to-Left Mark, U+200F).</summary>
+        // These three characters are invisible in an editor. Each one's Unicode code point is given
+        // in its doc comment and PersianDateTimeTests asserts the values, because damage from a bad
+        // copy-paste in the source would otherwise be impossible to see.
+        /// <summary>Right-to-Left Mark, U+200F.</summary>
         public const string Rlm = "‏";
 
-        /// <summary>آغاز جداسازِ چپ‌به‌راست (Left-to-Right Isolate, U+2066).</summary>
+        /// <summary>Left-to-Right Isolate, U+2066.</summary>
         public const string Lri = "⁦";
 
-        /// <summary>پایان جداساز (Pop Directional Isolate, U+2069).</summary>
+        /// <summary>Pop Directional Isolate, U+2069.</summary>
         public const string Pdi = "⁩";
 
         private const char ArabicIndicZero = '۰'; // ۰ فارسی
 
-        /// <summary>جداکنندهٔ هزارگان فارسی (U+066C).</summary>
+        /// <summary>Persian thousands separator, U+066C.</summary>
         private const char PersianThousandsSeparator = '٬';
 
-        /// <summary>جداکنندهٔ اعشار فارسی (U+066B).</summary>
+        /// <summary>Persian decimal separator, U+066B.</summary>
         private const char PersianDecimalSeparator = '٫';
 
         /// <summary>
-        /// ارقام لاتین را به ارقام فارسی تبدیل می‌کند. بقیهٔ نویسه‌ها دست‌نخورده می‌مانند.
+        /// Converts Latin digits to Persian digits. Every other character is left untouched.
         /// </summary>
         public static string ToPersianDigits(string? text)
         {
@@ -52,15 +51,15 @@
         }
 
         /// <summary>
-        /// عدد را با جداکنندهٔ هزارگان فارسی و ارقام فارسی قالب‌بندی می‌کند و با نشانگر
-        /// راست‌به‌چپ محافظت می‌کند تا در متن فارسی به هم نریزد.
+        /// Formats a number with Persian thousands separators and Persian digits, isolated so it does
+        /// not reorder inside Persian text.
         /// </summary>
-        /// <param name="value">مقدار عددی</param>
-        /// <param name="decimals">تعداد رقم اعشار (پیش‌فرض صفر — مناسب مبالغ تومانی)</param>
+        /// <param name="value">The numeric value.</param>
+        /// <param name="decimals">Decimal places; zero by default, which suits toman amounts.</param>
         public static string Number(decimal value, int decimals = 0)
         {
-            // ابتدا با قالب استاندارد (جداکننده لاتین) قالب‌بندی می‌شود، سپس نویسه‌ها
-            // به معادل فارسی نگاشت می‌شوند. این کار مستقل از Culture سیستم است.
+            // Format with the standard Latin separators first, then map the characters to their
+            // Persian equivalents. This is independent of the system culture.
             var formatted = value.ToString("N" + decimals.ToString(System.Globalization.CultureInfo.InvariantCulture),
                                            System.Globalization.CultureInfo.InvariantCulture);
 
@@ -68,16 +67,16 @@
         }
 
         /// <summary>
-        /// مقدار دارایی را با تعداد اعشار مناسب همان دارایی قالب‌بندی می‌کند
-        /// (مثلاً تومان بدون اعشار، آبشده با دو رقم اعشار).
-        /// اعشار اضافی صفر حذف می‌شود تا «۸ گرم» به‌جای «۸٬۰۰ گرم» نمایش داده شود.
+        /// Formats an asset amount with that asset's own number of decimals — toman has none, melted
+        /// gold has two. Trailing zero decimals are dropped, so it reads "8 grams" rather than
+        /// "8.00 grams".
         /// </summary>
         public static string Amount(decimal value, string assetCode)
         {
             var decimals = CurrenciesConstant.GetCurrencyInfo(assetCode)?.DecimalPlaces ?? 0;
 
-            // قالب با # در بخش اعشار، صفرهای انتهایی را نمایش نمی‌دهد؛ پس «۸ گرم» و
-            // «۸٫۵ گرم» به‌جای «۸٫۰۰» و «۸٫۵۰» نمایش داده می‌شوند.
+            // A format using # in the decimal section hides trailing zeros, so the output is "8" and
+            // "8.5" rather than "8.00" and "8.50".
             var pattern = decimals > 0
                 ? "#,##0." + new string('#', decimals)
                 : "#,##0";
@@ -86,63 +85,62 @@
             return Ltr(ToPersianDigits(Localize(formatted)));
         }
 
-        /// <summary>جداکننده‌های لاتین را با معادل فارسی جایگزین می‌کند.</summary>
+        /// <summary>Replaces Latin separators with their Persian equivalents.</summary>
         private static string Localize(string formatted) =>
             formatted
                 .Replace(",", PersianThousandsSeparator.ToString())
                 .Replace(".", PersianDecimalSeparator.ToString());
 
         /// <summary>
-        /// قطعه‌متن چپ‌به‌راست (عدد، تاریخ، شماره نسخه) را در یک «جداسازِ چپ‌به‌راست»
-        /// یونیکد می‌گذارد تا داخل جملهٔ فارسی دقیقاً به همان ترتیبی که نوشته شده دیده شود.
+        /// Wraps a left-to-right run — a number, a date, a version string — in a Unicode
+        /// left-to-right isolate, so inside a Persian sentence it displays in exactly the order it
+        /// was written.
         ///
         /// <para>
-        /// <b>قبلاً با RLM در دو طرف احاطه می‌شد و این غلط بود.</b> RLM یک نویسهٔ «قویِ
-        /// راست‌به‌چپ» است، پس جهت داخل قطعه را راست‌به‌چپ می‌کرد. برای یک عدد تنها فرقی
-        /// نمی‌کرد، ولی به محض اینکه قطعه <b>دو</b> گروه عدد داشت — مثل «۱۴۰۵/۰۵/۰۹ ۱۲:۰۷» —
-        /// فاصلهٔ میانشان جهت راست‌به‌چپ می‌گرفت و الگوریتم دوسویهٔ یونیکد **جای تاریخ و ساعت
-        /// را عوض می‌کرد**: کاربر «۱۲:۰۷ ۱۴۰۵/۰۵/۰۹» می‌دید.
+        /// <b>This used to surround the run with RLM on both sides, which was wrong.</b> RLM is a
+        /// strong right-to-left character, so it made the run's interior right-to-left. For a lone
+        /// number that made no difference, but as soon as the run held <b>two</b> groups of digits —
+        /// a date and a time together — the space between them took right-to-left direction and the
+        /// bidi algorithm <b>swapped the date and the time</b>, showing the user the time first.
         /// </para>
         ///
         /// <para>
-        /// U+2066 (LRI) تا U+2069 (PDI) پاسخ استاندارد همین مسئله است: کل قطعه یک واحدِ
-        /// چپ‌به‌راستِ جدا می‌شود، ترتیب داخلش حفظ می‌شود و جهت متن اطرافش هم دست‌نخورده
-        /// می‌ماند. این رفتار در خودِ استاندارد یونیکد تعریف شده و به تنظیمات دستگاه یا
-        /// زبان سیستم وابسته نیست.
+        /// U+2066 (LRI) to U+2069 (PDI) is the standard answer to exactly this: the whole run becomes
+        /// one isolated left-to-right unit, its internal order is preserved, and the direction of the
+        /// surrounding text is unaffected. The behaviour is defined in the Unicode standard itself
+        /// and does not depend on device or system language settings.
         /// </para>
         /// </summary>
         public static string Ltr(string? text) =>
             string.IsNullOrEmpty(text) ? string.Empty : $"{Lri}{text}{Pdi}";
 
         /// <summary>
-        /// نام فارسی جفت معاملاتی برای نمایش به کاربر (مثل «آبشده/تومان»).
-        /// جلوی نمایش نماد لاتین در متن فارسی را می‌گیرد.
+        /// The trading pair's Persian display name, which keeps Latin symbols out of Persian text.
         /// </summary>
         public static string Symbol(string symbol) =>
             CurrenciesConstant.GetPersianSymbolName(symbol);
 
-        /// <summary>نام فارسی یک دارایی (مثل «آبشده» یا «تومان»).</summary>
+        /// <summary>An asset's Persian name.</summary>
         public static string Asset(string assetCode) =>
             CurrenciesConstant.GetPersianName(assetCode);
 
-        /// <summary>واحد نمایش یک دارایی (مثل «گرم» یا «تومان»).</summary>
+        /// <summary>An asset's display unit.</summary>
         public static string Unit(string assetCode) =>
             CurrenciesConstant.GetCurrencyInfo(assetCode)?.Unit ?? string.Empty;
 
         /// <summary>
-        /// تاریخ و ساعت را همان‌طور که کاربر ایرانی انتظار دارد نمایش می‌دهد:
-        /// **تقویم شمسی، به وقت تهران (UTC+۳:۳۰)، با ارقام فارسی**.
+        /// Displays a date and time the way an Iranian user expects it: <b>Jalali calendar, Tehran
+        /// time (UTC+03:30), Persian digits</b>.
         ///
         /// <para>
-        /// این تنها راهِ نمایش تاریخ در پیام‌های ربات است. قبلاً هر جا به سلیقهٔ خودش
-        /// قالب‌بندی می‌کرد و همه هم میلادی و به وقت UTC بودند؛ یعنی معامله‌ای که ساعت ۱۳:۲۲
-        /// به وقت تهران انجام شده بود، ۰۹:۵۲ نمایش داده می‌شد و تاریخش هم میلادی بود.
+        /// This is the only way a date should be displayed in a bot message. Previously each call
+        /// site formatted its own, and all of them were Gregorian and in UTC — so a trade made at
+        /// 13:22 Tehran time showed as 09:52, with a Gregorian date.
         /// </para>
         ///
         /// <para>
-        /// <b>نحوهٔ ذخیره‌سازی تغییری نمی‌کند.</b> در دیتابیس همه چیز میلادی و UTC می‌ماند —
-        /// که برای مرتب‌سازی، مقایسه و تطبیق حساب‌ها درست است. این تابع فقط لایهٔ نمایش است
-        /// و هیچ ربطی به ذخیره‌سازی ندارد.
+        /// <b>Storage is unchanged.</b> Everything in the database stays Gregorian and UTC, which is
+        /// correct for sorting, comparison and reconciliation. This is a presentation concern only.
         /// </para>
         /// </summary>
         public static string DateTimeText(DateTime value) =>

--- a/src/TallaEgg/TallaEgg.Core/Utilties/Utils.cs
+++ b/src/TallaEgg/TallaEgg.Core/Utilties/Utils.cs
@@ -55,18 +55,18 @@ namespace TallaEgg.Core.Utilties
         }
 
         /// <summary>
-        /// اگر متن شامل حروف فارسی باشد، آن را راست‌چین می‌کند.
-        /// از RLE و PDF برای کنترل جهت متن استفاده می‌شود.
+        /// Forces right-to-left presentation when the text contains Persian letters, using RLE and
+        /// PDF to control direction.
         /// </summary>
         public static string AutoRtl(this string text)
         {
             if (string.IsNullOrWhiteSpace(text))
                 return text;
 
-            // چک می‌کنیم آیا متن شامل کاراکترهای فارسی/عربی هست یا نه
+            // Does the text contain Persian or Arabic characters?
             bool hasPersian = text.Any(c => c >= 0x0600 && c <= 0x06FF);
 
-            // اگر فارسی بود، متن را داخل RLE...PDF قرار می‌دهیم
+            // If so, wrap it in RLE ... PDF.
             if (hasPersian)
                 return $"\u202B{text}\u202C";
 
@@ -74,10 +74,10 @@ namespace TallaEgg.Core.Utilties
         }
 
         /// <summary>
-        /// دریافت متن فارسی از Description attribute یک enum
+        /// Reads an enum member's Persian text from its Description attribute.
         /// </summary>
-        /// <param name="value">مقدار enum</param>
-        /// <returns>متن فارسی از Description attribute یا نام enum در صورت عدم وجود</returns>
+        /// <param name="value">The enum value.</param>
+        /// <returns>The Description text, or the enum member's name if it has none.</returns>
         public static string GetEnumDescription(Enum value)
         {
             var field = value.GetType().GetField(value.ToString());
@@ -86,35 +86,33 @@ namespace TallaEgg.Core.Utilties
         }
 
         /// <summary>
-        /// تبدیل تاریخ میلادی به شمسی (تقریبی)
+        /// Converts a Gregorian date to Jalali.
         /// </summary>
-        /// <param name="dateTime">تاریخ میلادی</param>
-        /// <returns>تاریخ شمسی به فرمت yyyy/MM/dd HH:mm</returns>
+        /// <param name="dateTime">The Gregorian date.</param>
+        /// <returns>The Jalali date, formatted yyyy/MM/dd HH:mm.</returns>
         /// <summary>
-        /// تبدیل زمان UTC به تاریخ و ساعت شمسیِ تهران، با قالب yyyy/MM/dd HH:mm.
+        /// Converts a UTC instant to a Tehran-local Jalali date and time, formatted yyyy/MM/dd HH:mm.
         ///
-        /// نسخهٔ قبلی «تقریبی» بود و در عمل غلط: سال را ۶۲۱ واحد کم می‌کرد، ماه را جابه‌جا
-        /// می‌کرد، اما **روزِ میلادی را دست‌نخورده** برمی‌گرداند. مثلاً ۲۷ ژوئیهٔ ۲۰۲۶ که
-        /// معادل ۵ مرداد ۱۴۰۵ است، ۱۴۰۵/۰۵/۲۷ نمایش داده می‌شد — یعنی کاربر تاریخ معاملهٔ
-        /// خودش را ۲۲ روز اشتباه می‌دید.
+        /// The previous version was labelled "approximate" and was simply wrong: it subtracted 621
+        /// from the year and shifted the month, but returned the <b>Gregorian day unchanged</b>.
+        /// 27 July 2026, which is 5 Mordad 1405, was displayed as 1405/05/27 — so a user saw their
+        /// own trade dated 22 days out.
         ///
-        /// کامنت قبلی می‌گفت «برای پیاده‌سازی کامل نیاز به کتابخانه PersianCalendar است»؛
-        /// این درست نبود — PersianCalendar بخشی از خود دات‌نت است و هیچ وابستگی جدیدی
-        /// لازم ندارد.
+        /// The old comment claimed a full implementation would need a PersianCalendar library. That
+        /// was not true: PersianCalendar ships with .NET and needs no new dependency.
         /// </summary>
         public static string ConvertToPersianDate(DateTime dateTime)
         {
             var local = ToTehranTime(dateTime);
             var pc = new PersianCalendar();
 
-            // همهٔ قالب‌بندی‌ها با InvariantCulture انجام می‌شوند.
+            // All formatting goes through InvariantCulture.
             //
-            // بدون آن، هر قالبی به CurrentCulture تکیه می‌کرد — یعنی خروجی به «تنظیمات
-            // زبانِ ماشینی که سرویس رویش اجرا می‌شود» وابسته می‌شد. روی این دستگاه فرهنگ
-            // en-US است و درست به نظر می‌رسید؛ روی سروری با فرهنگ fa-IR، تقویمِ پیش‌فرضِ
-            // همان فرهنگ اعمال می‌شد و مسیر جایگزینِ پایین سالِ شمسی چاپ می‌کرد، یعنی یک
-            // تاریخ شمسی که برچسبش می‌گفت میلادی است. این همان وابستگی‌ای است که نباید
-            // وجود داشته باشد.
+            // Without it every format would fall back to CurrentCulture, making the output depend on
+            // the language settings of whatever machine runs the service. On this machine the
+            // culture is en-US and it looked correct; on a server with fa-IR, that culture's default
+            // calendar would apply and the fallback path below would print a Jalali year — a Jalali
+            // date labelled as Gregorian. That is exactly the dependency that should not exist.
             try
             {
                 var year = pc.GetYear(local);
@@ -127,45 +125,43 @@ namespace TallaEgg.Core.Utilties
             }
             catch (ArgumentOutOfRangeException)
             {
-                // PersianCalendar برای تاریخ‌های خیلی قدیمی استثنا می‌دهد. تاریخِ نمایشی
-                // هرگز نباید باعث شکست یک پیام شود، پس به قالب میلادی برمی‌گردیم.
+                // PersianCalendar throws for very old dates. A displayed date must never break a
+                // message, so fall back to the Gregorian format.
                 return local.ToString("yyyy/MM/dd HH:mm", CultureInfo.InvariantCulture);
             }
         }
 
         /// <summary>
-        /// زمان‌ها در دیتابیس UTC ذخیره می‌شوند (DateTime.UtcNow)، ولی کاربر ایرانی انتظار
-        /// ساعت تهران را دارد. بدون این تبدیل، معامله‌ای که ساعت ۱۳:۲۲ به وقت تهران انجام
-        /// شده، ۰۹:۵۲ نمایش داده می‌شد.
+        /// Times are stored in UTC via DateTime.UtcNow, but an Iranian user expects Tehran time.
+        /// Without this conversion a trade made at 13:22 Tehran time displayed as 09:52.
         ///
-        /// افست ثابت +۳:۳۰ است، نه جست‌وجو در پایگاه منطقه‌های زمانی سیستم‌عامل.
+        /// The offset is a fixed +03:30 rather than a lookup in the operating system's time-zone database.
         ///
-        /// ایران از سال ۱۴۰۱ ساعت تابستانی ندارد، پس ایران همیشه UTC+۳:۳۰ است و افست ثابت
-        /// همان جواب درست را می‌دهد. در عوض، تکیه بر پایگاه سیستم‌عامل سه ریسک داشت که
-        /// هیچ‌کدام سودی نداشتند: شناسهٔ منطقه روی ویندوز و لینوکس فرق دارد، سرور ممکن است
-        /// اصلاً پایگاه tz نداشته باشد (نصب‌های حداقلیِ کانتینر)، و یک پایگاهِ قدیمی هنوز
-        /// قاعدهٔ ساعت تابستانیِ منسوخ را اعمال می‌کند و ساعت را یک ساعت جابه‌جا نشان می‌دهد.
+        /// Iran has had no daylight saving since 2022, so it is always UTC+03:30 and a fixed offset
+        /// gives the right answer. Relying on the OS database instead carried three risks and no
+        /// benefit: the zone id differs between Windows and Linux, a server may have no tz database
+        /// at all in minimal container images, and an out-of-date database still applies the
+        /// obsolete daylight-saving rule and shows the time an hour out.
         ///
-        /// نتیجه این است که نمایش تاریخ روی هر ماشینی یکسان است و به پیکربندی سرور وابسته
-        /// نیست — که برای استقرار اهمیت دارد.
+        /// The result is that date display is identical on every machine and independent of server
+        /// configuration, which matters for deployment.
         /// </summary>
         public static DateTime ToTehranTime(DateTime dateTime)
         {
-            // زمان‌های Local قبلاً تبدیل شده‌اند؛ تبدیل دوباره جابه‌جایی اشتباه می‌ساخت.
-            // Unspecified مثل UTC رفتار می‌کند، چون همهٔ زمان‌های این سامانه با
-            // DateTime.UtcNow ساخته می‌شوند و پس از رفت‌وبرگشت از دیتابیس Kind خود را
-            // از دست می‌دهند.
+            // Local times have already been converted; converting again would shift them wrongly.
+            // Unspecified is treated as UTC, because every time in this system originates from
+            // DateTime.UtcNow and loses its Kind on a round trip through the database.
             if (dateTime.Kind == DateTimeKind.Local)
                 return dateTime;
 
             return dateTime.AddHours(3).AddMinutes(30);
         }
 
-        /// <summary>افست ثابت ایران نسبت به UTC. ایران ساعت تابستانی ندارد.</summary>
+        /// <summary>Iran's fixed offset from UTC. Iran does not observe daylight saving.</summary>
         public static readonly TimeSpan TehranOffset = new(3, 30, 0);
     }
     /// <summary>
-    /// برای تشخیص نوع کیف پول اینجوری خیلی راحت تره
+    /// Helpers for working out a wallet's type from its asset code.
     /// </summary>
     public static class AssetHelper
     {
@@ -174,7 +170,7 @@ namespace TallaEgg.Core.Utilties
         private const string SAVINGS_PREFIX = "SAVINGS_";
 
         /// <summary>
-        /// تبدیل Asset + WalletType به Asset string
+        /// Combines an asset and a wallet type into an asset string.
         /// </summary>
         public static string CreateAssetKey(string baseAsset, WalletType walletType)
         {
@@ -189,7 +185,7 @@ namespace TallaEgg.Core.Utilties
         }
 
         /// <summary>
-        /// استخراج نوع کیف پول از Asset string
+        /// Extracts the wallet type from an asset string.
         /// </summary>
         public static (string baseAsset, WalletType walletType) ParseAssetKey(string assetKey)
         {
@@ -206,7 +202,7 @@ namespace TallaEgg.Core.Utilties
         }
 
         /// <summary>
-        /// بررسی نوع کیف پول
+        /// Whether the asset string denotes a credit wallet.
         /// </summary>
         public static bool IsCreditWallet(string assetKey) => assetKey.StartsWith(CREDIT_PREFIX);
         public static bool IsMarginWallet(string assetKey) => assetKey.StartsWith(MARGIN_PREFIX);

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/IWalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/IWalletApiClient.cs
@@ -8,13 +8,13 @@ namespace TallaEgg.Infrastructure.Clients;
 
 /// <summary>
 /// Client interface for communicating with Wallet service
-/// واسط کلاینت برای ارتباط با سرویس کیف پول
+/// Client interface for the Wallet service.
 /// </summary>
 public interface IWalletApiClient
 {
     /// <summary>
     /// Get user balance for specific asset
-    /// دریافت موجودی کاربر برای دارایی مشخص
+    /// Returns a user's balance for one asset.
     /// </summary>
     Task<(bool Success, string Message, decimal? balance)> GetBalanceAsync(Guid userId, string asset);
 
@@ -24,37 +24,37 @@ public interface IWalletApiClient
     Task<ApiResponse<WalletBallanceDTO>> WithdrawalAsync(WalletRequest request);
     
     /// <summary>
-    /// ثبت تراکنش معامله و تغییر بالانس ها
+    /// Records a trade's transaction and updates the balances.
     /// </summary>
     Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade);
     
     /// <summary>
     /// Lock balance for order placement
-    /// قفل کردن موجودی برای ثبت سفارش
+    /// Locks balance when placing an order.
     /// </summary>
     Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(Guid userId, string asset, decimal amount);
 
     /// <summary>
     /// Unlock balance when order is cancelled
-    /// آزاد کردن موجودی هنگام لغو سفارش
+    /// Releases locked balance when an order is cancelled.
     /// </summary>
     Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount);
     /// <summary>
     /// Increase balance for order placement
-    /// افزایش موجودی برای ثبت سفارش
+    /// Increases a balance.
     /// </summary>
     Task<(bool Success, string Message)> IncreaseBalanceAsync(Guid userId, string asset, decimal amount);
 
     /// <summary>
     /// Validate if user has sufficient balance for order
-    /// بررسی داشتن موجودی کافی برای سفارش
+    /// Whether the user has enough balance for an order.
     /// </summary>
     Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(
         Guid userId,
         string asset,
         decimal amount);
     /// <summary>
-    /// بررسی اعتبار و موجودی کاربر برای ثبت سفارش
+    /// Checks a user's credit and balance before an order is placed.
     /// </summary>
     /// <param name="userId"></param>
     /// <param name="symbol">

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -608,13 +608,13 @@ public class UsersApiClient : IUsersApiClient
 
 
     /// <summary>
-    /// دریافت اطلاعات کاربر بر اساس شناسه کاربر
+    /// Returns a user by id.
     /// </summary>
-    /// <param name="userId">شناسه یکتای کاربر</param>
-    /// <returns>اطلاعات کاربر یا null در صورت عدم وجود</returns>
+    /// <param name="userId">User id.</param>
+    /// <returns>The user, or null if there is no such user.</returns>
     /// <remarks>
-    /// این متد برای دریافت اطلاعات کامل کاربر شامل TelegramUserId استفاده می‌شود
-    /// که برای ارسال اطلاعیه‌های تطبیق معامله ضروری است
+    /// Used to obtain the full user record including TelegramUserId, which is required in order to
+    /// send trade-match notifications.
     /// </remarks>
     public async Task<UserDto?> GetUserByIdAsync(Guid userId)
     {

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Text.Json;
@@ -13,7 +13,7 @@ namespace TallaEgg.Infrastructure.Clients;
 
 /// <summary>
 /// HTTP client for communicating with Wallet service
-/// کلاینت HTTP برای ارتباط با سرویس کیف پول
+/// HTTP client for the Wallet service.
 /// </summary>
 public class WalletApiClient : IWalletApiClient
 {
@@ -49,7 +49,7 @@ public class WalletApiClient : IWalletApiClient
 
     /// <summary>
     /// Lock balance for order placement
-    /// قفل کردن موجودی برای ثبت سفارش
+    /// Locks balance when placing an order.
     /// </summary>
     public async Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(
         Guid userId,
@@ -113,7 +113,7 @@ public class WalletApiClient : IWalletApiClient
 
     /// <summary>
     /// Unlock balance when order is cancelled
-    /// آزاد کردن موجودی هنگام لغو سفارش
+    /// Releases locked balance when an order is cancelled.
     /// </summary>
     public async Task<(bool Success, string Message)> UnlockBalanceAsync(
         Guid userId,
@@ -123,7 +123,7 @@ public class WalletApiClient : IWalletApiClient
         try
         {
             // Note: This endpoint might need to be implemented in Wallet service
-            // فراخوانی endpoint آزادسازی موجودی (ممکن است نیاز به پیاده‌سازی در سرویس Wallet داشته باشد)
+            // Calls the wallet's unlock endpoint.
             var request = new WalletRequest
             {
                 UserId = userId,
@@ -202,8 +202,8 @@ public class WalletApiClient : IWalletApiClient
 
     /// <summary>
     /// Validate if user has sufficient balance for order
-    /// بررسی داشتن موجودی کافی برای سفارش
-    /// اینجا باید حجم را به عنوان ورودی دریافت کنیم
+    /// Whether the user has enough balance for an order.
+    /// TODO: this should take the quantity as an argument.
     /// valume = price * amount
     /// </summary>
     public async Task<(bool Success, string Message, bool HasSufficientBalance)> ValidateBalanceAsync(
@@ -234,26 +234,28 @@ public class WalletApiClient : IWalletApiClient
         }
     }
     /// <summary>
-    /// با استفاده از این متد می‌توان اعتبار و موجودی کاربر را برای ثبت سفارش بررسی کرد
+    /// Checks a user's credit and balance before an order is placed.
     /// 
     /// </summary>
-    /// <param name="userId">شناسه کاربر در سیستم ما</param>
+    /// <param name="userId">User id in our system.</param>
     /// <param name="symbol">
-    /// نماد معاملاتی که شامل دو دارایی است
+    /// The trading symbol, which names two assets.
     /// Trading Pair: Base Asset / Quote Asset
     /// </param>
     /// <param name="amount">
-    /// مقدار دارایی که کاربر قصد خرید یا فروش آن را دارد
+    /// The quantity the user intends to buy or sell.
     /// Quantity
     /// </param>
     /// <param name="price">
-    /// قیمت بر اساس ارز مظنه که کاربر قصد خرید یا فروش دارد
+    /// The price, denominated in the quote currency.
     /// Quote Asset
     /// </param>
     /// <returns>
-    /// اگر Success برابر true باشد یعنی عملیات بدون خطا انجام شده است
-    /// اگر HasSufficientCreditAndBalanceBase برابر true باشد یعنی کاربر برای دارایی پایه (Base Asset) اعتبار و موجودی کافی دارد و می‌تواند سفارش فروش را ثبت کند
-    /// اگر HasSufficientCreditAndBalanceQuote برابر true باشد یعنی کاربر برای دارایی مظنه (Quote Asset) اعتبار و موجودی کافی دارد و می‌تواند سفارش خرید را ثبت کند
+    /// Success is true when the check itself ran without error.
+    /// HasSufficientCreditAndBalanceBase is true when the user has enough credit and balance in the
+    /// base asset to place a sell order.
+    /// HasSufficientCreditAndBalanceQuote is true when they have enough in the quote asset to place
+    /// a buy order.
     /// </returns>
     public async Task<(
                         bool Success,
@@ -265,7 +267,7 @@ public class WalletApiClient : IWalletApiClient
     {
         try
         {
-            // دریافت موجودی‌های مختلف کاربر
+            // Read the user's various balances.
             var spotBaseAsset = await GetBalanceAsync(userId, symbol.Split('/')[0]);
             var creditBaseAsset = await GetBalanceAsync(userId, "CREDIT_" + symbol.Split('/')[0]);
             var spotQuoteAsset = await GetBalanceAsync(userId, symbol.Split('/')[1]);
@@ -521,11 +523,11 @@ public class WalletApiClient : IWalletApiClient
         }
     }
     /// <summary>
-    /// بعد از اینکه معامله‌ای انجام شد، باید تراکنش معامله ثبت و بالانس‌ها به‌روزرسانی شوند.
+    /// Once a trade has executed, its transaction must be recorded and the balances updated.
     ///
-    /// دلیل رد شدن تسویه باید عیناً به فراخوان برسد. پیش‌تر هر خطایی به یک پیام عمومی
-    /// تبدیل می‌شد، پس پردازشگر outbox هیچ‌وقت نمی‌فهمید مشکل واقعی چه بوده و همان
-    /// رشتهٔ بی‌فایده در LastError ذخیره می‌شد (issue #38).
+    /// The reason a settlement was refused must reach the caller verbatim. Every error used to be
+    /// collapsed into a generic message, so the outbox processor never learned what actually went
+    /// wrong and stored that useless string in LastError (issue #38).
     /// </summary>
     public async Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade)
     {
@@ -537,14 +539,14 @@ public class WalletApiClient : IWalletApiClient
             var response = await _httpClient.PostAsync("api/wallet/changeBalance", stringContent);
             var body = await response.Content.ReadAsStringAsync();
 
-            // endpoint در هر دو حالت موفق و ناموفق یک ApiResponse برمی‌گرداند و پیام
-            // دقیق تسویه در Message آن است.
+            // The endpoint returns an ApiResponse on both success and failure, and the precise
+            // settlement message is in its Message field.
             var parsed = TryParseMessage(body);
 
             if (response.IsSuccessStatusCode)
             {
-                // _logger عمداً با ?. صدا زده می‌شود: یکی از سازنده‌های این کلاس logger
-                // نمی‌گیرد و آن را null می‌گذارد.
+                // _logger is called with ?. deliberately: one of this class's constructors takes no
+                // logger and leaves it null.
                 _logger?.LogInformation(
                     "Trade {TradeId} settled by the wallet service. Symbol: {Symbol}, quantity: {Quantity}, quote: {QuoteQuantity}.",
                     trade.Id, trade.Symbol, trade.Quantity, trade.QuoteQuantity);
@@ -568,9 +570,9 @@ public class WalletApiClient : IWalletApiClient
     }
 
     /// <summary>
-    /// پیام را از بدنهٔ ApiResponse بیرون می‌کشد. اگر بدنه خالی یا غیرقابل‌تجزیه بود
-    /// null برمی‌گرداند تا فراخوان خودش یک پیام جایگزین بسازد — خواندن پیام هرگز نباید
-    /// خودش باعث شکست تسویه شود.
+    /// Extracts the message from an ApiResponse body. Returns null when the body is empty or cannot
+    /// be parsed, so the caller can supply its own fallback — reading a message must never be what
+    /// fails a settlement.
     /// </summary>
     private string? TryParseMessage(string body)
     {

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -53,7 +53,7 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
-// نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
+// Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
@@ -62,12 +62,12 @@ if (urls is { Length: > 0 })
     builder.WebHost.UseUrls(urls);
 }
 
-// تنظیم اتصال به دیتابیس SQL Server
+// SQL Server connection.
 builder.Services.AddDbContext<UsersDbContext>(options =>
     options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "UsersDb"),
         b => b.MigrationsAssembly("Users.Api")));
 
-// فقط در production محافظت فعال شود
+// Protection is only wired up in Production.
 if (builder.Environment.IsProduction())
 {
     builder.Services.AddAuthentication("ApiKey")
@@ -76,7 +76,7 @@ if (builder.Environment.IsProduction())
             options.ApiKey = APIKeyConstant.RequireTallaEggApiKey();
         });
 
-    // Authorization Policy سراسری فقط برای production
+    // Global authorization policy, Production only.
     builder.Services.AddAuthorization(options =>
     {
         options.FallbackPolicy = new AuthorizationPolicyBuilder()
@@ -86,7 +86,7 @@ if (builder.Environment.IsProduction())
 }
 else
 {
-    // برای development فقط authorization اضافه کنید (بدون authentication)
+    // Development adds authorization only, with no authentication in front of it.
     builder.Services.AddAuthorization();
 }
 
@@ -95,14 +95,14 @@ builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<UserMapper>();
 builder.Services.AddTallaEggErrorHandling();
 
-// HttpClient برای فراخوانی Wallet API
+// HttpClient for calling the Wallet API.
 builder.Services.AddHttpClient("WalletAPI", client =>
 {
     client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("WalletApiUrl") ?? "https://localhost:60932/");
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
-// اضافه کردن CORS — issue #31: whitelist از پیکربندی، نه AllowAnyOrigin
+// CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.
 builder.Services.AddTallaEggCors(builder.Configuration);
 
 // Add Swagger services
@@ -120,7 +120,7 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
-// پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
+// Serilog: log to rolling files and the console.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
@@ -132,7 +132,7 @@ var app = builder.Build();
 
 app.UseTallaEggErrorHandling();
 
-// --- مایگریشن و سیید اولیه ---
+// --- Migrations and initial seed ---
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
@@ -179,7 +179,7 @@ using (var scope = app.Services.CreateScope())
 
 
 
-// Authentication و Authorization فقط در production
+// Authentication and authorization, Production only.
 if (app.Environment.IsProduction())
 {
     app.UseAuthentication();
@@ -196,7 +196,7 @@ app.UseSwaggerUI(c =>
     c.RoutePrefix = "api-docs";
 });
 
-// تنظیم CORS
+// Apply the CORS policy.
 app.UseTallaEggCors();
 
 // Add Swagger middleware
@@ -249,7 +249,7 @@ app.MapPost("/api/user/register", async (RegisterUserRequest request, UserServic
 /// <response code="404">User not found</response>
 app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserService userService) =>
 {
-    // UpdateUserPhoneAsync throws InvalidOperationException("کاربر یافت نشد.") — a user-facing
+    // UpdateUserPhoneAsync throws InvalidOperationException with a user-facing "not found" message — a
     // message, not boilerplate, so it stays local. See #88.
     try
     {
@@ -280,13 +280,13 @@ app.MapGet("/api/user/{telegramId}", async (long telegramId, UserService userSer
 });
 
 /// <summary>
-/// دریافت اطلاعات کاربر بر اساس شناسه
+/// Returns a user by id.
 /// </summary>
-/// <param name="userId">شناسه یکتای کاربر</param>
-/// <param name="userService">سرویس کاربر برای منطق تجاری</param>
-/// <returns>جزئیات کاربر در صورت یافتن</returns>
-/// <response code="200">کاربر پیدا شد و با موفقیت برگردانده شد</response>
-/// <response code="404">کاربر پیدا نشد</response>
+/// <param name="userId">User id.</param>
+/// <param name="userService">User service.</param>
+/// <returns>The user, if found.</returns>
+/// <response code="200">User found.</response>
+/// <response code="404">User not found.</response>
 app.MapGet("/api/user/userId/{userId}", async (Guid userId, UserService userService) =>
 {
     var user = await userService.GetUserByIdAsync(userId);
@@ -327,7 +327,7 @@ app.MapGet("/api/users/list", async (
         int? pageNumber,
         int? pageSize, UserService userService) =>
 {
-    // اعتبارسنجی
+    // Validation.
     var page = pageNumber ?? 1;
     var size = Math.Clamp(pageSize ?? 10, 1, 100);
 
@@ -346,7 +346,7 @@ app.MapGet("/api/users/list", async (
 /// <response code="404">User not found</response>
 app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserService userService) =>
 {
-    // UpdateUserStatusAsync throws InvalidOperationException("کاربر یافت نشد.") — a user-facing
+    // UpdateUserStatusAsync throws InvalidOperationException with a user-facing "not found" message — a
     // message, not boilerplate, so it stays local. See #88.
     try
     {
@@ -458,14 +458,14 @@ app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService 
 });
 
 /// <summary>
-/// ایجاد کیف پول‌های پیش‌فرض برای کاربر موجود
+/// Creates the default wallets for an existing user.
 /// </summary>
-/// <param name="userId">شناسه کاربر</param>
-/// <param name="userService">سرویس کاربران</param>
-/// <returns>نتیجه عملیات</returns>
-/// <response code="200">کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند</response>
-/// <response code="400">خطا در ایجاد کیف پول‌ها</response>
-/// <response code="404">کاربر یافت نشد</response>
+/// <param name="userId">User id.</param>
+/// <param name="userService">User service.</param>
+/// <returns>Whether it succeeded.</returns>
+/// <response code="200">Default wallets created.</response>
+/// <response code="400">Wallet creation failed.</response>
+/// <response code="404">User not found.</response>
 app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, UserService userService) =>
 {
     var user = await userService.GetUserByIdAsync(userId);
@@ -477,7 +477,7 @@ app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, Use
         );
     }
 
-    // فراخوانی endpoint کیف پول
+    // Call the wallet endpoint.
     using var httpClient = new HttpClient();
     httpClient.BaseAddress = new Uri("https://localhost:7001/");
     var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);

--- a/src/User/Users.Application/Mappers/UserMapper.cs
+++ b/src/User/Users.Application/Mappers/UserMapper.cs
@@ -32,7 +32,7 @@ namespace Users.Application.Mappers
         }
 
         /// <summary>
-        ///  // todo باید کامل شود
+        /// TODO: incomplete.
         /// </summary>
         /// <param name="dto"></param>
         /// <returns></returns>

--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -1,4 +1,4 @@
-using Affiliate.Core;
+﻿using Affiliate.Core;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using System.Text;
@@ -49,7 +49,7 @@ public class UserService
 
         await _userRepository.CreateAsync(user);
         
-        // ایجاد کیف پول‌های پیش‌فرض
+        // Create the user's default wallets.
         await CreateDefaultWalletsAsync(user.Id);
         
         return _userMapper.Map(user);
@@ -111,14 +111,14 @@ public class UserService
         if (string.IsNullOrWhiteSpace(invitationCode))
             return null;
 
-        // ابتدا در جدول Users جستجو می‌کنیم
+        // Look in the Users table first.
         var id = await _userRepository.GetUserIdByInvitationCodeAsync(invitationCode);
         if (id != null)
         {
             return id;
         }
 
-        // اگر در جدول Users پیدا نشد، در جدول Invitations جستجو می‌کنیم
+        // If not there, look in the Invitations table.
         
         //var invitation = await _userRepository.GetInvitationByCodeAsync(invitationCode);
         //if (invitation != null)
@@ -134,14 +134,14 @@ public class UserService
         if (string.IsNullOrWhiteSpace(phoneNumber))
             return null;
 
-        // ابتدا در جدول Users جستجو می‌کنیم
+        // Look in the Users table first.
         var id = await _userRepository.GetUserIdByPhonenumberAsync(phoneNumber);
         if (id != null)
         {
             return id;
         }
 
-        // اگر در جدول Users پیدا نشد، در جدول Invitations جستجو می‌کنیم
+        // If not there, look in the Invitations table.
         
         //var invitation = await _userRepository.GetInvitationByCodeAsync(invitationCode);
         //if (invitation != null)
@@ -175,7 +175,7 @@ public class UserService
         ArgumentNullException.ThrowIfNull(user);
         var createdUser = await _userRepository.CreateAsync(user);
         
-        // ایجاد کیف پول‌های پیش‌فرض
+        // Create the user's default wallets.
         await CreateDefaultWalletsAsync(createdUser.Id);
         
         return createdUser;
@@ -191,47 +191,18 @@ public class UserService
         return await _userRepository.GetUsersByRoleAsync(role);
     }
 
-    // اگر جایی در این فایل یا پروژه متدی دارید که آرگومان دوم آن باید از نوع Users.Core.UserRole باشد، 
-    // باید مقدار رشته را به Enum تبدیل کنید. مثال:
     public UserRole ParseUserRole(string roleString)
     {
         if (Enum.TryParse<UserRole>(roleString, true, out var role))
             return role;
-        return UserRole.User; // مقدار پیش‌فرض
+        return UserRole.User; // Default.
     }
-
-    // سپس هنگام فراخوانی متد، به جای رشته، مقدار Enum را ارسال کنید:
-    // var userRole = ParseUserRole(roleString);
-    // someMethod(userId, userRole);
-
-    // اطمینان حاصل کنید که IUserRepository متد زیر را دارد:
-    // Task<Invitation?> GetInvitationByCodeAsync(string invitationCode);
-
-    // اگر ندارد، باید به اینترفیس IUserRepository اضافه شود و در کلاس پیاده‌سازی آن نیز نوشته شود.
-    // مثال برای اینترفیس:
-    /*
-    public interface IUserRepository
-    {
-        // ...existing code...
-        Task<Invitation?> GetInvitationByCodeAsync(string invitationCode);
-        // ...existing code...
-    }
-    */
-
-    // سپس در کلاس UserRepository پیاده‌سازی کنید:
-    /*
-    public async Task<Invitation?> GetInvitationByCodeAsync(string invitationCode)
-    {
-        // منطق دریافت دعوت‌نامه از دیتابیس
-        // return await dbContext.Invitations.FirstOrDefaultAsync(x => x.Code == invitationCode);
-    }
-    */
 
     /// <summary>
-    /// دریافت کاربر بر اساس شناسه یکتا
+    /// Returns a user by id.
     /// </summary>
-    /// <param name="userId">شناسه یکتای کاربر</param>
-    /// <returns>اطلاعات کاربر در قالب DTO یا null در صورت عدم وجود</returns>
+    /// <param name="userId">User id.</param>
+    /// <returns>The user as a DTO, or null if there is no such user.</returns>
     public async Task<UserDto?> GetUserByIdAsync(Guid userId)
     {
         var user = await _userRepository.GetByIdAsync(userId);
@@ -239,10 +210,10 @@ public class UserService
     }
 
     /// <summary>
-    /// ایجاد کیف پول‌های پیش‌فرض برای کاربر جدید
+    /// Creates the default wallets for a new user.
     /// </summary>
-    /// <param name="userId">شناسه کاربر</param>
-    /// <returns>نتیجه عملیات</returns>
+    /// <param name="userId">User id.</param>
+    /// <returns>Whether it succeeded.</returns>
     private async Task<bool> CreateDefaultWalletsAsync(Guid userId)
     {
         try

--- a/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.cs
+++ b/src/Wallet/Wallet.Api/Migrations/20260727104807_AddTradeSettlements.cs
@@ -6,10 +6,10 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Wallet.Api.Migrations
 {
     /// <summary>
-    /// جدول TradeSettlements را می‌سازد و سطرهای معاملاتی که از قبل تسویه شده‌اند را پر می‌کند.
+    /// Creates the TradeSettlements table and backfills rows for trades that already settled.
     ///
-    /// این جدول سد یکتایی تسویه است (issue #42): چون TradeId کلید اصلی است، دو تسویهٔ
-    /// همزمان از یک معامله دیگر نمی‌توانند هر دو اعمال شوند.
+    /// This table is the settlement uniqueness barrier (issue #42): because TradeId is the primary
+    /// key, two concurrent settlements of one trade can no longer both apply.
     /// </summary>
     public partial class AddTradeSettlements : Migration
     {


### PR DESCRIPTION
**Branch Name**: `refactor/translate-comments-shared`
**Linked**: STANDARDS.md §1, §5 · PR_TEMPLATE (no commented-out code) · follows #126, #127

---

## Description

Third slice, after Wallet (#126) and Orders (#127). **23 files, ~250 Persian comment lines**
across the shared `TallaEgg.Core` and the Users service.

**This completes `src/`** apart from Affiliate, which is out of scope at the product owner's
request.

---

## Type of Change

- [x] Refactor (code organization, no behavior change)

No executable statement was added, removed or altered.

---

## Where the value is

`TallaEgg.Core` holds the reasoning that the rest of the system depends on:

- **`CurrenciesConstant`** — why the currency is IRT and not IRR, and why the collateral lock
  rounds **up** while consumption rounds **down**, including the inequality that makes
  "total consumed ≤ locked" a mathematical guarantee rather than a hope (#52).
- **`Utils`** — why the Jalali conversion uses .NET's own `PersianCalendar` rather than arithmetic
  that shifted the year and month but left the Gregorian **day** untouched, showing users a trade
  dated 22 days out; and why Iran's offset is hard-coded rather than looked up in the OS time-zone
  database.
- **`PersianFormat`** — why a left-to-right isolate replaced RLM, after RLM silently swapped the
  date and the time in every message that carried both.

These are translated in full, not compressed.

---

## Persian kept where it is data, not prose

Quoted terms stay inside English sentences: the admin command keywords, the asset display names,
and the role strings `UserRoleNames` matches against. Translating those would describe something
the code does not do — it matches on the Persian text itself.

---

## Removed rather than translated

- **A block of instructional scaffolding in `UserService`** — notes addressed to a future
  developer ("if you have a method whose second argument should be…, you need to convert the
  string to an enum"), plus two commented-out sketches of an interface and a method body. This is
  the clearest example of the "useless comments" in the original request. `ParseUserRole` itself
  is real code and stays.
- A junk fragment in `TelegramLoggerService`.

---

## Safety: user-facing Persian is untouched

Verified mechanically across all 23 changed files:

```
files changed: 23 | with altered live Persian strings: 0
```

---

## Testing Completed

```
dotnet build TallaEgg.sln  -> 0 errors
dotnet test  TallaEgg.sln  -> 483 passed, 0 failed, 0 skipped
```

---

## Security Checklist

- [x] No hardcoded secrets, credentials or tokens
- [x] No behaviour change, so no new attack surface

---

## Breaking Changes?

- [x] No breaking changes

---

## Remaining

| Slice | Persian comment lines |
|---|---|
| ~~Wallet~~ (#126) · ~~Orders~~ (#127) · ~~Core + Users~~ | done |
| `TelegramBot` | ~470 |
| `tests` | ~360 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
