### PR TITLE
refactor(tests): translate comments to English

### DIFF
--- a/tests/TallaEgg.AllServices.Tests/AutoQuoteCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuoteCommandTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
 using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.User;
@@ -60,7 +60,7 @@ public class AutoQuoteCommandTests
             From = new User { Id = AdminTelegramId }
         });
 
-    // ── اسپرد ────────────────────────────────────────────────────────────────────
+    // ── Spread command ──────────────────────────────────────────────────────────
 
     [Fact]
     public async Task AnAdminCanSetTheSpread()
@@ -140,7 +140,7 @@ public class AutoQuoteCommandTests
         Assert.DoesNotContain(_messenger.Texts, t => t.Contains("قالب دستور درست نیست"));
     }
 
-    // ── اتومات ───────────────────────────────────────────────────────────────────
+    // ── Automatic-quote command ─────────────────────────────────────────────────
 
     [Fact]
     public async Task AnAdminCanTurnAutoQuoteOn()
@@ -223,7 +223,7 @@ public class AutoQuoteCommandTests
         Assert.Contains(_messenger.Texts, t => t.Contains("قالب"));
     }
 
-    // ── نماد فعال/غیرفعال ────────────────────────────────────────────────────────
+    // ── Symbol enable/disable command ───────────────────────────────────────────
 
     [Fact]
     public async Task AnAdminCanActivateASymbol()

--- a/tests/TallaEgg.AllServices.Tests/Fakes/BotTestDoubles.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/BotTestDoubles.cs
@@ -95,7 +95,7 @@ public sealed class FakeOrderApiClient : IOrderApiClient
     public Task<ApiResponse<bool>> NotifyMatchingEngineAsync(NotifyMatchingEngineRequest request) =>
         throw new NotSupportedException(nameof(NotifyMatchingEngineAsync));
 
-    // ── مظنهٔ اتومات (issue #90) ─────────────────────────────────────────────────
+    // ── Automatic quotes (issue #90) ────────────────────────────────────────────
 
     public AutoQuoteSettingsDto? AutoQuoteSettings { get; set; }
 
@@ -121,7 +121,7 @@ public sealed class FakeOrderApiClient : IOrderApiClient
         return Task.FromResult(EnabledToggleResult);
     }
 
-    // ── فعال/غیرفعال بودن نماد ───────────────────────────────────────────────────
+    // ── Symbol enable/disable ───────────────────────────────────────────────────
 
     /// <summary>
     /// Defaults to the three symbols the platform actually seeds as active (see the
@@ -145,7 +145,7 @@ public sealed class FakeOrderApiClient : IOrderApiClient
         return Task.FromResult(ActiveToggleResult);
     }
 
-    // ── سود و زیان (issue #93) ───────────────────────────────────────────────────
+    // ── Profit and loss (issue #93) ─────────────────────────────────────────────
 
     public ApiResponse<PositionsResponseDto> PositionsResult { get; set; } =
         ApiResponse<PositionsResponseDto>.Ok(new PositionsResponseDto(), "ok");

--- a/tests/TallaEgg.AllServices.Tests/LockResidueTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/LockResidueTests.cs
@@ -1,20 +1,20 @@
-using TallaEgg.Core;
+﻿using TallaEgg.Core;
 
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// وثیقهٔ قفل‌شده باید پس از پر شدن کامل سفارش، کاملاً مصرف یا آزاد شود.
+/// Locked collateral must be fully consumed or released once an order is completely filled.
 ///
-/// دو منبع مستقل باقی‌مانده وجود داشت (issue #52):
+/// There were two independent sources of residue (issue #52):
 ///
-/// ۱. یک‌باره، هنگام قفل: ربات قیمت را گرد‌نشده می‌فرستاد (قیمت مثقال ÷ ۴٫۳۳۱۸) و قفل
-///    از همان مقدار حساب می‌شد، ولی ستون Orders.Price فقط دو رقم اعشار نگه می‌دارد و
-///    تسویه قیمتِ گردشده را از دیتابیس می‌خواند.
+/// 1. Once, at lock time: the bot sent an unrounded price (mesghal price / 4.3318) and the lock was
+///    computed from it, but Orders.Price holds only two decimals and settlement reads the rounded
+///    price back from the database.
 ///
-/// ۲. در هر fill: مصرف هر معامله جداگانه گرد می‌شود، و مجموعِ مقادیرِ جداگانه‌گردشده
-///    با مقدارِ یک‌بار‌گردشده برابر نیست.
+/// 2. Per fill: each trade's consumption is rounded separately, and the sum of separately-rounded
+///    amounts does not equal the once-rounded whole.
 ///
-/// این تست‌ها روی خودِ حسابِ عددی کار می‌کنند، چون همین حساب است که اشتباه بود.
+/// These tests work on the arithmetic itself, because the arithmetic is what was wrong.
 /// </summary>
 public class LockResidueTests
 {
@@ -24,18 +24,18 @@ public class LockResidueTests
     private static decimal PricePerGram(decimal perMesghal) =>
         perMesghal / CurrenciesConstant.GramsPerMesghal;
 
-    /// <summary>قفل: رو به بالا — همان چیزی که OrderService استفاده می‌کند.</summary>
+    /// <summary>The lock rounds up, the same as OrderService does.</summary>
     private static decimal Lock(decimal quantity, decimal price) =>
         CurrenciesConstant.CeilingToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
 
-    /// <summary>مصرف هر معامله: رو به پایین — همان چیزی که CreateTrade استفاده می‌کند.</summary>
+    /// <summary>Each trade's consumption rounds down, the same as CreateTrade does.</summary>
     private static decimal Fill(decimal quantity, decimal price) =>
         CurrenciesConstant.FloorToCurrencyPrecision(quantity * price, CurrenciesConstant.Toman);
 
     /// <summary>
-    /// منبع ۱. قیمتِ گردشده همان است که ذخیره و بعداً برای تسویه خوانده می‌شود، پس قفل
-    /// باید از همان حساب شود. نرخ خرید انتخاب شده چون ۷۹٬۰۰۰٬۰۰۰ ÷ ۴٫۳۳۱۸ به دو رقم
-    /// اعشار بسته نمی‌شود — همان حالتی که باگ را نشان داد.
+    /// Source 1. The rounded price is what gets stored and later read back for settlement, so the
+    /// lock has to be computed from it. This buy rate was chosen because 79,000,000 / 4.3318 does
+    /// not close at two decimals — the case that exposed the bug.
     /// </summary>
     [Fact]
     public void LockUsesTheSamePriceThatWillBeStored()
@@ -46,12 +46,12 @@ public class LockResidueTests
         var lockedFromRawPrice = Lock(1000m, raw);
         var lockedFromStoredPrice = Lock(1000m, stored);
 
-        // این دو عدد پیش‌تر ۲ تومان اختلاف داشتند و همان اختلاف تا ابد قفل می‌ماند.
+        // These two figures used to differ by 2 toman, and that difference stayed locked forever.
         Assert.NotEqual(lockedFromRawPrice, lockedFromStoredPrice);
         Assert.Equal(18_237_222_400m, lockedFromStoredPrice);
     }
 
-    /// <summary>قیمت باید دقیقاً به دقت ستون گرد شود، نه بیشتر و نه کمتر.</summary>
+    /// <summary>The price must round to the column's precision exactly — no more, no less.</summary>
     [Theory]
     [InlineData(80_000_000, 18_468_073.32)]
     [InlineData(79_000_000, 18_237_222.40)]
@@ -64,11 +64,11 @@ public class LockResidueTests
     }
 
     /// <summary>
-    /// منبع ۲، و دلیل اینکه گرد کردن قیمت به‌تنهایی کافی نیست: حتی با قیمت یکسان،
-    /// مجموع fillهای جداگانه‌گردشده با قفلِ یک‌بار‌گردشده برابر نیست.
+    /// Source 2, and why rounding the price alone is not enough: even at an identical price, the sum
+    /// of separately-rounded fills does not equal the once-rounded lock.
     ///
-    /// این تست وجودِ باقی‌مانده را اثبات می‌کند تا روشن باشد چرا آزادسازی در پایان
-    /// سفارش لازم است و نمی‌توان صرفاً به گرد کردن قیمت اکتفا کرد.
+    /// This proves the residue exists, so it is clear why a release at the end of the order is
+    /// required and why rounding the price is not a substitute.
     /// </summary>
     [Fact]
     public void PerFillRounding_LeavesAResidue_EvenWithTheStoredPrice()
@@ -78,16 +78,16 @@ public class LockResidueTests
         var locked = Lock(10m, price);
         var consumed = Fill(3m, price) + Fill(3m, price) + Fill(3m, price) + Fill(1m, price);
 
-        // باقی‌مانده وجود دارد و صرفاً با گرد کردن قیمت از بین نمی‌رود — برای همین
-        // آزادسازی در پایان سفارش لازم است و نمی‌توان به گرد کردن اکتفا کرد.
+        // A residue exists and rounding the price does not remove it — which is why the release at
+        // the end of the order is necessary.
         Assert.NotEqual(locked, consumed);
         Assert.True(locked > consumed);
     }
 
     /// <summary>
-    /// همان حالتی که پیش‌تر بیش‌مصرف می‌کرد: پنج fill دو گرمی، که هرکدام کسر ۰٫۸ دارد.
-    /// با AwayFromZero همه رو به بالا گرد می‌شدند و مجموعشان ۱ تومان از قفل بیشتر
-    /// می‌شد، پس گاردِ «وثیقهٔ کافی نیست» یک معاملهٔ کاملاً معتبر را رد می‌کرد.
+    /// The case that used to over-consume: five two-gram fills, each with a 0.8 fraction. Under
+    /// AwayFromZero every one rounded up and their sum exceeded the lock by 1 toman, so the
+    /// "insufficient collateral" guard refused a perfectly valid trade.
     /// </summary>
     [Fact]
     public void FillsThatUsedToOverConsume_NoLongerDo()
@@ -101,14 +101,14 @@ public class LockResidueTests
     }
 
     /// <summary>
-    /// خودِ تضمین، نه یک نمونه: برای هر ترکیبی از اندازهٔ fillها، مجموع مصرف هرگز از
-    /// مقدار قفل‌شده بیشتر نمی‌شود.
+    /// The guarantee itself rather than one example: for any combination of fill sizes, total
+    /// consumption never exceeds the locked amount.
     ///
     ///     Σ Floor(qᵢ × p) ≤ Σ qᵢ×p = Q×p ≤ Ceiling(Q×p)
     ///
-    /// این چیزی است که یک تست تک‌نمونه‌ای نمی‌تواند نشان دهد — یک ترکیب خوش‌شانس
-    /// می‌تواند سبز بماند در حالی که ترکیب دیگری می‌شکند. دقیقاً همان اتفاقی که با
-    /// ۳+۳+۴ افتاد و باعث شد چند ساعت به نظر برسد باقی‌مانده رشد نمی‌کند.
+    /// A single-example test cannot show this — one lucky combination stays green while another
+    /// breaks. That is exactly what happened with 3+3+4, and for a few hours it looked as though the
+    /// residue did not grow.
     /// </summary>
     [Theory]
     [InlineData(new double[] { 2, 2, 2, 2, 2 })]
@@ -130,8 +130,8 @@ public class LockResidueTests
     }
 
     /// <summary>
-    /// و باقی‌مانده باید ناچیز بماند — حداکثر یک واحد به‌ازای هر fill. اگر روزی جهت
-    /// گرد کردن اشتباه عوض شود، مجموع مصرف کمتر می‌شود ولی این تست هم می‌شکند.
+    /// And the residue must stay negligible — at most one unit per fill. If the rounding direction
+    /// is ever changed wrongly, total consumption drops and this test breaks with it.
     /// </summary>
     [Theory]
     [InlineData(new double[] { 2, 2, 2, 2, 2 })]
@@ -148,8 +148,8 @@ public class LockResidueTests
     }
 
     /// <summary>
-    /// باقی‌مانده = «آنچه قفل شد» منهای «آنچه مصرف شد». همان فرمولی که مسیر لغو و
-    /// مسیر تکمیل هر دو استفاده می‌کنند. با آزاد کردن این مقدار، قفل به صفر می‌رسد.
+    /// Residue = what was locked minus what was consumed — the same formula the cancellation and
+    /// completion paths both use. Releasing that amount brings the lock to zero.
     /// </summary>
     [Fact]
     public void ReleasingTheResidue_BringsTheLockToZero()
@@ -166,9 +166,9 @@ public class LockResidueTests
     }
 
     /// <summary>
-    /// سمت فروشنده باقی‌مانده ندارد: وثیقه‌اش دارایی پایه است و هر معامله دقیقاً
-    /// Quantity مصرف می‌کند، بدون گرد کردن. این تست آن فرض را تثبیت می‌کند تا اگر
-    /// روزی عوض شد، سکوت نکند.
+    /// The sell side has no residue: its collateral is the base asset and each trade consumes
+    /// exactly Quantity, with no rounding. This test pins that assumption so a change to it cannot
+    /// pass silently.
     /// </summary>
     [Fact]
     public void SellSide_HasNoResidue()

--- a/tests/TallaEgg.AllServices.Tests/MarketModeTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/MarketModeTests.cs
@@ -6,19 +6,19 @@ using TallaEgg.Core.Enums.Order;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// حالت بازار هر نماد (issue #48).
+/// Each symbol's market mode (issue #48).
 ///
 /// <para>
-/// نکتهٔ اصلی این تست‌ها سازگاری با گذشته است: تنظیم
-/// <c>Matching:RequireMarketMakerCounterparty</c> از قبل وجود داشت و دقیقاً همین قاعده را
-/// بیان می‌کرد. اگر <c>MarketMode</c> آن را نادیده می‌گرفت، دو تعریف موازی برای یک قاعده
-/// داشتیم — همان الگویی که در این کدبیس بارها به باگ ختم شده.
+/// The point of these tests is backward compatibility: <c>Matching:RequireMarketMakerCounterparty</c>
+/// already existed and expressed exactly this rule. Had <c>MarketMode</c> ignored it, there would
+/// be two parallel definitions of one rule — the pattern that has repeatedly produced bugs in this
+/// codebase.
 /// </para>
 ///
 /// <para>
-/// <b>«بازارگردان کیست» دیگر اینجا نیست.</b> این کلاس فقط می‌گوید یک نماد در کدام حالت کار
-/// می‌کند. طرف مقابلِ معامله حالا خودِ مظنه است — منتشرکننده‌اش — که در
-/// <see cref="QuoteFillCounterpartyTests"/> پوشش داده می‌شود.
+/// <b>Who the market maker is no longer lives here.</b> This class only reports which mode a symbol
+/// runs in. The counterparty is now the quote itself — whoever published it — which is covered in
+/// <see cref="QuoteFillCounterpartyTests"/>.
 /// </para>
 /// </summary>
 public class MarketModeTests
@@ -34,7 +34,7 @@ public class MarketModeTests
         return new MarketModeProvider(configuration, NullLogger<MarketModeProvider>.Instance);
     }
 
-    /// <summary>بدون هیچ تنظیمی، رفتار تاریخی سیستم حفظ می‌شود: دفتر سفارش.</summary>
+    /// <summary>With no configuration at all, the historical behaviour holds: the order book.</summary>
     [Fact]
     public void WithNoConfiguration_TheModeIsOrderBook()
     {
@@ -42,8 +42,8 @@ public class MarketModeTests
     }
 
     /// <summary>
-    /// تنظیم قدیمی باید همچنان کار کند. اگر کسی آن را روشن کرده بود، نباید با این تغییر
-    /// بی‌صدا خاموش شود.
+    /// The old setting must keep working. Anyone who had turned it on must not have it silently
+    /// turned off by this change.
     /// </summary>
     [Fact]
     public void TheLegacyMarketMakerSettingStillMeansDealerMode()
@@ -53,7 +53,7 @@ public class MarketModeTests
         Assert.Equal(MarketMode.Dealer, provider.GetMode(Symbol));
     }
 
-    /// <summary>تنظیم مخصوص یک نماد بر تنظیم سراسری اولویت دارد.</summary>
+    /// <summary>A symbol's own setting takes precedence over the global one.</summary>
     [Fact]
     public void APerSymbolSettingOverridesTheGlobalOne()
     {
@@ -65,8 +65,9 @@ public class MarketModeTests
     }
 
     /// <summary>
-    /// دو نماد می‌توانند همزمان در دو حالت باشند — همان چیزی که «همزیستی» در issue #48
-    /// یعنی: یک نماد مظنه‌ای بماند و نماد دیگری با نقدینگی واقعی به دفتر سفارش برود.
+    /// Two symbols can be in two different modes at once — which is what coexistence means in
+    /// issue #48: one symbol stays on quotes while another, with real liquidity, moves to the order
+    /// book.
     /// </summary>
     [Fact]
     public void TwoSymbolsCanRunInDifferentModes()
@@ -79,7 +80,7 @@ public class MarketModeTests
         Assert.Equal(MarketMode.OrderBook, provider.GetMode("BTC/IRT"));
     }
 
-    /// <summary>مقدار نامعتبر نباید باعث استثنا شود؛ به رفتار پیش‌فرض برمی‌گردیم.</summary>
+    /// <summary>An invalid value must not throw; it falls back to the default.</summary>
     [Fact]
     public void AnUnrecognisedModeFallsBackInsteadOfThrowing()
     {

--- a/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
@@ -13,17 +13,17 @@ using TallaEgg.AllServices.Tests.Fakes;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// پردازشگر outbox باید دقیقاً پیام‌هایی را بردارد که «سررسید» شده‌اند، و هیچ‌کدام از
-/// بقیه را (issue #46).
+/// The outbox processor must pick up exactly the messages that are due, and none of the others
+/// (issue #46).
 ///
-/// این انتخاب تنها چیزی است که میان «تلاش مجدد» و «تلاش بی‌وقفه» فرق می‌گذارد. عقب‌نشینی
-/// نمایی در <see cref="OutboxMessageTests"/> ثابت شده — ولی آن فقط <c>NextAttemptAt</c> را
-/// جلو می‌برد. اگر کوئری آن را نادیده بگیرد، عقب‌نشینی هیچ اثری ندارد و پیامی که سرویس
-/// کیف پول را از پا انداخته، هر پنج ثانیه دوباره به آن می‌کوبد تا سهمیهٔ تلاشش تمام شود.
+/// This selection is the only thing separating a retry from an unbroken hammering. Exponential
+/// backoff is proven in <see cref="OutboxMessageTests"/> — but that only advances
+/// <c>NextAttemptAt</c>. If the query ignores it, the backoff has no effect and a message that
+/// felled the wallet service keeps hitting it every five seconds until its attempts run out.
 ///
-/// همین‌طور یک پیام <c>Failed</c> نباید دوباره برداشته شود: برداشتنش یعنی مسیر re-drive
-/// دستی (#39) بی‌معنا می‌شود، چون سیستم خودش کاری را که اپراتور باید آگاهانه انجام بدهد
-/// تکرار می‌کند.
+/// Likewise a <c>Failed</c> message must not be picked up again: doing so would make the manual
+/// re-drive path (#39) meaningless, since the system would keep repeating the very action an
+/// operator is supposed to take deliberately.
 /// </summary>
 public class OutboxDueSelectionTests : IDisposable
 {
@@ -57,7 +57,7 @@ public class OutboxDueSelectionTests : IDisposable
         _connection.Dispose();
     }
 
-    /// <summary>هر تسویه را می‌پذیرد و شناسهٔ معامله‌ای که برایش صدا زده شده را نگه می‌دارد.</summary>
+    /// <summary>Accepts every settlement and records the trade id it was called for.</summary>
     private sealed class RecordingWalletClient : StubWalletApiClient
     {
         public List<Guid> SettledTradeIds { get; } = [];
@@ -80,7 +80,7 @@ public class OutboxDueSelectionTests : IDisposable
             QuoteQuantity = 184_680_733m
         });
 
-    /// <summary>یک پیام ذخیره می‌کند و اجازه می‌دهد پیش از ذخیره حالتش دستکاری شود.</summary>
+    /// <summary>Stores one message, allowing its state to be adjusted before saving.</summary>
     private (Guid MessageId, Guid TradeId) Seed(string type = "TradeSettlement", Action<OutboxMessage>? arrange = null)
     {
         using var db = new OrdersDbContext(Options());
@@ -107,7 +107,7 @@ public class OutboxDueSelectionTests : IDisposable
         return await db.OutboxMessages.SingleAsync(m => m.Id == messageId);
     }
 
-    // ── چه چیزی برداشته می‌شود ──────────────────────────────────────────────────
+    // ── What gets picked up ─────────────────────────────────────────────────────
 
     [Fact]
     public async Task AFreshPendingMessage_IsProcessed()
@@ -121,9 +121,9 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// پیامی که یک بار شکست خورده تا لحظهٔ سررسیدش کنار گذاشته می‌شود. بدون این فیلتر،
-    /// عقب‌نشینی نمایی فقط یک عدد در دیتابیس است و هیچ فشاری از سرویسِ در حال خفگی برداشته
-    /// نمی‌شود.
+    /// A message that has failed once is skipped until it comes due. Without this filter,
+    /// exponential backoff is just a number in the database and takes no pressure off a service that
+    /// is already struggling.
     /// </summary>
     [Fact]
     public async Task APendingMessageWhoseRetryIsNotDueYet_IsSkipped()
@@ -140,8 +140,8 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// پیامِ به‌طور دائم شکست‌خورده کنار گذاشته می‌شود. اگر برداشته می‌شد، هم لاگ «تسویه
-    /// گیر کرده» بی‌پایان تکرار می‌شد و هم re-drive اپراتور بی‌معنا می‌شد.
+    /// A permanently failed message is skipped. Picking it up would repeat the "settlement stuck"
+    /// log without end and make an operator's re-drive meaningless.
     /// </summary>
     [Fact]
     public async Task AFailedMessage_IsSkipped()
@@ -161,9 +161,8 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// پیام رهاشده (issue #39) هم باید کنار گذاشته شود — دقیقاً به همان دلیل پیام
-    /// <c>Failed</c>: برداشتنش یعنی تصمیم آگاهانهٔ اپراتور («این هرگز تسویه نمی‌شود») را
-    /// دور می‌زند.
+    /// An abandoned message (issue #39) is skipped too, for the same reason as a <c>Failed</c> one:
+    /// picking it up would override an operator's deliberate decision that it will never settle.
     /// </summary>
     [Fact]
     public async Task AnAbandonedMessage_IsSkipped()
@@ -182,8 +181,8 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// پیام تکمیل‌شده دوباره فرستاده نمی‌شود. تسویه تکرارپذیر است، پس این ایمنی است نه
-    /// درستی — ولی هر تحویل مجدد یک فراخوانی HTTP بیهوده به سرویس کیف پول است.
+    /// A completed message is not redelivered. Settlement is idempotent, so this is safety rather
+    /// than correctness — but every redelivery is a pointless HTTP call to the wallet service.
     /// </summary>
     [Fact]
     public async Task ACompletedMessage_IsSkipped()
@@ -197,9 +196,9 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// پیامی که سررسیدش رسیده باید برداشته شود — وگرنه فیلتر بالا به «هرگز تلاش مجدد نکن»
-    /// تبدیل می‌شود و همان تسویهٔ گیرکرده‌ای ساخته می‌شود که outbox قرار بود جلویش را
-    /// بگیرد. سررسید با گذاشتن آن در گذشته شبیه‌سازی می‌شود تا تست منتظر نماند.
+    /// A message that has come due must be picked up — otherwise the filter above becomes "never
+    /// retry" and produces exactly the stuck settlement the outbox exists to prevent. Being due is
+    /// simulated by placing the timestamp in the past, so the test does not have to wait.
     /// </summary>
     [Fact]
     public async Task APendingMessageWhoseRetryHasComeDue_IsProcessed()
@@ -213,15 +212,15 @@ public class OutboxDueSelectionTests : IDisposable
         Assert.Equal(OutboxMessageStatus.Completed, (await ReloadAsync(messageId)).Status);
     }
 
-    // ── نوع ناشناخته ────────────────────────────────────────────────────────────
+    // ── Unknown message type ────────────────────────────────────────────────────
 
     /// <summary>
-    /// نوع پیامی که مسیری برایش تعریف نشده باید صریحاً رد شود، نه بی‌صدا تکمیل.
+    /// A message type with no dispatch path must be refused explicitly, not silently completed.
     ///
-    /// اگر <c>default</c> پیام را <c>Completed</c> علامت می‌زد، افزودن نوع جدیدی از پیام —
-    /// بدون نوشتن مسیرش — به صف پاک‌شده‌ای می‌رسید که هیچ کاری انجام نداده بود، و هیچ ردی
-    /// هم باقی نمی‌ماند. پیام خطا باید نوع را نام ببرد، چون همان تنها سرنخِ اپراتور در
-    /// <c>LastError</c> است.
+    /// If <c>default</c> marked the message <c>Completed</c>, adding a new message type without
+    /// writing its dispatch path would produce a drained queue that had done nothing, leaving no
+    /// trace. The error message has to name the type, because that is the operator's only clue in
+    /// <c>LastError</c>.
     /// </summary>
     [Fact]
     public async Task AnUnknownMessageType_FailsLoudlyAndNamesTheType()
@@ -239,8 +238,8 @@ public class OutboxDueSelectionTests : IDisposable
     }
 
     /// <summary>
-    /// محتوای خراب هم باید همین‌طور رفتار کند: یک تلاش ناموفقِ ثبت‌شده، نه استثنایی که از
-    /// حلقه بیرون بزند و بقیهٔ دسته را زمین بگذارد.
+    /// Malformed content behaves the same way: a recorded failed attempt, not an exception that
+    /// escapes the loop and drops the rest of the batch.
     /// </summary>
     [Fact]
     public async Task AnUndeserializablePayload_IsRecordedAsAFailedAttempt()

--- a/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orders.Core;
@@ -8,16 +8,16 @@ using TallaEgg.Core.Enums.Order;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// سفارشی که هنوز تأیید نشده نباید وارد تطبیق شود.
+/// An unconfirmed order must not enter matching.
 ///
-/// این ریشهٔ یافتهٔ ممیزی C-5 است. سفارش لحظه‌ای که ذخیره می‌شود <c>Pending</c> است —
-/// پیش از آنکه وثیقه‌اش قفل شود. پیش‌تر پرس‌وجوهای دفتر سفارش <c>Pending</c> را هم
-/// برمی‌گرداندند، پس حلقهٔ پس‌زمینه (هر ثانیه) می‌توانست سفارشی را بردارد که هیچ وثیقه‌ای
-/// پشتش نبود و معامله‌ای ثبت کند که تسویه‌اش هرگز موفق نمی‌شد.
+/// This is the root of audit finding C-5. An order is <c>Pending</c> from the moment it is saved,
+/// which is before its collateral is locked. The order-book queries used to return <c>Pending</c>
+/// orders too, so the background loop — running every second — could pick up an order with nothing
+/// backing it and record a trade that could never settle.
 ///
-/// حالا ترتیب «قفل، سپس تأیید، سپس تطبیق» است و فقط <c>Confirmed</c> دیده می‌شود — پس
-/// «هیچ معامله‌ای پیش از قفل وثیقه‌اش وجود ندارد» یک تضمین ساختاری است، نه یک قرارداد
-/// رفتاری که کد باید رعایتش کند.
+/// The order is now lock, then confirm, then match, and only <c>Confirmed</c> is visible — so "no
+/// trade exists before its collateral is locked" is a structural guarantee rather than a
+/// behavioural contract the code has to remember to honour.
 /// </summary>
 public class PendingOrderNotMatchableTests : IDisposable
 {
@@ -43,7 +43,7 @@ public class PendingOrderNotMatchableTests : IDisposable
         _connection.Dispose();
     }
 
-    /// <summary>سفارش را در وضعیت دلخواه می‌سازد. بدون Confirm، سفارش Pending می‌ماند.</summary>
+    /// <summary>Creates an order in the desired state. Without a confirm it stays Pending.</summary>
     private Order AddOrder(OrderSide side, bool confirm)
     {
         var order = Order.CreateMakerOrder(Symbol, 10m, 20_000_000m, Guid.NewGuid(), side, TradingType.Spot);
@@ -53,15 +53,15 @@ public class PendingOrderNotMatchableTests : IDisposable
         return order;
     }
 
-    // نکته دربارهٔ پوشش: GetBuyOrdersWithLockAsync و GetSellOrdersWithLockAsync اینجا
-    // مستقیماً تست نمی‌شوند، چون با ‎OrderBy(o => o.Price)‎ مرتب می‌کنند و SQLite مرتب‌سازی
-    // روی decimal را پشتیبانی نمی‌کند (روی SQL Server مشکلی نیست). هر دو از همان
-    // Expression مشترکِ Matchable استفاده می‌کنند که تست GetActiveAssetsAsync پایین آن
-    // را پوشش می‌دهد. این محدودیتِ محیط تست است، نه کد — و در #46 ثبت می‌شود.
+    // A note on coverage: GetBuyOrdersWithLockAsync and GetSellOrdersWithLockAsync are not tested
+    // directly here, because they sort with OrderBy(o => o.Price) and SQLite does not support
+    // ordering on decimal, which is fine on SQL Server. Both use the same shared Matchable
+    // expression that the GetActiveAssetsAsync test below covers. This is a limitation of the test
+    // environment rather than the code, and is recorded in #46.
 
     /// <summary>
-    /// حلقهٔ پس‌زمینه از این فهرست تصمیم می‌گیرد کدام دارایی‌ها را اسکن کند. اگر سفارش
-    /// Pending اینجا بیاید، موتور بیدار می‌شود تا روی سفارشی کار کند که هنوز وثیقه ندارد.
+    /// The background loop decides which assets to scan from this list. If a Pending order appears
+    /// here, the engine wakes up to work on an order that has no collateral yet.
     /// </summary>
     [Fact]
     public async Task PendingOrders_DoNotMakeAnAssetLookActive()
@@ -71,8 +71,8 @@ public class PendingOrderNotMatchableTests : IDisposable
         Assert.Empty(await _repository.GetActiveAssetsAsync());
     }
 
-    /// <summary>و سفارش تأییدشده باید همچنان دارایی را «فعال» نشان دهد — وگرنه تست بالا
-    /// با «هیچ‌چیز هرگز فعال نیست» هم سبز می‌ماند.</summary>
+    /// <summary>A confirmed order must still mark the asset active — otherwise the test above would
+    /// stay green under "nothing is ever active".</summary>
     [Fact]
     public async Task ConfirmedOrders_DoMakeAnAssetActive()
     {
@@ -82,14 +82,15 @@ public class PendingOrderNotMatchableTests : IDisposable
     }
 
     /// <summary>
-    /// دفاع در عمق: حتی اگر سفارشی از راه دیگری به تطبیق برسد، بازبینیِ داخل تراکنش هم
-    /// باید آن را رد کند. این تضمین می‌کند فیلترِ پرس‌وجو و بازبینیِ اتمی از هم جدا نشوند.
+    /// Defence in depth: even if an order reaches matching by another route, the in-transaction
+    /// re-check must refuse it. This keeps the query filter and the atomic re-check from drifting
+    /// apart.
     ///
-    /// مقدار تطبیق عمداً <b>کمتر</b> از مقدار سفارش است تا پر شدن جزئی رخ دهد.
-    /// با پر شدن کامل، <c>Order.Complete()</c> روی سفارش Pending استثنا می‌دهد و معامله
-    /// به‌طور تصادفی برگردانده می‌شود — یعنی تست حتی بدون این رفع هم سبز می‌ماند و چیزی
-    /// را ثابت نمی‌کند. مسیر پر شدن جزئی چنین گارد تصادفی‌ای ندارد، پس تنها همین حالت
-    /// واقعاً فیلتر را می‌سنجد.
+    /// The match quantity is deliberately <b>less</b> than the order quantity, producing a partial
+    /// fill. On a complete fill, <c>Order.Complete()</c> throws against a Pending order and the trade
+    /// is rolled back incidentally — so the test would stay green even without the fix and prove
+    /// nothing. The partial-fill path has no such accidental guard, so only this case actually
+    /// exercises the filter.
     /// </summary>
     [Fact]
     public async Task APartialMatchAgainstAPendingOrder_IsRejectedInsideTheTransaction()
@@ -103,13 +104,13 @@ public class PendingOrderNotMatchableTests : IDisposable
         Assert.Null(trade);
         Assert.Empty(_context.Trades);
 
-        // پیام مشخص، تا رد شدن به دلیل دیگری با این اشتباه گرفته نشود.
+        // A specific message, so a refusal for some other reason cannot be mistaken for this one.
         Assert.Contains("وضعیت سفارشات", error);
     }
 
     /// <summary>
-    /// و مسیر عادی هنوز کار می‌کند — وگرنه تست‌های بالا با «هیچ‌چیز تطبیق نمی‌خورد» هم
-    /// سبز می‌ماندند.
+    /// And the normal path still works — otherwise the tests above would stay green under "nothing
+    /// ever matches".
     /// </summary>
     [Fact]
     public async Task TwoConfirmedOrders_StillMatch()

--- a/tests/TallaEgg.AllServices.Tests/PersianDateTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/PersianDateTests.cs
@@ -1,22 +1,20 @@
-using TallaEgg.Core.Utilties;
+﻿using TallaEgg.Core.Utilties;
 
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// تبدیل تاریخ میلادی به شمسی.
+/// Gregorian to Jalali date conversion.
 ///
-/// نسخهٔ قبلی سال را ۶۲۱ واحد کم می‌کرد و ماه را جابه‌جا می‌کرد، اما روزِ میلادی را
-/// دست‌نخورده برمی‌گرداند. نتیجه‌اش این بود که کاربر تاریخ معاملهٔ خودش را تا ۲۲ روز
-/// اشتباه می‌دید — مثلاً ۲۷ ژوئیهٔ ۲۰۲۶ به‌جای «۵ مرداد» به‌صورت «۲۷ مرداد» نمایش
-/// داده می‌شد.
+/// The previous version subtracted 621 from the year and shifted the month, but returned the
+/// Gregorian day unchanged. A user could see their own trade dated up to 22 days out: 27 July 2026
+/// displayed as the 27th of the Jalali month instead of the 5th.
 ///
-/// همچنین زمان‌ها در دیتابیس UTC ذخیره می‌شوند و بدون تبدیل، ساعت اشتباه نمایش داده
-/// می‌شد.
+/// Times are also stored in UTC, and without conversion the wrong hour was displayed.
 /// </summary>
 public class PersianDateTests
 {
     /// <summary>
-    /// همان تاریخی که باگ روی آن دیده شد. ۲۷ ژوئیهٔ ۲۰۲۶ = ۵ مرداد ۱۴۰۵.
+    /// The date the bug was spotted on: 27 July 2026 is 5 Mordad 1405.
     /// </summary>
     [Fact]
     public void TheDateThatExposedTheBug_ConvertsCorrectly()
@@ -29,8 +27,8 @@ public class PersianDateTests
     }
 
     /// <summary>
-    /// چند تاریخ مرزی. مرز ماه‌ها و مرز سال جایی است که محاسبهٔ «تقریبی» قبلی بیشترین
-    /// خطا را داشت.
+    /// A few boundary dates. Month and year boundaries are where the previous approximation was
+    /// most wrong.
     /// </summary>
     [Theory]
     [InlineData(2026, 3, 21, "1405/01/01")] // نوروز ۱۴۰۵
@@ -40,8 +38,8 @@ public class PersianDateTests
     [InlineData(2026, 12, 31, "1405/10/10")]
     public void KnownDates_ConvertCorrectly(int year, int month, int day, string expected)
     {
-        // ساعت ۱۲ ظهر UTC انتخاب شده تا افست +۳:۳۰ تهران روز را جابه‌جا نکند و تست
-        // دربارهٔ خودِ تبدیل تقویم باشد، نه دربارهٔ مرز نیمه‌شب.
+        // Midday UTC is used so Tehran's +03:30 offset cannot shift the day, keeping the test about
+        // the calendar conversion rather than the midnight boundary.
         var utc = new DateTime(year, month, day, 12, 0, 0, DateTimeKind.Utc);
 
         var result = Utils.ConvertToPersianDate(utc);
@@ -50,8 +48,8 @@ public class PersianDateTests
     }
 
     /// <summary>
-    /// ساعت باید به وقت تهران باشد. معامله‌ای که ۰۹:۵۲ به وقت UTC ثبت شده، برای کاربر
-    /// ایرانی ۱۳:۲۲ اتفاق افتاده است.
+    /// The time must be Tehran's. A trade recorded at 09:52 UTC happened at 13:22 for an Iranian
+    /// user.
     /// </summary>
     [Fact]
     public void TimeIsShownInTehranTime_NotUtc()
@@ -64,9 +62,9 @@ public class PersianDateTests
     }
 
     /// <summary>
-    /// تبدیل منطقهٔ زمانی می‌تواند تاریخ را هم عوض کند: ۲۲:۰۰ به وقت UTC یعنی ۰۱:۳۰
-    /// روز بعد در تهران. اگر فقط ساعت تبدیل می‌شد و تاریخ از UTC می‌آمد، این حالت
-    /// یک روز عقب نمایش داده می‌شد.
+    /// A time-zone conversion can change the date too: 22:00 UTC is 01:30 the next day in Tehran. If
+    /// only the time were converted while the date came from UTC, this case would display a day
+    /// behind.
     /// </summary>
     [Fact]
     public void LateUtcEvening_RollsOverToTheNextPersianDay()

--- a/tests/TallaEgg.AllServices.Tests/QuarantinedStubTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/QuarantinedStubTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wallet.Application;
@@ -9,26 +9,25 @@ using Wallet.Infrastructure;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// چیزی که پشت قرنطینهٔ <c>POST /api/wallet/transaction/trade</c> است (یافتهٔ ممیزی C-8،
+/// What sits behind the <c>POST /api/wallet/transaction/trade</c> quarantine (audit finding C-8,
 /// issue #46).
 ///
-/// این تست‌ها جایگزین <c>Wallet.Api/Tests/QuarantinedEndpointsTests.cs</c> هستند که حذف شد.
-/// آن فایل دو مشکل داشت: اصلاً کامپایل نمی‌شد (پروژهٔ Wallet.Api نه NUnit دارد نه Moq، و
-/// <c>Results.StatusCode</c> اورلودی با دو آرگومان ندارد)، و مهم‌تر اینکه در
-/// <c>Setup</c> خودش یک <c>WebApplication</c> تازه می‌ساخت و <b>همان endpoint را دوباره
-/// می‌نوشت</b> — یعنی نسخه‌ای را می‌سنجید که در خود فایل تست تعریف شده بود، نه چیزی که در
-/// <c>Program.cs</c> اجرا می‌شود. حتی اگر endpoint واقعی حذف می‌شد، آن تست‌ها سبز
-/// می‌ماندند.
+/// These replace <c>Wallet.Api/Tests/QuarantinedEndpointsTests.cs</c>, which was deleted. That file
+/// had two problems: it did not compile at all — Wallet.Api has neither NUnit nor Moq, and
+/// <c>Results.StatusCode</c> has no two-argument overload — and, more importantly, its <c>Setup</c>
+/// built a fresh <c>WebApplication</c> and <b>redefined the endpoint</b>, so it asserted against a
+/// copy declared inside the test file rather than what <c>Program.cs</c> actually runs. Deleting the
+/// real endpoint would have left those tests green.
 ///
-/// چرا خطر واقعی است: اگر پرچم <c>FeatureFlags:QuarantineStubEndpoints</c> خاموش شود،
-/// endpoint به <see cref="WalletService.MakeTradeAsync"/> می‌رسد — و آن متد
-/// <c>new WalletBallanceDTO()</c> برمی‌گرداند، یعنی <b>HTTP 200 با اعداد صفر</b>، بدون
-/// اینکه ریالی جابه‌جا شود. برای فراخوان، این از ۵۰۱ بدتر است: شکستِ خاموش به‌جای رد
-/// صریح.
+/// Why the risk is real: turn <c>FeatureFlags:QuarantineStubEndpoints</c> off and the endpoint
+/// reaches <see cref="WalletService.MakeTradeAsync"/> — which returns
+/// <c>new WalletBallanceDTO()</c>, meaning <b>HTTP 200 with zeroes</b> and not a single unit of
+/// currency moved. To the caller that is worse than a 501: a silent failure instead of an explicit
+/// refusal.
 ///
-/// این تست‌ها همان را پین می‌کنند. اگر روزی <c>MakeTradeAsync</c> واقعاً پیاده‌سازی شود،
-/// این فایل می‌شکند — و درست است که بشکند: همان تغییر باید قرنطینه را هم بردارد و این
-/// تست‌ها را با تست‌های واقعیِ انتقال جایگزین کند.
+/// These tests pin that. If <c>MakeTradeAsync</c> is ever genuinely implemented this file breaks —
+/// and it should: the same change must lift the quarantine and replace these tests with real
+/// transfer tests.
 /// </summary>
 public class QuarantinedStubTests : IDisposable
 {
@@ -76,8 +75,8 @@ public class QuarantinedStubTests : IDisposable
     }
 
     /// <summary>
-    /// ادعای اصلی: متد «موفق» برمی‌گردد ولی هیچ پولی جابه‌جا نمی‌کند. دقیقاً همین است که
-    /// قرنطینه را لازم می‌کند — یک متدی که خطا بدهد بی‌خطرتر بود.
+    /// The central claim: the method returns successfully while moving no money. That is precisely
+    /// what makes the quarantine necessary — a method that threw would be safer.
     /// </summary>
     [Fact]
     public async Task MakeTradeAsync_ReportsSuccessButMovesNoMoney()
@@ -92,9 +91,9 @@ public class QuarantinedStubTests : IDisposable
     }
 
     /// <summary>
-    /// خروجی نه‌تنها اشتباه است، بلکه <b>خالی</b> است: هر فراخوانی که موجودی قبل/بعد را
-    /// بخواند صفر می‌بیند و کد پیگیری هم ندارد. یعنی هیچ راهی نیست که فراخوان بفهمد چیزی
-    /// انجام نشده.
+    /// The result is not merely wrong but <b>empty</b>: any caller reading the before and after
+    /// balances sees zeroes, and there is no tracking code either. Nothing tells the caller that
+    /// nothing happened.
     /// </summary>
     [Fact]
     public async Task MakeTradeAsync_ReturnsAnEmptyResultWithNoTrackingCode()
@@ -107,8 +106,8 @@ public class QuarantinedStubTests : IDisposable
     }
 
     /// <summary>
-    /// دو گاردی که واقعاً کار می‌کنند باید بمانند — تنها اعتبارسنجی‌های این متد هستند و
-    /// تنها چیزی که پیاده‌سازی آینده می‌تواند بی‌سروصدا از دست بدهد.
+    /// The two guards that do work must stay — they are this method's only validation, and the only
+    /// thing a future implementation could quietly lose.
     /// </summary>
     [Fact]
     public async Task MakeTradeAsync_StillRefusesATransferToSelf()

--- a/tests/TallaEgg.AllServices.Tests/QuoteTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/QuoteTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orders.Core;
@@ -8,8 +8,8 @@ using TallaEgg.Core.Enums.Order;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// مظنهٔ ادمین: قیمتی که منتشر می‌شود، بدون اینکه سفارشی در دفتر بگذارد یا وثیقه‌ای
-/// قفل کند (issue #48).
+/// The admin's quote: a published price that places no order in the book and locks no collateral
+/// (issue #48).
 /// </summary>
 public class QuoteTests : IDisposable
 {
@@ -36,11 +36,11 @@ public class QuoteTests : IDisposable
         _connection.Dispose();
     }
 
-    // ── قیمت‌گذاری ──────────────────────────────────────────────────────────────
+    // ── Pricing ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// مشتری از ادمین می‌خرد، پس قیمتِ <b>فروشِ</b> ادمین را می‌پردازد. جابه‌جا کردن این
-    /// دو، همان باگ وارونگی خریدار/فروشنده است با لباس دیگر.
+    /// A customer buys from the admin, so they pay the admin's <b>sell</b> price. Swapping the two is
+    /// the buyer/seller inversion bug wearing a different hat.
     /// </summary>
     [Fact]
     public void CustomerBuyingPaysTheAdminsSellPrice()
@@ -59,8 +59,8 @@ public class QuoteTests : IDisposable
     }
 
     /// <summary>
-    /// اسپرد منفی یعنی ادمین گران‌تر می‌خرد از آنچه می‌فروشد. مشتری می‌توانست بی‌نهایت بار
-    /// بخرد و بفروشد و هر بار سود کند — مستقیماً از جیب طلافروش.
+    /// A negative spread means the admin buys higher than they sell. A customer could buy and sell
+    /// endlessly, profiting every time, straight out of the shop's pocket.
     /// </summary>
     [Fact]
     public void ANegativeSpreadIsRejected()
@@ -71,7 +71,7 @@ public class QuoteTests : IDisposable
         Assert.Contains("قیمت خرید", ex.Message);
     }
 
-    /// <summary>اسپرد صفر مجاز است — ادمین بدون حاشیه معامله می‌کند، ولی ضرر نمی‌کند.</summary>
+    /// <summary>A zero spread is allowed: the admin trades at no margin, but does not lose.</summary>
     [Fact]
     public void AZeroSpreadIsAllowed()
     {
@@ -89,7 +89,7 @@ public class QuoteTests : IDisposable
         Assert.Throws<ArgumentException>(() => Quote.Publish(Symbol, 17_000_000m, badPrice, Admin));
     }
 
-    // ── انتشار ──────────────────────────────────────────────────────────────────
+    // ── Publishing ──────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task PublishingMakesTheQuoteReadable()
@@ -103,8 +103,8 @@ public class QuoteTests : IDisposable
     }
 
     /// <summary>
-    /// انتشار مظنهٔ جدید باید قبلی را کنار بگذارد. اگر دو مظنه فعال بمانند، معلوم نیست
-    /// مشتری روی کدام قیمت معامله می‌کند.
+    /// Publishing a new quote must retire the previous one. With two active quotes it is undefined
+    /// Which price the customer trades at.
     /// </summary>
     [Fact]
     public async Task PublishingAgainReplacesThePreviousQuote()
@@ -119,8 +119,8 @@ public class QuoteTests : IDisposable
     }
 
     /// <summary>
-    /// مظنهٔ قدیمی حذف نمی‌شود؛ فقط غیرفعال می‌شود — تا بعداً بشود فهمید هر معامله روی چه
-    /// قیمتی انجام شده.
+    /// An old quote is deactivated rather than deleted, so it stays possible to find out what price
+    /// a past trade used.
     /// </summary>
     [Fact]
     public async Task ThePreviousQuoteIsKeptAsHistory()
@@ -132,7 +132,7 @@ public class QuoteTests : IDisposable
         Assert.Equal(1, await _context.Quotes.CountAsync(q => !q.IsActive && q.DeactivatedAt != null));
     }
 
-    /// <summary>نمادها بر هم اثر نمی‌گذارند: انتشار برای یکی، مظنهٔ دیگری را کنار نمی‌زند.</summary>
+    /// <summary>Symbols do not affect each other: publishing for one does not displace another's quote.</summary>
     [Fact]
     public async Task PublishingForOneSymbolLeavesAnotherAlone()
     {
@@ -149,7 +149,7 @@ public class QuoteTests : IDisposable
         Assert.Null(await _repository.GetActiveAsync(Symbol));
     }
 
-    /// <summary>نماد باید بدون توجه به بزرگی و کوچکی حروف پیدا شود.</summary>
+    /// <summary>A symbol must be found regardless of case.</summary>
     [Fact]
     public async Task SymbolLookupIsCaseInsensitive()
     {

--- a/tests/TallaEgg.AllServices.Tests/SettlementBranchTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SettlementBranchTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wallet.Core;
@@ -7,18 +7,18 @@ using Wallet.Infrastructure;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// شاخه‌های <c>SettleTradeAsync</c> که مسیر خوشبینانه به آن‌ها نمی‌رسد (issue #46).
+/// The <c>SettleTradeAsync</c> branches the happy path never reaches (issue #46).
 ///
-/// <see cref="SettleTradeAsyncTests"/> مسیر موفق، تکرارپذیری، خودمعاملگی، کارمزد غیرصفر و
-/// وثیقهٔ قفل‌نشده را پوشش می‌دهد. آنچه اینجا اضافه می‌شود سه شاخهٔ باقی‌مانده است: نبودِ
-/// کیف پول یکی از طرفین، نماد بدشکل، و تسویه‌ای که پشتوانه‌اش اعتبار است (موجودی در دسترسِ
-/// منفی).
+/// <see cref="SettleTradeAsyncTests"/> covers the successful path, idempotency, self-trading,
+/// non-zero fees and unlocked collateral. What this adds is the three remaining branches: a missing
+/// wallet on one side, a malformed symbol, and a settlement backed by credit, where the available
+/// balance is negative.
 ///
-/// شاخهٔ سوم مهم‌ترین است: تا امروز فقط با معاملهٔ دستی روی محیط توسعه دیده شده بود.
-/// <c>ConsumeLockedBalance</c> دقیقاً برای همین حالت نوشته شد — اگر کسی آن را با
-/// <c>UnLockBalance</c> + <c>DecreaseBalance</c> جایگزین کند، گاردِ «موجودی منفی نشود» در
-/// <c>DecreaseBalance</c> فعال می‌شود و تسویهٔ هر مشتری بدهکار شکست می‌خورد — بدون اینکه
-/// هیچ تست دیگری بشکند.
+/// The third branch matters most: until now it had only been seen through manual trading on a
+/// development machine. <c>ConsumeLockedBalance</c> exists precisely for it — replace that call
+/// with <c>UnLockBalance</c> followed by <c>DecreaseBalance</c> and the non-negative guard in
+/// <c>DecreaseBalance</c> fires, failing settlement for every customer in debt, while no other test
+/// breaks.
 /// </summary>
 public class SettlementBranchTests : IDisposable
 {
@@ -78,23 +78,22 @@ public class SettlementBranchTests : IDisposable
         _repository.SettleTradeAsync(
             tradeId, _buyerId, _sellerId, symbol, Quantity, QuoteQuantity, feeBuyer: 0m, feeSeller: 0m);
 
-    // ── کیف پول ناموجود ─────────────────────────────────────────────────────────
+    // ── Missing wallet ──────────────────────────────────────────────────────────
 
     /// <summary>
-    /// تسویه چهار کیف پول لازم دارد. کیف پول «برای دریافت» ممکن است هرگز ساخته نشده باشد —
-    /// مشتری‌ای که تا امروز فقط تومان داشته، کیف پول طلا ندارد.
+    /// Settlement needs four wallets. The receiving wallet may never have been created — a customer
+    /// who has only ever held toman has no gold wallet.
     ///
-    /// این دقیقاً همان چیزی بود که در محیط واقعی خرید اول یک نماد جدید (مثل BTC/IRT) را رد
-    /// می‌کرد — وثیقهٔ فروشنده قبلاً قفل شده بود، ولی چون کیف پول طلای خریدار وجود نداشت
-    /// کل تسویه با «wallets were not found» رول‌بک می‌شد و وثیقه بدون معاملهٔ کامل قفل
-    /// می‌ماند. رفتار درست این است: کیف پولِ ناموجود (برای دارایی معتبر) در همان لحظه ساخته
-    /// شود و تسویه کامل انجام شود، همان‌طور که کیف پول تومان/طلا در ثبت‌نام لِیزی ساخته
-    /// می‌شود.
+    /// This is exactly what refused the first purchase of a new symbol in the live environment: the
+    /// seller's collateral was already locked, but because the buyer had no wallet for the asset the
+    /// whole settlement rolled back with "wallets were not found", leaving collateral locked against
+    /// a trade that never completed. The correct behaviour is to create the missing wallet — for a
+    /// valid asset — on the spot and settle, the same way registration creates wallets lazily.
     /// </summary>
     [Fact]
     public async Task WhenAParticipantWalletIsMissing_ItIsCreatedAndSettlementSucceeds()
     {
-        // کیف پول طلای خریدار ساخته نشده — همان کیفی که باید طلا را دریافت کند.
+        // The buyer has no gold wallet — the very wallet that should receive the gold.
         SeedWallet(_buyerId, Quote, balance: 0m, locked: QuoteQuantity);
         SeedWallet(_sellerId, Base, balance: 0m, locked: Quantity);
         SeedWallet(_sellerId, Quote, balance: 0m, locked: 0m);
@@ -118,9 +117,9 @@ public class SettlementBranchTests : IDisposable
     }
 
     /// <summary>
-    /// یک نماد بدشکل که هیچ‌کدام از دو طرفش دارایی واقعی نیست (پس نه فقط ناموجود بلکه
-    /// ناشناخته) نباید کیف پول جعلی بسازد — همان گاردِ <c>IsValidCurrency</c> که در سطح
-    /// شارژ ادمین هم اعمال می‌شود.
+    /// A malformed symbol whose sides are not real assets — unknown rather than merely missing —
+    /// must not create phantom wallets. That is the <c>IsValidCurrency</c> guard, the same one the
+    /// admin top-up path applies.
     /// </summary>
     [Fact]
     public async Task WhenAParticipantWalletIsMissingForAnUnknownAsset_NothingMoves()
@@ -144,15 +143,16 @@ public class SettlementBranchTests : IDisposable
         Assert.Equal(0, await _context.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
     }
 
-    // ── نماد بدشکل ──────────────────────────────────────────────────────────────
+    // ── Malformed symbol ────────────────────────────────────────────────────────
 
     /// <summary>
-    /// نماد باید دقیقاً <c>BASE/QUOTE</c> باشد. کد قبلاً جاهایی <c>Split('/')[1]</c> کورکورانه
-    /// می‌نوشت؛ با نماد بدشکل آن یک <c>IndexOutOfRangeException</c> می‌شد که در پردازشگر
-    /// outbox به «تلاش ناموفق» ترجمه می‌شد و پنج بار تکرار می‌شد — در حالی که تکرار هرگز
-    /// نمی‌توانست کمکی کند، چون داده خراب بود نه شرایط.
+    /// A symbol must be exactly <c>BASE/QUOTE</c>. The code used to write <c>Split('/')[1]</c>
+    /// blindly in places; against a malformed symbol that became an
+    /// <c>IndexOutOfRangeException</c>, which the outbox processor read as a failed attempt and
+    /// retried five times — retries that could never help, because the data was bad, not the
+    /// conditions.
     ///
-    /// یک رد صریح، همان اشتباه را در همان تلاش اول قابل‌فهم می‌کند.
+    /// An explicit refusal makes the same mistake legible on the first attempt.
     /// </summary>
     [Theory]
     [InlineData("MAUA")]        // بدون جداکننده
@@ -177,8 +177,9 @@ public class SettlementBranchTests : IDisposable
     }
 
     /// <summary>
-    /// نماد درست ولی با حروف کوچک و فاصله باید پذیرفته شود. اگر نرمال‌سازی حذف شود، این
-    /// تسویه با «کیف پول پیدا نشد» رد می‌شود — خطایی که علتش هیچ ربطی به کیف پول ندارد.
+    /// A valid symbol in lower case and with surrounding spaces must be accepted. Remove the
+    /// normalisation and this settlement fails with "wallet not found" — an error whose cause has
+    /// nothing to do with wallets.
     /// </summary>
     [Fact]
     public async Task AWellFormedSymbolIsNormalised_SoCaseAndSpacingDoNotBreakSettlement()
@@ -191,22 +192,23 @@ public class SettlementBranchTests : IDisposable
         Assert.Equal(Quantity, (await ReloadAsync(_buyerId, Base)).Balance);
     }
 
-    // ── تسویهٔ پشتوانه‌شده با اعتبار ─────────────────────────────────────────────
+    // ── Credit-backed settlement ────────────────────────────────────────────────
 
     /// <summary>
-    /// خریدار تومان ندارد و با اعتبار می‌خرد: هنگام قفلِ وثیقه موجودی در دسترسش منفی شده
-    /// است. تسویه باید انجام شود و بدهی روی <c>Balance</c> بماند.
+    /// The buyer holds no toman and buys on credit: locking the collateral already drove their
+    /// available balance negative. Settlement must succeed, and the debt must remain on
+    /// <c>Balance</c>.
     ///
-    /// این همان حالتی است که <c>ConsumeLockedBalance</c> برایش نوشته شد. مسیر ساده‌تر —
-    /// <c>UnLockBalance</c> و بعد <c>DecreaseBalance</c> — همین‌جا شکست می‌خورد، چون
-    /// <c>DecreaseBalance</c> کف صفر دارد و موجودیِ منفی را رد می‌کند. یعنی هر مشتری بدهکار
-    /// تسویه‌اش گیر می‌کرد، و چون هیچ تست دیگری موجودی منفی ندارد، هیچ چیز دیگری این را
-    /// نمی‌گرفت.
+    /// This is the case <c>ConsumeLockedBalance</c> was written for. The simpler route —
+    /// <c>UnLockBalance</c> then <c>DecreaseBalance</c> — fails here, because
+    /// <c>DecreaseBalance</c> has a floor of zero and refuses a negative balance. Settlement would
+    /// stall for every customer in debt, and since no other test uses a negative balance, nothing
+    /// else would catch it.
     /// </summary>
     [Fact]
     public async Task ACreditBackedBuyer_SettlesAndKeepsTheDebtOnTheBalance()
     {
-        // مسیر واقعی: کیف پول با موجودی صفر، بعد قفل وثیقه — که موجودی را منفی می‌کند.
+        // The real sequence: a zero-balance wallet, then the collateral lock, which takes it negative.
         var buyerQuote = SeedWallet(_buyerId, Quote, balance: 0m, locked: 0m);
         buyerQuote.LockBalance(QuoteQuantity);
         SeedWallet(_buyerId, Base, balance: 0m, locked: 0m);
@@ -221,25 +223,25 @@ public class SettlementBranchTests : IDisposable
 
         Assert.True(success, message);
 
-        // قفل مصرف شد، ولی بدهی سر جایش ماند — پول از هیچ ساخته نشد.
+        // The lock was consumed but the debt remains — no money was created.
         var settledBuyerQuote = await ReloadAsync(_buyerId, Quote);
         Assert.Equal(0m, settledBuyerQuote.LockedBalance);
         Assert.Equal(-QuoteQuantity, settledBuyerQuote.Balance);
 
-        // و طلایی که خرید را واقعاً گرفت.
+        // And the buyer actually received the gold.
         Assert.Equal(Quantity, (await ReloadAsync(_buyerId, Base)).Balance);
 
-        // فروشنده تومانش را کامل گرفت: بدهکار بودنِ خریدار نباید از دریافتی او کم کند.
+        // The seller received their toman in full: the buyer being in debt must not reduce it.
         Assert.Equal(QuoteQuantity, (await ReloadAsync(_sellerId, Quote)).Balance);
 
         Assert.Equal(4, await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
     }
 
     /// <summary>
-    /// جمع ارزش خالص باید صفر بماند: آنچه خریدار بدهکار است دقیقاً همان چیزی است که
-    /// فروشنده گرفته، و طلایی که خریدار گرفته دقیقاً همان است که فروشنده داده.
+    /// Net value across both sides must stay zero: what the buyer owes is exactly what the seller
+    /// received, and the gold the buyer gained is exactly what the seller gave up.
     ///
-    /// این همان بررسی‌ای است که در جلسه‌های تست دستی با SQL دستی انجام می‌شد.
+    /// This is the same check that was previously run by hand in SQL during manual testing.
     /// </summary>
     [Fact]
     public async Task ACreditBackedSettlement_ConservesMoney()
@@ -257,7 +259,7 @@ public class SettlementBranchTests : IDisposable
         _context.ChangeTracker.Clear();
         var all = await _context.Wallets.ToListAsync();
 
-        // موجودی در دسترس + قفل‌شده، به تفکیک دارایی.
+        // Available plus locked balance, per asset.
         var gold = all.Where(w => w.Asset == Base).Sum(w => w.Balance + w.LockedBalance);
         var toman = all.Where(w => w.Asset == Quote).Sum(w => w.Balance + w.LockedBalance);
 

--- a/tests/TallaEgg.AllServices.Tests/SettlementUniquenessTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SettlementUniquenessTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wallet.Core;
@@ -7,15 +7,16 @@ using Wallet.Infrastructure;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// «هر معامله دقیقاً یک بار تسویه می‌شود» باید توسط دیتابیس تضمین شود، نه توسط ترتیب اجرای کد.
+/// "Every trade settles exactly once" must be guaranteed by the database, not by the order in which
+/// code happens to run.
 ///
-/// پیش‌تر تنها محافظ، یک SELECT بود که ۴۶ خط پیش از باز شدن تراکنش اجرا می‌شد و هیچ قید
-/// یکتایی پشتش نبود. دو تسویهٔ همزمان از یک معامله می‌توانستند هر دو از آن بررسی رد شوند
-/// و هر دو اعمال شوند — یعنی هر دو طرف دو برابر اعتبار می‌گرفتند و پول از هیچ ساخته
+/// The only protection used to be a SELECT running 46 lines before the transaction opened, with no
+/// uniqueness constraint behind it. Two concurrent settlements of one trade could both pass that
+/// check and both apply — crediting each side twice and creating money from
 /// می‌شد (issue #42).
 ///
-/// حالا TradeId کلید اصلی جدول TradeSettlements است و آن سطر داخل همان تراکنشِ جابه‌جایی
-/// پول درج می‌شود.
+/// TradeId is now the primary key of TradeSettlements, and that row is inserted inside the same
+/// transaction that moves the money.
 /// </summary>
 public class SettlementUniquenessTests : IDisposable
 {
@@ -32,14 +33,14 @@ public class SettlementUniquenessTests : IDisposable
     private const decimal QuoteQuantity = 1000m;
 
     /// <summary>
-    /// یک قلاب درست پیش از SaveChanges، برای بازسازی قطعی و بدون رقابتِ حالتی که رقیب
-    /// دقیقاً در بازهٔ بین «بررسی سریع» و «درج» ما commit کرده است.
+    /// A hook just before SaveChanges, to reproduce deterministically and without a real race the
+    /// case where a competitor commits in the window between our fast check and our insert.
     ///
-    /// چرا این روش و نه اجرای واقعی دو Task موازی: SQLite در حافظه روی یک اتصال، دو
-    /// تراکنش نوشتنِ همزمان را پشتیبانی نمی‌کند، پس تست موازی یا قفل می‌شد یا وابسته به
-    /// زمان‌بندی و ناپایدار می‌شد. آنچه باید اثبات شود این نیست که «رقابت رخ می‌دهد»،
-    /// بلکه این است که «وقتی رخ داد، دیتابیس جلویش را می‌گیرد و کد آن را درست ترجمه
-    /// می‌کند» — و این تست دقیقاً همان را با قید واقعی دیتابیس می‌سنجد.
+    /// Why this rather than genuinely running two parallel tasks: in-memory SQLite on a single
+    /// connection does not support two concurrent write transactions, so a parallel test would
+    /// either deadlock or become timing-dependent and flaky. What needs proving is not that a race
+    /// can happen, but that when it does the database stops it and the code translates that
+    /// correctly — which is exactly what this exercises, against the real constraint.
     /// </summary>
     private sealed class HookedWalletDbContext : WalletDbContext
     {
@@ -101,7 +102,7 @@ public class SettlementUniquenessTests : IDisposable
         return await _context.Wallets.SingleAsync(w => w.UserId == userId && w.Asset == asset);
     }
 
-    /// <summary>یک تسویهٔ عادی باید سطر تسویه را ثبت کند — پایهٔ همهٔ تضمین‌های بعدی.</summary>
+    /// <summary>An ordinary settlement must record its settlement row — the basis of every guarantee below.</summary>
     [Fact]
     public async Task Settlement_RecordsExactlyOneTradeSettlementRow()
     {
@@ -114,16 +115,16 @@ public class SettlementUniquenessTests : IDisposable
     }
 
     /// <summary>
-    /// مورد اصلی #42: رقیب پس از رد شدن ما از بررسی سریع، commit می‌کند. درج ما باید با
-    /// نقض کلید اصلی شکست بخورد و کل تراکنش برگردد.
+    /// The core case from #42: a competitor commits after we have passed the fast check. Our insert
+    /// must fail on the primary key and the whole transaction must roll back.
     /// </summary>
     [Fact]
     public async Task ConcurrentSettlement_IsRefusedByTheDatabase_AndReportedAsAlreadySettled()
     {
         var tradeId = Guid.NewGuid();
 
-        // رقیب: سطر تسویه را مستقیماً درج می‌کند، درست پیش از SaveChanges ما — یعنی همان
-        // لحظه‌ای که بررسی سریع ما از قبل رد شده و دیگر کاری از آن برنمی‌آید.
+        // The competitor inserts the settlement row directly, just before our SaveChanges — the
+        // moment at which our fast check has already passed and can no longer help.
         _context.BeforeSave = () =>
             _context.Database.ExecuteSqlRaw(
                 @"INSERT INTO TradeSettlements
@@ -133,16 +134,16 @@ public class SettlementUniquenessTests : IDisposable
 
         var (success, message) = await SettleAsync(tradeId);
 
-        // از دید فراخوان موفق است: معامله تسویه شده — فقط نه توسط ما.
-        // اگر خطا برمی‌گشت، پردازشگر outbox پنج بار retry می‌کرد و معاملهٔ سالم را
-        // به‌عنوان «گیرکرده» به اپراتور هشدار می‌داد.
+        // From the caller's point of view this succeeded: the trade is settled, just not by us.
+        // Returning an error would make the outbox processor retry five times and raise a healthy
+        // trade to an operator as stuck.
         Assert.True(success, message);
         Assert.Contains("already settled", message, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
-    /// مهم‌ترین ادعا: بازندهٔ رقابت نباید هیچ پولی جابه‌جا کرده باشد. این همان چیزی است
-    /// که #42 دربارهٔ آن بود — نه پیام خطا، بلکه دو برابر شدن موجودی.
+    /// The claim that matters most: the loser of the race must have moved no money at all. That is
+    /// what #42 was about — not an error message, but a doubled balance.
     /// </summary>
     [Fact]
     public async Task ConcurrentSettlement_LeavesBalancesAndTransactionsUntouched()
@@ -158,10 +159,10 @@ public class SettlementUniquenessTests : IDisposable
 
         await SettleAsync(tradeId);
 
-        // هیچ سطر تراکنشی نوشته نشده — نه اینکه نوشته و بعد جبران شده باشد.
+        // No transaction row was written at all — not written and then compensated.
         Assert.Equal(0, await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
 
-        // و موجودی‌ها دقیقاً همان حالت پیش از تسویه‌اند: وثیقه هنوز قفل، هیچ دارایی‌ای منتقل نشده.
+        // And the balances are exactly as they were before: collateral still locked, nothing moved.
         var buyerQuote = await ReloadAsync(_buyerId, Quote);
         var buyerBase = await ReloadAsync(_buyerId, Base);
         var sellerBase = await ReloadAsync(_sellerId, Base);
@@ -176,8 +177,8 @@ public class SettlementUniquenessTests : IDisposable
     }
 
     /// <summary>
-    /// تحویل مجدد عادی outbox (رقابتی در کار نیست) باید از مسیر سریع رد شود: بدون استثنا،
-    /// بدون تراکنش، و بدون نوشتن سطر دوم.
+    /// An ordinary outbox redelivery, with no race involved, must take the fast path: no exception,
+    /// no transaction, and no second row.
     /// </summary>
     [Fact]
     public async Task RedeliveryAfterSuccess_IsIdempotent_AndDoesNotDoubleApply()
@@ -193,14 +194,14 @@ public class SettlementUniquenessTests : IDisposable
         Assert.Equal(1, await _context.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
         Assert.Equal(4, await _context.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
 
-        // موجودی‌ها فقط یک بار جابه‌جا شده‌اند.
+        // The balances moved exactly once.
         Assert.Equal(Quantity, (await ReloadAsync(_buyerId, Base)).Balance);
         Assert.Equal(QuoteQuantity, (await ReloadAsync(_sellerId, Quote)).Balance);
     }
 
     /// <summary>
-    /// دو معاملهٔ متفاوت نباید همدیگر را مسدود کنند — قید یکتایی باید روی شناسهٔ معامله
-    /// باشد و نه چیزی که به‌طور اتفاقی بین معاملات مشترک است (مثل طرفین یا نماد).
+    /// Two different trades must not block each other — the uniqueness constraint has to be on the
+    /// trade id and not on something trades happen to share, such as the parties or the symbol.
     /// </summary>
     [Fact]
     public async Task DifferentTrades_BetweenTheSameParties_BothSettle()
@@ -208,10 +209,10 @@ public class SettlementUniquenessTests : IDisposable
         var firstTrade = Guid.NewGuid();
         var secondTrade = Guid.NewGuid();
 
-        // وثیقهٔ لازم برای معاملهٔ دوم را هم قفل می‌کنیم.
+        // Lock the collateral the second trade needs as well.
         //
-        // هر دو کیف پول در یک واحد کاری بارگذاری می‌شوند و بین آن‌ها ChangeTracker پاک
-        // نمی‌شود؛ در غیر این صورت موجودیت اول detach می‌شد و تغییرش هرگز ذخیره نمی‌شد.
+        // Both wallets are loaded in one unit of work and the ChangeTracker is not cleared between
+        // them; otherwise the first entity would detach and its change would never be saved.
         _context.ChangeTracker.Clear();
         var buyerQuote = await _context.Wallets.SingleAsync(w => w.UserId == _buyerId && w.Asset == Quote);
         var sellerBase = await _context.Wallets.SingleAsync(w => w.UserId == _sellerId && w.Asset == Base);

--- a/tests/TallaEgg.AllServices.Tests/SingleTradeCreationPathTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SingleTradeCreationPathTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Orders.Application.Services;
 using Orders.Core;
 using Orders.Infrastructure;
@@ -6,30 +6,29 @@ using Orders.Infrastructure;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// یک معاملهٔ تطبیق‌شده باید از یک مسیر ساخته شود، نه دو مسیر (issue #40).
+/// A matched trade must be created by one path, not two (issue #40).
 ///
-/// پیش‌تر دو جا <c>Trade.Create</c> را صدا می‌زدند:
-/// <c>MatchingEngineService.CreateMakerTakerTrade</c> با نرخ کارمزد <c>0.000</c>، و
-/// <c>OrderMatchingRepository.CreateTrade</c> با نرخ <c>0.001/0.002</c>. موتور اولی را
-/// می‌ساخت و دور می‌ریخت و بلافاصله دومی را — از طریق <c>ExecuteAtomicMatchAsync</c> —
-/// صدا می‌زد. نسخه‌ای که ذخیره و برای تسویه صف می‌شد همیشه دومی بود.
+/// Two places used to call <c>Trade.Create</c>:
+/// <c>MatchingEngineService.CreateMakerTakerTrade</c> with fee rates of <c>0.000</c>, and
+/// <c>OrderMatchingRepository.CreateTrade</c> with <c>0.001/0.002</c>. The engine built the first,
+/// threw it away, and immediately called the second through <c>ExecuteAtomicMatchAsync</c>. The
+/// version stored and queued for settlement was always the second.
 ///
-/// چرا این فقط «کد تکراری» نبود: خواندن کد موتور می‌گفت کارمزد صفر است، در حالی که معاملهٔ
-/// ذخیره‌شده کارمزد داشت — آن هم به واحد ارز مظنه. نتیجه‌اش این شد که تسویهٔ هر معامله با
-/// «کارمزد از مبلغ معامله بیشتر است» رد می‌شد و علتش در کدی پنهان بود که اصلاً اجرا
-/// نمی‌شد. تعریف نرخ در یک جا، ولی خوانده‌شدن از جای دیگر، دقیقاً همان چیزی است که این
-/// باگ را ساخت.
+/// Why this was more than duplicate code: reading the engine said the fees were zero, while the
+/// stored trade carried fees — denominated in the quote currency. Every settlement was then refused
+/// with "fee exceeds trade amount", and the cause was hidden in code that never ran. A rate defined
+/// in one place but read from another is exactly what produced the bug.
 ///
-/// این تست ساختاری است، نه رفتاری: نمی‌شود با اجرای یک تطبیق ثابت کرد که مسیر دومی وجود
-/// ندارد — مسیر دوم آن زمان هم اجرا می‌شد و هیچ تستی را نمی‌شکست، چون خروجی‌اش دور ریخته
-/// می‌شد. تنها چیزی که می‌تواند برگشتنش را بگیرد، شمردن جایگاه‌های فراخوانی است.
+/// This test is structural rather than behavioural: running a match cannot prove a second path does
+/// not exist — the second path ran back then too and broke no test, because its output was
+/// discarded. Counting call sites is the only thing that catches its return.
 /// </summary>
 public class SingleTradeCreationPathTests
 {
     /// <summary>
-    /// اسمبلی‌هایی که می‌توانند معامله بسازند. <c>Orders.Core</c> هم هست چون
-    /// <c>Trade.Create</c> آنجا تعریف شده و یک کارخانهٔ دوم در همان‌جا هم به‌اندازهٔ
-    /// کارخانه‌ای در لایهٔ بالاتر مشکل‌ساز است.
+    /// The assemblies that could create a trade. <c>Orders.Core</c> is included because
+    /// <c>Trade.Create</c> is defined there, and a second factory alongside it would be just as much
+    /// of a problem as one in a higher layer.
     /// </summary>
     private static readonly Assembly[] ProductionAssemblies =
     [
@@ -53,9 +52,9 @@ public class SingleTradeCreationPathTests
     }
 
     /// <summary>
-    /// نرخ کارمزد هم باید فقط در همان یک مسیر تعریف شود. اگر جای دیگری نرخ خودش را داشته
-    /// باشد، همان تناقضی برمی‌گردد که باعث شد کد یک عدد بگوید و پایگاه‌داده عدد دیگری
-    /// نشان بدهد — حتی اگر آن کد معامله‌ای نسازد و فقط نرخ را برای گزارش حساب کند.
+    /// Fee rates must also be defined only on that one path. A rate of its own anywhere else brings
+    /// back the contradiction where the code said one number and the database showed another — even
+    /// if that code creates no trade and only computes a rate for reporting.
     /// </summary>
     [Fact]
     public void MatchingEngine_DoesNotDeclareItsOwnFeeRates()
@@ -75,15 +74,15 @@ public class SingleTradeCreationPathTests
         Assert.DoesNotContain(engineMethods, m => m.ReturnType == typeof(Trade));
     }
 
-    // ── پیمایش IL ───────────────────────────────────────────────────────────────
+    // ── IL scanning ─────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// نام «تایپ.متد» هر جایی که <paramref name="target"/> را صدا می‌زند، مرتب‌شده.
+    /// The sorted Type.Method names of everywhere that calls <paramref name="target"/>.
     ///
-    /// متدهای async به یک ماشین حالتِ تولیدشدهٔ کامپایلر تبدیل می‌شوند، پس فراخوانی واقعی
-    /// داخل <c>MoveNext</c> یک تایپ تودرتوی مخفی می‌نشیند. اسم آن تایپ (مثلاً
-    /// <c>&lt;ExecuteAtomicMatchAsync&gt;d__12</c>) به تایپ و متد اصلی برگردانده می‌شود تا
-    /// پیام شکست تست قابل‌خواندن بماند.
+    /// Async methods compile into a generated state machine, so the real call sits inside
+    /// <c>MoveNext</c> on a hidden nested type. That type's name — for example
+    /// <c>&lt;ExecuteAtomicMatchAsync&gt;d__12</c> — is mapped back to the original type and method so
+    /// the failure message stays readable.
     /// </summary>
     private static string[] FindCallersOf(MethodInfo target) =>
         ProductionAssemblies
@@ -104,15 +103,15 @@ public class SingleTradeCreationPathTests
     private const byte OpCallvirt = 0x6F;
 
     /// <summary>
-    /// آیا بدنهٔ <paramref name="caller"/> شامل <c>call</c>/<c>callvirt</c> به
-    /// <paramref name="target"/> هست؟
+    /// Does <paramref name="caller"/>'s body contain a <c>call</c> or <c>callvirt</c> to
+    /// <paramref name="target"/>?
     ///
-    /// این پیمایش تقریبی است: هر بایت <c>0x28</c>/<c>0x6F</c> را می‌بیند و ۴ بایت بعدی را
-    /// به‌عنوان توکن متادیتا حل می‌کند، بدون اینکه طول دستورها را دقیق دنبال کند. یعنی
-    /// ممکن است بایتی که در واقع عملوند است را دستور بپندارد. برای این تست بی‌خطر است:
-    /// چنین تصادفی باید دقیقاً به <c>Trade.Create</c> حل شود تا مثبت کاذب بسازد، و از طرف
-    /// دیگر هیچ فراخوانی واقعی‌ای را از دست نمی‌دهد — که سمت مهم ماجراست، چون کار این تست
-    /// پیدا کردن مسیر دومِ برگشته است.
+    /// The scan is approximate: it looks for any <c>0x28</c> or <c>0x6F</c> byte and resolves the
+    /// following four bytes as a metadata token, without tracking instruction lengths exactly. It
+    /// could therefore mistake an operand byte for an opcode. That is harmless here: such a
+    /// coincidence would have to resolve to <c>Trade.Create</c> precisely to produce a false
+    /// positive, and it never misses a real call — which is the side that matters, since this test's
+    /// job is to catch a second path coming back.
     /// </summary>
     private static bool Calls(MethodBase caller, MethodInfo target)
     {
@@ -144,7 +143,7 @@ public class SingleTradeCreationPathTests
             }
             catch
             {
-                // توکن معتبر نبود — یعنی این بایت اصلاً دستور نبوده. رد شو.
+                // Not a valid token, so this byte was not an opcode at all. Skip it.
             }
         }
 
@@ -152,8 +151,8 @@ public class SingleTradeCreationPathTests
     }
 
     /// <summary>
-    /// <c>&lt;X&gt;d__7.MoveNext</c> را به <c>DeclaringType.X</c> برمی‌گرداند تا خروجی تست
-    /// نام متد واقعی را نشان بدهد، نه نام تولیدشدهٔ کامپایلر.
+    /// Maps <c>&lt;X&gt;d__7.MoveNext</c> back to <c>DeclaringType.X</c>, so the test output names the
+    /// real method rather than the compiler-generated one.
     /// </summary>
     private static string DisplayName(MethodBase method)
     {

--- a/tests/TallaEgg.AllServices.Tests/TradeListSideTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/TradeListSideTests.cs
@@ -1,15 +1,15 @@
-using TallaEgg.Core.DTOs;
+﻿using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.TelegramBot.Infrastructure.Handlers;
 
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// فهرست معاملات باید بگوید هر معامله از دید بیننده خرید بوده یا فروش.
+/// The trade list must say whether each trade was a buy or a sell from the viewer's point of view.
 ///
-/// پیش‌تر نمی‌گفت: کاربر فقط مقدار و مبلغ را می‌دید و هیچ راهی نداشت بفهمد طلا خریده
-/// یا فروخته. این یک ویژگی خودِ معامله نیست — یک معاملهٔ واحد برای یک طرف خرید است و
-/// برای طرف مقابل فروش — پس شناسهٔ بیننده باید به تابع ساخت متن داده شود.
+/// It used not to: the user saw only a quantity and an amount, with no way to tell whether they had
+/// bought or sold. This is not a property of the trade — one trade is a buy to one party and a sell
+/// to the other — so the viewer's id has to be passed to the message builder.
 /// </summary>
 public class TradeListSideTests
 {
@@ -59,9 +59,8 @@ public class TradeListSideTests
     }
 
     /// <summary>
-    /// همان معاملهٔ واحد باید برای دو طرف برعکس هم نمایش داده شود. این تستی است که یک
-    /// برچسب هاردکدشده را می‌گیرد — دو تست بالا به‌تنهایی با یک مقدار ثابت هم سبز
-    /// می‌شدند اگر داده‌هایشان متفاوت نبود.
+    /// The same trade must render oppositely for the two parties. This is the test that catches a
+    /// hard-coded label — the two above would pass against a constant if their data did not differ.
     /// </summary>
     [Fact]
     public async Task TheSameTrade_AppearsAsBuyToOnePartyAndSellToTheOther()
@@ -76,7 +75,8 @@ public class TradeListSideTests
     }
 
     /// <summary>
-    /// جهت پول هم باید صریح باشد: «ارزش کل» نمی‌گفت این مبلغ پرداخت شده یا دریافت.
+    /// The direction of the money must be explicit too: a bare total did not say whether the amount
+    /// was paid or received.
     /// </summary>
     [Fact]
     public async Task TheMoneyDirectionIsLabelled()
@@ -90,14 +90,14 @@ public class TradeListSideTests
         Assert.Contains("دریافتی", sellerView);
     }
 
-    /// <summary>تاریخ نمایش‌داده‌شده باید شمسیِ درست باشد و نه روزِ میلادی.</summary>
+    /// <summary>The displayed date must be the correct Jalali one, not the Gregorian day.</summary>
     [Fact]
     public async Task TheDateIsCorrectPersianDate()
     {
         var text = await TradeListHandler.BuildTradesListAsync(
             PageWith(Trade(buyer: Customer, seller: MarketMaker)), 1, Customer);
 
-        // ۲۷ ژوئیهٔ ۲۰۲۶ ساعت ۰۹:۵۲ UTC  =  ۵ مرداد ۱۴۰۵ ساعت ۱۳:۲۲ به وقت تهران
+        // 27 July 2026 at 09:52 UTC = 5 Mordad 1405 at 13:22 Tehran time.
         Assert.Contains("۱۴۰۵/۰۵/۰۵", text);
         Assert.Contains("۱۳:۲۲", text);
     }


### PR DESCRIPTION
**Branch Name**: `refactor/translate-comments-tests`
**Linked**: STANDARDS.md §1, §5 · follows #126, #127, #128, #129 — **final slice**

---

## Description

Last slice of the comment-language work. **13 files, ~350 Persian comment lines.**

With this merged, `STANDARDS.md` §1 holds across the whole repository apart from Affiliate, which
was excluded at the product owner's request.

---

## Type of Change

- [x] Refactor (code organization, no behavior change)

No test was altered — only its comments. 483 passed before, 483 after.

---

## Why these comments were worth the care

A test's value is in what it claims and why that claim is hard to get right. Preserved in full:

- **`SettlementUniquenessTests`** — why the race is reproduced with a hook rather than two parallel
  tasks: in-memory SQLite on one connection cannot run two concurrent write transactions, so a
  parallel test would deadlock or go flaky. What needs proving is not that a race occurs, but that
  the database stops it when it does.
- **`LockResidueTests`** — both sources of residue derived, and why a single-example test cannot
  show the guarantee: one lucky combination stays green while another breaks, which is exactly
  what 3+3+4 did for several hours.
- **`PendingOrderNotMatchableTests`** — why the match quantity must be a *partial* fill. On a
  complete fill `Order.Complete()` throws against a Pending order and the trade rolls back
  incidentally, so the test would pass without the fix and prove nothing.
- **`SingleTradeCreationPathTests`** — why it is structural rather than behavioural, and why its
  approximate IL scan is safe in the direction that matters: it never misses a real call.
- **`QuarantinedStubTests`** — that the tests it replaced asserted against an endpoint *redefined
  inside the test file*, so deleting the real one would have left them green.

---

## Four comments keep Persian

Each is an English sentence quoting a command name or the literal message text under test. Those
quotes are the subject of the assertion, so translating them would describe a different test.

---

## Safety, with an extra reason here

```
files changed: 13 | with altered live Persian strings: 0
```

This check matters twice over in this project: those strings are not only what the bot says, they
are **the assertions themselves**. Altering one would change what a test proves, not merely what a
user reads — and the suite would very likely still be green.

---

## Testing Completed

```
dotnet build TallaEgg.sln  -> 0 errors
dotnet test  TallaEgg.sln  -> 483 passed, 0 failed, 0 skipped
```

---

## Security Checklist

- [x] No hardcoded secrets, credentials or tokens
- [x] No behaviour change

---

## Breaking Changes?

- [x] No breaking changes

---

## The work, complete

| Slice | PR | Files |
|---|---|---|
| Wallet | #126 | 8 |
| Orders | #127 | 18 |
| Core + Users | #128 | 23 |
| Bot | #129 | 13 |
| **Tests** | **this PR** | **13** |

**75 files, roughly 1,850 Persian comment lines.** Every slice built clean, kept 483/483 green, and
was verified not to have touched a single live Persian string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
