### PR TITLE
chore: clear the mechanical compiler warnings (168 -> 85) and tidy the Swagger setup

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -457,13 +457,6 @@ namespace TallaEgg.TelegramBot
         {
             var ids = await _botClient.GetAdminUserIdsAsync(Constants.GroupId);
             return ids.Contains(user.TelegramId);
-            //  Check if user has admin status or is a known admin Telegram ID
-            // var adminTelegramIds = new[] { 123456789L }; // Add actual admin Telegram IDs here
-            //return user.Status?.ToLower().Contains("admin") == true ||
-            //       user.Status?.ToLower().Contains("root") == true ||
-            //       adminTelegramIds.Contains(user.TelegramId);
-
-            return false;
         }
 
         /// <summary>
@@ -710,7 +703,6 @@ namespace TallaEgg.TelegramBot
             // unexpected, sent the admin ex.Message verbatim, and logged nowhere. Letting it
             // bubble reaches TelegramBotHostedService.HandleUpdateAsync's catch, which does
             // both.
-            const decimal defaultAmount = 1000m;    // Default amount
 
             // First, cancel all existing active orders for this user
             await _messenger.SendAsync(chatId, BotMsgs.MsgAdminProcessing);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
@@ -166,7 +166,7 @@ public class AffiliateApiClient : IAffiliateApiClient
         }
         catch (Exception ex)
         {
-            // Log exception here if needed
+            _logger.LogError(ex, "Error creating an invitation for user {CreatedByUserId}.", createdByUserId);
             return (false, null);
         }
     }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/ActiveOrdersHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/ActiveOrdersHandler.cs
@@ -21,11 +21,11 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
         /// Prices are shown per mesghal, because that is the unit users and admins enter them in.
         /// Storage is per gram.
         /// </summary>
-        public static async Task<string> BuildActiveOrdersListAsync(List<OrderHistoryDto> orders, bool isAdmin = false)
+        public static Task<string> BuildActiveOrdersListAsync(List<OrderHistoryDto> orders, bool isAdmin = false)
         {
             if (orders == null || !orders.Any())
             {
-                return "هیچ سفارش فعالی وجود ندارد.";
+                return Task.FromResult("هیچ سفارش فعالی وجود ندارد.");
             }
 
             var sb = new StringBuilder();
@@ -59,7 +59,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
                 sb.AppendLine();
             }
 
-            return sb.ToString();
+            return Task.FromResult(sb.ToString());
         }
 
         public static InlineKeyboardMarkup? BuildCancelOrderKeyboard(List<OrderHistoryDto> orders, bool isAdmin = false)

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/OrderListHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/OrderListHandler.cs
@@ -25,11 +25,11 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
             return navButtons.Any() ? new InlineKeyboardMarkup(navButtons) : null;
         }
 
-        public static async Task<string> BuildOrdersListAsync(PagedResult<OrderHistoryDto> page, int currentPage)
+        public static Task<string> BuildOrdersListAsync(PagedResult<OrderHistoryDto> page, int currentPage)
         {
             if (page == null || !page.Items.Any())
             {
-                return "هیچ سفارشی یافت نشد.";
+                return Task.FromResult("هیچ سفارشی یافت نشد.");
             }
 
             // Plain text, no Markdown — the same reason as ActiveOrdersHandler: EscapeMarkdownV2
@@ -63,7 +63,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
                 sb.AppendLine();
             }
 
-            return sb.ToString();
+            return Task.FromResult(sb.ToString());
         }
 
         private static string GetTypeIcon(OrderSide type) => type switch

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/TradeListHandler.cs
@@ -43,13 +43,13 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
         /// Passed in rather than looked up here so this stays a pure builder that a test can
         /// call without a users service (issue #65).
         /// </param>
-        public static async Task<string> BuildTradesListAsync(
+        public static Task<string> BuildTradesListAsync(
             PagedResult<TradeHistoryDto> page, int currentPage, Guid viewerUserId,
             IReadOnlyDictionary<Guid, string>? counterpartyPhones = null)
         {
             if (page == null || !page.Items.Any())
             {
-                return "هیچ معامله‌ای انجام نشده است.";
+                return Task.FromResult("هیچ معامله‌ای انجام نشده است.");
             }
 
             // Plain text: the previous version mixed HTML tags with Markdown markers and neither
@@ -100,7 +100,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
                 sb.AppendLine();
             }
 
-            return sb.ToString();
+            return Task.FromResult(sb.ToString());
         }
     }
 }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/UserListHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Handlers/UserListHandler.cs
@@ -24,7 +24,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
             return navButtons.Any() ? new InlineKeyboardMarkup(navButtons) : null;
         }
 
-        public static async Task<string> BuildUsersListAsync(PagedResult<UserDto> page, int currentPage, string? query)
+        public static Task<string> BuildUsersListAsync(PagedResult<UserDto> page, int currentPage, string? query)
         {
             var sb = new StringBuilder();
             sb.AppendLine($"👥 لیست کاربران – صفحه {currentPage} از {page.TotalPages}\n");
@@ -57,7 +57,7 @@ namespace TallaEgg.TelegramBot.Infrastructure.Handlers
                 sb.AppendLine("──────────────────────");
             }
 
-            return sb.ToString();
+            return Task.FromResult(sb.ToString());
         }
 
     }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
@@ -5,9 +5,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <!--رفع باگ افزایش عدد سوم
-	  افزودن ویژگی جدید افزایش عدد دوم
-	  تغییر دیتابیس یا تغییرات پایه ای افزایش عدد اول-->
+	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
+       a database or foundational change the first. -->
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/Order/Orders.Api/Orders.Api.csproj
+++ b/src/Order/Orders.Api/Orders.Api.csproj
@@ -6,9 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-	  <!--رفع باگ افزایش عدد سوم
-	  افزودن ویژگی جدید افزایش عدد دوم
-	  تغییر دیتابیس یا تغییرات پایه ای افزایش عدد اول-->
+	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
+       a database or foundational change the first. -->
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -226,32 +226,33 @@ using (var scope = app.Services.CreateScope())
 if (app.Environment.IsProduction())
 {
     app.UseAuthentication();
-    app.MapGet("/api-docs/{**path}", (string path) => Results.Redirect($"/api-docs/{path}"))
-       .AllowAnonymous();
 }
 app.UseAuthorization();
 
 // Apply the CORS policy.
 app.UseTallaEggCors();
 
-
-
-app.UseSwagger();
+// API documentation, Development only. Swagger has no consumer in Production: the APIs are
+// called by the Telegram bot through hand-written typed clients, and nothing generates a client
+// from the OpenAPI document. Publishing the endpoint map and schemas there is attack surface
+// bought for nothing.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Orders API V1");
         c.RoutePrefix = "api-docs";
     });
+}
 
 
 // Order management endpoints
 
 // ──────────────────────────── Dealer model (issue #48) ────────────────────────────
 
-/// <summary>
-/// Publishes the admin's quote for a symbol. Places no order in the book and locks no collateral.
-/// The symbol's previous quote is deactivated atomically.
-/// </summary>
+// Publishes the admin's quote for a symbol. Places no order in the book and locks no collateral.
+// The symbol's previous quote is deactivated atomically.
 app.MapPost("/api/quotes", async (PublishQuoteRequest request, IQuoteRepository quotes) =>
 {
     try
@@ -274,7 +275,7 @@ app.MapPost("/api/quotes", async (PublishQuoteRequest request, IQuoteRepository 
     }
 });
 
-/// <summary>The active quote for a symbol.</summary>
+// The active quote for a symbol.
 app.MapGet("/api/quotes/{Base}/{Quote}", async (string Base, string Quote, IQuoteRepository quotes) =>
 {
     var symbol = $"{Base}/{Quote}";
@@ -287,7 +288,7 @@ app.MapGet("/api/quotes/{Base}/{Quote}", async (string Base, string Quote, IQuot
 
 // ─────────────────────── Automatic quotes (issue #90) ───────────────────────
 
-/// <summary>A symbol's current automatic-quote settings.</summary>
+// A symbol's current automatic-quote settings.
 app.MapGet("/api/autoquote-settings/{Base}/{Quote}", async (string Base, string Quote, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
 {
     var symbol = $"{Base}/{Quote}";
@@ -296,7 +297,7 @@ app.MapGet("/api/autoquote-settings/{Base}/{Quote}", async (string Base, string 
     return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings)));
 });
 
-/// <summary>Changes a symbol's automatic-quote spread.</summary>
+// Changes a symbol's automatic-quote spread.
 app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
     string Base, string Quote, UpdateAutoQuoteSpreadRequest request, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
 {
@@ -316,7 +317,7 @@ app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
     }
 });
 
-/// <summary>Turns a symbol's automatic quoting on or off.</summary>
+// Turns a symbol's automatic quoting on or off.
 app.MapPost("/api/autoquote-settings/{Base}/{Quote}/enabled", async (
     string Base, string Quote, SetAutoQuoteEnabledRequest request, Orders.Core.IAutoQuoteSettingsRepository settingsRepo) =>
 {
@@ -340,14 +341,14 @@ static AutoQuoteSettingsDto ToAutoQuoteSettingsDto(Orders.Core.AutoQuoteSettings
 
 // ─────────────────────── Symbol enable/disable ─────────────────────────
 
-/// <summary>The symbols currently tradable — the bot uses this for its symbol menu.</summary>
+// The symbols currently tradable — the bot uses this for its symbol menu.
 app.MapGet("/api/symbols/active", async (Orders.Core.ISymbolSettingsRepository settingsRepo) =>
 {
     var symbols = await settingsRepo.GetActiveSymbolsAsync();
     return Results.Ok(ApiResponse<List<string>>.Ok(symbols.ToList()));
 });
 
-/// <summary>Enables or disables a symbol.</summary>
+// Enables or disables a symbol.
 app.MapPost("/api/symbols/{Base}/{Quote}/active", async (
     string Base, string Quote, SetSymbolActiveRequest request, Orders.Core.ISymbolSettingsRepository settingsRepo) =>
 {
@@ -381,14 +382,12 @@ static QuoteDto ToQuoteDto(Quote q) => new()
     DeactivatedAt = q.DeactivatedAt
 };
 
-/// <summary>
-/// Published quotes for a symbol, newest first, including ones already replaced.
-///
-/// This is what the bot's quote history reads. It replaced order history in the customer
-/// menu: in the dealer model an order lives only for the instant of a fill, so a customer's
-/// order list was always either empty or entirely completed rows — nothing to act on. The
-/// prices the shop published are the history that means something.
-/// </summary>
+// Published quotes for a symbol, newest first, including ones already replaced.
+//
+// This is what the bot's quote history reads. It replaced order history in the customer
+// menu: in the dealer model an order lives only for the instant of a fill, so a customer's
+// order list was always either empty or entirely completed rows — nothing to act on. The
+// prices the shop published are the history that means something.
 app.MapGet("/api/quotes/{Base}/{Quote}/history", async (
     string Base, string Quote, IQuoteRepository quotes, int page = 1, int size = 5) =>
 {
@@ -406,10 +405,8 @@ app.MapGet("/api/quotes/{Base}/{Quote}/history", async (
     return Results.Ok(ApiResponse<PagedResult<QuoteDto>>.Ok(result));
 });
 
-/// <summary>
-/// A customer fills a quote: two orders for exactly the requested quantity are created, locked and
-/// matched immediately. The customer does not enter a price.
-/// </summary>
+// A customer fills a quote: two orders for exactly the requested quantity are created, locked and
+// matched immediately. The customer does not enter a price.
 app.MapPost("/api/quotes/accept", async (AcceptQuoteRequest request, QuoteFillService fillService) =>
 {
     var (success, message, trade) = await fillService.AcceptQuoteAsync(
@@ -422,15 +419,13 @@ app.MapPost("/api/quotes/accept", async (AcceptQuoteRequest request, QuoteFillSe
 
 // ─────────────────────────────────────────────────────────────────────────────────
 
-/// <summary>
-/// Creates a single order of any type (limit or market), determining maker/taker automatically.
-/// </summary>
-/// <param name="request">Order creation request.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The order, its role, and any trades executed.</returns>
-/// <response code="200">Order created.</response>
-/// <response code="400">Invalid data, or a business rule was violated.</response>
-/// <response code="401">Unauthorized.</response>
+// Creates a single order of any type (limit or market), determining maker/taker automatically.
+// request: Order creation request.
+// orderService: Order service.
+// Returns: The order, its role, and any trades executed.
+// 200: Order created.
+// 400: Invalid data, or a business rule was violated.
+// 401: Unauthorized.
 app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, OrderService orderService) =>
 {
     try
@@ -463,6 +458,7 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error creating an order.");
         return Results.Json(ApiResponse<CreateOrderResponse>.Fail("خطای داخلی سرور"), statusCode: 500);
     }
 })
@@ -473,14 +469,12 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
 .Produces<ApiResponse<CreateOrderResponse>>(200)
 .ProducesValidationProblem(400);
 
-/// <summary>
-/// Returns an order by id.
-/// </summary>
-/// <param name="orderId">Order id.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The order, if found.</returns>
-/// <response code="200">Order found.</response>
-/// <response code="404">Order not found.</response>
+// Returns an order by id.
+// orderId: Order id.
+// orderService: Order service.
+// Returns: The order, if found.
+// 200: Order found.
+// 404: Order not found.
 app.MapGet("/api/orders/{orderId}", async (Guid orderId, OrderService orderService) =>
 {
     try
@@ -493,6 +487,7 @@ app.MapGet("/api/orders/{orderId}", async (Guid orderId, OrderService orderServi
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error fetching order {OrderId}.", orderId);
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -502,16 +497,14 @@ app.MapGet("/api/orders/{orderId}", async (Guid orderId, OrderService orderServi
 .Produces(200)
 .Produces(404);
 
-/// <summary>
-/// Cancels an order.
-/// </summary>
-/// <param name="orderId">Order id.</param>
-/// <param name="reason">Optional cancellation reason.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The result of the cancellation.</returns>
-/// <response code="200">Order cancelled.</response>
-/// <response code="400">Cancellation failed or was not valid.</response>
-/// <response code="404">Order not found.</response>
+// Cancels an order.
+// orderId: Order id.
+// reason: Optional cancellation reason.
+// orderService: Order service.
+// Returns: The result of the cancellation.
+// 200: Order cancelled.
+// 400: Cancellation failed or was not valid.
+// 404: Order not found.
 app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason, OrderService orderService) =>
 {
     try
@@ -528,6 +521,7 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error cancelling order {OrderId}.", orderId);
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -538,19 +532,15 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
 .Produces(400)
 .Produces(404);
 
-/// <summary>
-/// Cancels all of a user's active orders.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="reason">Optional cancellation reason.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>How many orders were cancelled.</returns>
-/// <response code="200">Orders cancelled.</response>
-/// <response code="400">Cancelling the orders failed.</response>
-/// <remarks>
-/// Finds the user's active orders, cancels them with the supplied reason, and returns how many were
-/// cancelled, wrapped in the standard ApiResponse shape.
-/// </remarks>
+// Cancels all of a user's active orders.
+// userId: User id.
+// reason: Optional cancellation reason.
+// orderService: Order service.
+// Returns: How many orders were cancelled.
+// 200: Orders cancelled.
+// 400: Cancelling the orders failed.
+// Finds the user's active orders, cancels them with the supplied reason, and returns how many were
+// cancelled, wrapped in the standard ApiResponse shape.
 app.MapPost("/api/orders/user/{userId}/cancel-active", async (Guid userId, string? reason, OrderService orderService) =>
 {
     try
@@ -563,6 +553,7 @@ app.MapPost("/api/orders/user/{userId}/cancel-active", async (Guid userId, strin
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error cancelling the active orders of user {UserId}.", userId);
         return Results.Json(ApiResponse<CancelActiveOrdersResponseDto>.Fail("خطای داخلی سرور"), statusCode: 500);
     }
 })
@@ -572,15 +563,13 @@ app.MapPost("/api/orders/user/{userId}/cancel-active", async (Guid userId, strin
 .Produces(200)
 .Produces(400);
 
-/// <summary>
-/// Confirms an order, moving it from Pending to Confirmed.
-/// </summary>
-/// <param name="orderId">Order id.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The result of the confirmation.</returns>
-/// <response code="200">Order confirmed.</response>
-/// <response code="400">Order cannot be confirmed.</response>
-/// <response code="404">Order not found.</response>
+// Confirms an order, moving it from Pending to Confirmed.
+// orderId: Order id.
+// orderService: Order service.
+// Returns: The result of the confirmation.
+// 200: Order confirmed.
+// 400: Order cannot be confirmed.
+// 404: Order not found.
 app.MapPost("/api/orders/{orderId}/confirm", async (Guid orderId, OrderService orderService) =>
 {
     try
@@ -604,6 +593,7 @@ app.MapPost("/api/orders/{orderId}/confirm", async (Guid orderId, OrderService o
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error confirming order {OrderId}.", orderId);
         return Results.Json(new { 
             success = false, 
             message = "خطای داخلی سرور در تایید سفارش" 
@@ -618,16 +608,14 @@ app.MapPost("/api/orders/{orderId}/confirm", async (Guid orderId, OrderService o
 .Produces(400)
 .Produces(404);
 
-/// <summary>
-/// Returns a user's orders, paginated.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="pageNumber">Page number, default 1.</param>
-/// <param name="pageSize">Items per page, default 10, maximum 100.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>A page of the user's orders.</returns>
-/// <response code="200">Orders returned.</response>
-/// <response code="400">Invalid request parameters.</response>
+// Returns a user's orders, paginated.
+// userId: User id.
+// pageNumber: Page number, default 1.
+// pageSize: Items per page, default 10, maximum 100.
+// orderService: Order service.
+// Returns: A page of the user's orders.
+// 200: Orders returned.
+// 400: Invalid request parameters.
 app.MapGet("/api/orders/user/{userId}", async (
     Guid userId,
     int? pageNumber,
@@ -648,6 +636,7 @@ app.MapGet("/api/orders/user/{userId}", async (
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error fetching the orders of user {UserId}.", userId);
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -657,16 +646,14 @@ app.MapGet("/api/orders/user/{userId}", async (
 .Produces<ApiResponse<PagedResult<OrderHistoryDto>>>(200)
 .Produces(400);
 
-/// <summary>
-/// Returns a user's trades, paginated.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="pageNumber">Page number, default 1.</param>
-/// <param name="pageSize">Items per page, default 10, maximum 100.</param>
-/// <param name="tradeService">Trade service.</param>
-/// <returns>A page of the user's trades.</returns>
-/// <response code="200">Trades returned.</response>
-/// <response code="400">Invalid request parameters.</response>
+// Returns a user's trades, paginated.
+// userId: User id.
+// pageNumber: Page number, default 1.
+// pageSize: Items per page, default 10, maximum 100.
+// tradeService: Trade service.
+// Returns: A page of the user's trades.
+// 200: Trades returned.
+// 400: Invalid request parameters.
 app.MapGet("/api/trades/user/{userId}", async (
     Guid userId,
     int? pageNumber,
@@ -687,6 +674,7 @@ app.MapGet("/api/trades/user/{userId}", async (
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error fetching the trades of user {UserId}.", userId);
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -696,11 +684,9 @@ app.MapGet("/api/trades/user/{userId}", async (
 .Produces<ApiResponse<PagedResult<TradeHistoryDto>>>(200)
 .Produces(400);
 
-/// <summary>
-/// A user's position and profit/loss across every symbol they have traded (issue #93). The same
-/// endpoint serves the admin/SuperAdmin — they are the counterparty to every quote fill, so the
-/// shop's profit and loss is this same calculation run against the admin's own user id.
-/// </summary>
+// A user's position and profit/loss across every symbol they have traded (issue #93). The same
+// endpoint serves the admin/SuperAdmin — they are the counterparty to every quote fill, so the
+// shop's profit and loss is this same calculation run against the admin's own user id.
 app.MapGet("/api/positions/user/{userId}", async (
     Guid userId,
     Orders.Application.Services.PositionService positionService) =>
@@ -722,14 +708,12 @@ app.MapGet("/api/positions/user/{userId}", async (
 .Produces<ApiResponse<PositionsResponseDto>>(200)
 .Produces(500);
 
-/// <summary>
-/// Returns a user's active orders.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The user's active orders.</returns>
-/// <response code="200">Active orders returned.</response>
-/// <response code="400">Invalid request.</response>
+// Returns a user's active orders.
+// userId: User id.
+// orderService: Order service.
+// Returns: The user's active orders.
+// 200: Active orders returned.
+// 400: Invalid request.
 app.MapGet("/api/orders/active/user/{userId}", async (
     Guid userId,
     OrderService orderService) =>
@@ -758,6 +742,7 @@ app.MapGet("/api/orders/active/user/{userId}", async (
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error fetching the active orders of user {UserId}.", userId);
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -767,13 +752,11 @@ app.MapGet("/api/orders/active/user/{userId}", async (
 .Produces<ApiResponse<List<OrderHistoryDto>>>(200)
 .Produces(400);
 
-/// <summary>
-/// Returns every active order in the system, for admins.
-/// </summary>
-/// <param name="orderService">Order service.</param>
-/// <returns>All active orders.</returns>
-/// <response code="200">All active orders returned.</response>
-/// <response code="500">Internal server error.</response>
+// Returns every active order in the system, for admins.
+// orderService: Order service.
+// Returns: All active orders.
+// 200: All active orders returned.
+// 500: Internal server error.
 app.MapGet("/api/orders/active/all", async (OrderService orderService) =>
 {
     try
@@ -800,6 +783,7 @@ app.MapGet("/api/orders/active/all", async (OrderService orderService) =>
     }
     catch (Exception ex)
     {
+        Log.Error(ex, "Unhandled error fetching all active orders.");
         return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
     }
 })
@@ -809,17 +793,15 @@ app.MapGet("/api/orders/active/all", async (OrderService orderService) =>
 .Produces<ApiResponse<List<OrderHistoryDto>>>(200)
 .Produces(500);
 
-/// <summary>
-/// Returns the best bid and ask prices.
-/// </summary>
-/// <param name="symbol">Trading symbol, for example MAUA/IRT.</param>
-/// <param name="tradingType">Trading type, default standard.</param>
-/// <param name="orderService">Order service.</param>
-/// <returns>The best bid and ask prices.</returns>
-/// <response code="200">Best prices returned.</response>
-/// <response code="400">Invalid request.</response>
-/// <response code="404">Trading symbol not found.</response>
-/// <response code="500">Internal server error.</response>
+// Returns the best bid and ask prices.
+// symbol: Trading symbol, for example MAUA/IRT.
+// tradingType: Trading type, default standard.
+// orderService: Order service.
+// Returns: The best bid and ask prices.
+// 200: Best prices returned.
+// 400: Invalid request.
+// 404: Trading symbol not found.
+// 500: Internal server error.
 app.MapGet("/api/orders/{Base}/{Quote}/best-prices", async (
     string Base,
     string Quote,
@@ -917,8 +899,6 @@ app.MapGet("/api/orders/{Base}/{Quote}/best-prices", async (
         Log.Information(">--------------------- finally best-prices ---------------------<");
     }
 
-    Log.Information(">--------------------- end best-prices ---------------------<");
-
 })
 .WithName("GetBestPrices")
 .WithSummary("دریافت بهترین قیمت‌های خرید و فروش")
@@ -982,9 +962,9 @@ static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironm
 // delivery is a no-op rather than a double settlement.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Lists trades whose settlement never completed, newest first. Abandoned messages are
-/// excluded by default — an operator already reviewed and closed those — but stay
-/// queryable via includeAbandoned=true for reconciliation and audit.
+// Lists trades whose settlement never completed, newest first. Abandoned messages are
+// excluded by default — an operator already reviewed and closed those — but stay
+// queryable via includeAbandoned=true for reconciliation and audit.
 app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAbandoned = false) =>
 {
     try
@@ -1025,7 +1005,7 @@ app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAband
     }
 });
 
-/// Puts a permanently-failed settlement back in the queue after the cause has been fixed.
+// Puts a permanently-failed settlement back in the queue after the cause has been fixed.
 app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbContext db) =>
 {
     try
@@ -1055,7 +1035,7 @@ app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbCo
     }
 });
 
-/// Re-drives every failed settlement at once, for use after a fix that affects them all.
+// Re-drives every failed settlement at once, for use after a fix that affects them all.
 app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
 {
     try
@@ -1081,11 +1061,11 @@ app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
     }
 });
 
-/// Closes a permanently-failed settlement an operator has reviewed and decided will never
-/// settle (e.g. its collateral was consumed by later activity). The record is kept, not
-/// deleted, so the trade stays reconcilable — it just stops showing up as actionable and can
-/// never be re-driven again. No compensating wallet action is taken: for this shop, settling
-/// such a trade is a manual, offline decision, and the reason recorded here is that note.
+// Closes a permanently-failed settlement an operator has reviewed and decided will never
+// settle (e.g. its collateral was consumed by later activity). The record is kept, not
+// deleted, so the trade stays reconcilable — it just stops showing up as actionable and can
+// never be re-driven again. No compensating wallet action is taken: for this shop, settling
+// such a trade is a manual, offline decision, and the reason recorded here is that note.
 app.MapPost("/api/outbox/{messageId}/abandon", async (Guid messageId, AbandonOutboxMessageRequest request, OrdersDbContext db) =>
 {
     try
@@ -1128,97 +1108,43 @@ app.Run();
 /// Request model for creating a new maker order
 /// </summary>
 public record CreateOrderRequest(
-    /// <summary>
-    /// Trading asset symbol (e.g., BTC, ETH, USDT)
-    /// </summary>
     string Asset, 
-    /// <summary>
-    /// Order quantity/amount
-    /// </summary>
     decimal Amount, 
-    /// <summary>
-    /// Order price per unit
-    /// </summary>
     decimal Price, 
-    /// <summary>
-    /// Unique identifier of the user placing the order
-    /// </summary>
     Guid UserId, 
-    /// <summary>
-    /// Type of order (Buy or Sell)
-    /// </summary>
     OrderSide Type,
-    /// <summary>
-    /// Trading type (Spot or Futures)
-    /// </summary>
     TradingType TradingType,
-    /// <summary>
-    /// Optional notes for the order
-    /// </summary>
     string? Notes = null);
 
 /// <summary>
 /// Request model for creating a new limit order
 /// </summary>
 public record CreateLimitOrderRequest(
-    /// <summary>
-    /// Trading symbol (e.g., BTC, ETH)
-    /// </summary>
     string Symbol,
-    /// <summary>
-    /// Order quantity
-    /// </summary>
     decimal Quantity,
-    /// <summary>
-    /// Limit price for the order
-    /// </summary>
     decimal Price,
-    /// <summary>
-    /// Unique identifier of the user placing the order
-    /// </summary>
     Guid UserId);
 
 /// <summary>
 /// Request model for creating a new taker order
 /// </summary>
 public record CreateTakerOrderRequest(
-    /// <summary>
-    /// Unique identifier of the parent maker order
-    /// </summary>
     Guid ParentOrderId,
-    /// <summary>
-    /// Order amount
-    /// </summary>
     decimal Amount,
-    /// <summary>
-    /// Unique identifier of the user placing the order
-    /// </summary>
     Guid UserId,
-    /// <summary>
-    /// Optional notes for the order
-    /// </summary>
     string? Notes = null);
 
 /// <summary>
 /// Request model for updating order status
 /// </summary>
 public record UpdateOrderStatusRequest(
-    /// <summary>
-    /// New status for the order
-    /// </summary>
     OrderStatus Status, 
-    /// <summary>
-    /// Optional notes for the status change
-    /// </summary>
     string? Notes = null);
 
 /// <summary>
 /// Request model for cancelling an order
 /// </summary>
 public record CancelOrderRequest(
-    /// <summary>
-    /// Optional reason for cancellation
-    /// </summary>
     string? Reason = null);
 
 /// <summary>
@@ -1231,17 +1157,8 @@ public record AbandonOutboxMessageRequest(string Reason);
 /// Request model for notifying the matching engine about a new order
 /// </summary>
 public record NotifyMatchingEngineRequest(
-    /// <summary>
-    /// Unique identifier of the order to process
-    /// </summary>
     Guid OrderId,
-    /// <summary>
-    /// Trading asset symbol
-    /// </summary>
     string Asset,
-/// <summary>
-/// Type of order (Buy or Sell)
-/// </summary>
 OrderSide Type);
 
 

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -273,7 +273,8 @@ app.MapPost("/api/quotes", async (PublishQuoteRequest request, IQuoteRepository 
         Log.Error(ex, "Error publishing quote for {Symbol}", request.Symbol);
         return Results.BadRequest(ApiResponse<QuoteDto>.Fail("خطا در انتشار مظنه."));
     }
-});
+})
+.WithTags("Quotes");
 
 // The active quote for a symbol.
 app.MapGet("/api/quotes/{Base}/{Quote}", async (string Base, string Quote, IQuoteRepository quotes) =>
@@ -284,7 +285,8 @@ app.MapGet("/api/quotes/{Base}/{Quote}", async (string Base, string Quote, IQuot
     return quote is null
         ? Results.NotFound(ApiResponse<QuoteDto>.Fail("مظنه‌ای منتشر نشده است."))
         : Results.Ok(ApiResponse<QuoteDto>.Ok(ToQuoteDto(quote)));
-});
+})
+.WithTags("Quotes");
 
 // ─────────────────────── Automatic quotes (issue #90) ───────────────────────
 
@@ -295,7 +297,8 @@ app.MapGet("/api/autoquote-settings/{Base}/{Quote}", async (string Base, string 
     var settings = await settingsRepo.GetOrCreateAsync(symbol);
 
     return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings)));
-});
+})
+.WithTags("Auto-quote");
 
 // Changes a symbol's automatic-quote spread.
 app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
@@ -315,7 +318,8 @@ app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
     {
         return Results.BadRequest(ApiResponse<AutoQuoteSettingsDto>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Auto-quote");
 
 // Turns a symbol's automatic quoting on or off.
 app.MapPost("/api/autoquote-settings/{Base}/{Quote}/enabled", async (
@@ -329,7 +333,8 @@ app.MapPost("/api/autoquote-settings/{Base}/{Quote}/enabled", async (
 
     return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings),
         request.IsEnabled ? "مظنهٔ اتومات روشن شد." : "مظنهٔ اتومات خاموش شد."));
-});
+})
+.WithTags("Auto-quote");
 
 static AutoQuoteSettingsDto ToAutoQuoteSettingsDto(Orders.Core.AutoQuoteSettings s) => new()
 {
@@ -346,7 +351,8 @@ app.MapGet("/api/symbols/active", async (Orders.Core.ISymbolSettingsRepository s
 {
     var symbols = await settingsRepo.GetActiveSymbolsAsync();
     return Results.Ok(ApiResponse<List<string>>.Ok(symbols.ToList()));
-});
+})
+.WithTags("Symbols");
 
 // Enables or disables a symbol.
 app.MapPost("/api/symbols/{Base}/{Quote}/active", async (
@@ -360,7 +366,8 @@ app.MapPost("/api/symbols/{Base}/{Quote}/active", async (
 
     return Results.Ok(ApiResponse<SymbolSettingsDto>.Ok(ToSymbolSettingsDto(settings),
         request.IsActive ? "نماد فعال شد." : "نماد غیرفعال شد."));
-});
+})
+.WithTags("Symbols");
 
 static SymbolSettingsDto ToSymbolSettingsDto(Orders.Core.SymbolSettings s) => new()
 {
@@ -403,7 +410,8 @@ app.MapGet("/api/quotes/{Base}/{Quote}/history", async (
     };
 
     return Results.Ok(ApiResponse<PagedResult<QuoteDto>>.Ok(result));
-});
+})
+.WithTags("Quotes");
 
 // A customer fills a quote: two orders for exactly the requested quantity are created, locked and
 // matched immediately. The customer does not enter a price.
@@ -415,7 +423,8 @@ app.MapPost("/api/quotes/accept", async (AcceptQuoteRequest request, QuoteFillSe
     return success
         ? Results.Ok(ApiResponse<Guid?>.Ok(trade?.Id, message))
         : Results.BadRequest(ApiResponse<Guid?>.Fail(message));
-});
+})
+.WithTags("Quotes");
 
 // ─────────────────────────────────────────────────────────────────────────────────
 
@@ -463,8 +472,8 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
     }
 })
 .WithName("CreateOrder")
-.WithSummary("ایجاد سفارش واحد")
-.WithDescription("ایجاد سفارش Limit یا Market با تشخیص خودکار نقش Maker/Taker")
+.WithSummary("Create an order")
+.WithDescription("Creates a limit or market order, determining the maker/taker role automatically.")
 .WithTags("Orders")
 .Produces<ApiResponse<CreateOrderResponse>>(200)
 .ProducesValidationProblem(400);
@@ -492,7 +501,7 @@ app.MapGet("/api/orders/{orderId}", async (Guid orderId, OrderService orderServi
     }
 })
 .WithName("GetOrderById")
-.WithSummary("دریافت سفارش با شناسه")
+.WithSummary("Get an order by id")
 .WithTags("Orders")
 .Produces(200)
 .Produces(404);
@@ -526,7 +535,7 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
     }
 })
 .WithName("CancelOrder")
-.WithSummary("لغو سفارش")
+.WithSummary("Cancel an order")
 .WithTags("Orders")
 .Produces(200)
 .Produces(400)
@@ -558,7 +567,7 @@ app.MapPost("/api/orders/user/{userId}/cancel-active", async (Guid userId, strin
     }
 })
 .WithName("CancelUserActiveOrders")
-.WithSummary("لغو همه سفارشات فعال کاربر")
+.WithSummary("Cancel every active order of a user")
 .WithTags("Orders")
 .Produces(200)
 .Produces(400);
@@ -601,8 +610,8 @@ app.MapPost("/api/orders/{orderId}/confirm", async (Guid orderId, OrderService o
     }
 })
 .WithName("ConfirmOrder")
-.WithSummary("تایید سفارش")
-.WithDescription("تغییر وضعیت سفارش از Pending به Confirmed با حفظ ایمنی همزمانی")
+.WithSummary("Confirm an order")
+.WithDescription("Moves an order from Pending to Confirmed without losing concurrency safety.")
 .WithTags("Orders")
 .Produces(200)
 .Produces(400)
@@ -641,7 +650,7 @@ app.MapGet("/api/orders/user/{userId}", async (
     }
 })
 .WithName("GetUserOrders")
-.WithSummary("دریافت سفارشات کاربر")
+.WithSummary("Get a user's orders")
 .WithTags("Orders")
 .Produces<ApiResponse<PagedResult<OrderHistoryDto>>>(200)
 .Produces(400);
@@ -679,7 +688,7 @@ app.MapGet("/api/trades/user/{userId}", async (
     }
 })
 .WithName("GetUserTrades")
-.WithSummary("دریافت معاملات کاربر")
+.WithSummary("Get a user's trades")
 .WithTags("Trades")
 .Produces<ApiResponse<PagedResult<TradeHistoryDto>>>(200)
 .Produces(400);
@@ -703,7 +712,7 @@ app.MapGet("/api/positions/user/{userId}", async (
     }
 })
 .WithName("GetUserPositions")
-.WithSummary("دریافت موقعیت و سود/زیان کاربر در همهٔ نمادها")
+.WithSummary("Get a user's position and profit/loss across every symbol")
 .WithTags("Positions")
 .Produces<ApiResponse<PositionsResponseDto>>(200)
 .Produces(500);
@@ -747,7 +756,7 @@ app.MapGet("/api/orders/active/user/{userId}", async (
     }
 })
 .WithName("GetUserActiveOrders")
-.WithSummary("دریافت سفارشات فعال کاربر")
+.WithSummary("Get a user's active orders")
 .WithTags("Orders")
 .Produces<ApiResponse<List<OrderHistoryDto>>>(200)
 .Produces(400);
@@ -788,7 +797,7 @@ app.MapGet("/api/orders/active/all", async (OrderService orderService) =>
     }
 })
 .WithName("GetAllActiveOrders")
-.WithSummary("دریافت تمام سفارشات فعال")
+.WithSummary("Get every active order")
 .WithTags("Orders")
 .Produces<ApiResponse<List<OrderHistoryDto>>>(200)
 .Produces(500);
@@ -901,8 +910,8 @@ app.MapGet("/api/orders/{Base}/{Quote}/best-prices", async (
 
 })
 .WithName("GetBestPrices")
-.WithSummary("دریافت بهترین قیمت‌های خرید و فروش")
-.WithDescription("این endpoint بهترین قیمت‌های Bid (خرید) و Ask (فروش) را برای نماد معاملاتی مشخص شده بازمی‌گرداند.")
+.WithSummary("Get the best bid and ask prices")
+.WithDescription("Returns the best bid and ask prices for the given trading symbol.")
 .WithTags("Market Data")
 .Produces<ApiResponse<BestPricesDto>>(200, "application/json")
 .Produces<ApiResponse<BestPricesDto>>(400, "application/json")
@@ -1003,7 +1012,8 @@ app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAband
         Log.Error(ex, "Error listing unsettled outbox messages");
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Outbox");
 
 // Puts a permanently-failed settlement back in the queue after the cause has been fixed.
 app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbContext db) =>
@@ -1033,7 +1043,8 @@ app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbCo
         Log.Error(ex, "Error re-driving outbox message {MessageId}", messageId);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Outbox");
 
 // Re-drives every failed settlement at once, for use after a fix that affects them all.
 app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
@@ -1059,7 +1070,8 @@ app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
         Log.Error(ex, "Error re-driving all failed outbox messages");
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Outbox");
 
 // Closes a permanently-failed settlement an operator has reviewed and decided will never
 // settle (e.g. its collateral was consumed by later activity). The record is kept, not
@@ -1098,7 +1110,8 @@ app.MapPost("/api/outbox/{messageId}/abandon", async (Guid messageId, AbandonOut
         Log.Error(ex, "Error abandoning outbox message {MessageId}", messageId);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Outbox");
 
 app.Run();
 

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -561,8 +561,7 @@ public class OrderService
             }
             catch (Exception ex)
             {
-                // Log the error but continue with other orders
-                // TODO: Consider adding proper logging here
+                _logger.LogError(ex, "Failed to cancel order {OrderId} while cancelling every active order of user {UserId}; continuing with the rest.", order.Id, userId);
                 continue;
             }
         }

--- a/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
@@ -135,9 +135,11 @@ namespace TallaEgg.Core.Services
                 var data = new StringContent(_text, Encoding.UTF8, "application/json");
                 await Send(data);
             }
-            catch (Exception eex)
+            catch (Exception)
             {
-
+                // Deliberately silent: this is the logger itself. Throwing would turn a failed
+                // log into a failed operation, and logging the failure would recurse. Losing an
+                // informational message is the cheaper outcome; the error path below does persist.
             }
 
         }
@@ -186,7 +188,11 @@ namespace TallaEgg.Core.Services
             }
             catch (Exception eex)
             {
-                await File.AppendAllTextAsync("SendExceptions.txt", Newtonsoft.Json.JsonConvert.SerializeObject(ex, Newtonsoft.Json.Formatting.Indented));
+                // Last resort: Telegram is unreachable, so persist both the exception being
+                // reported and the one that stopped it from being reported. Writing only the
+                // former, as this used to, leaves no way to tell why the send failed.
+                await File.AppendAllTextAsync("SendExceptions.txt", Newtonsoft.Json.JsonConvert.SerializeObject(
+                    new { Reported = ex, SendFailure = eex }, Newtonsoft.Json.Formatting.Indented));
                 await File.AppendAllTextAsync("SendExceptions.txt", "====================================================");
             }
 

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -317,6 +317,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "Error fetching the wallet balances of user {UserId}.", userId);
             return TallaEgg.Core.DTOs.ApiResponse<IEnumerable<WalletDTO>>.Fail("خطا در ارتباط با سرور");
 
         }
@@ -364,6 +365,7 @@ public class WalletApiClient : IWalletApiClient
                 }
                 catch (JsonException jsonEx)
                 {
+                    _logger?.LogError(jsonEx, "Unreadable balance payload for user {UserId}, asset {Asset}.", userId, asset);
                     return (false, $"خطا در پردازش اطلاعات دریافتی: پاسخ سرور قابل تفسیر نیست.", null);
                 }
             }
@@ -430,6 +432,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (JsonException jsonEx)
         {
+            _logger?.LogError(jsonEx, "Unreadable error payload for user {UserId}, asset {Asset}.", userId, asset);
             // JSON parsing errors
             return (false, "خطا در پردازش اطلاعات دریافتی از سرور.", null);
         }
@@ -484,6 +487,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "Error depositing to the wallet of user {UserId}.", request.UserId);
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در ارتباط با سرور");
 
         }
@@ -518,6 +522,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "Error withdrawing from the wallet of user {UserId}.", request.UserId);
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در ارتباط با سرور");
 
         }

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -183,40 +183,34 @@ using (var scope = app.Services.CreateScope())
 if (app.Environment.IsProduction())
 {
     app.UseAuthentication();
-    app.MapGet("/api-docs/{**path}", (string path) => Results.Redirect($"/api-docs/{path}"))
-       .AllowAnonymous();
 }
 app.UseAuthorization();
-
-// Add Swagger middleware
-app.UseSwagger();
-app.UseSwaggerUI(c =>
-{
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Users API v1");
-    c.RoutePrefix = "api-docs";
-});
 
 // Apply the CORS policy.
 app.UseTallaEggCors();
 
-// Add Swagger middleware
-app.UseSwagger();
-app.UseSwaggerUI(c =>
+// API documentation, Development only. Swagger has no consumer in Production: the APIs are
+// called by the Telegram bot through hand-written typed clients, and nothing generates a client
+// from the OpenAPI document. Publishing the endpoint map and schemas there is attack surface
+// bought for nothing.
+if (app.Environment.IsDevelopment())
 {
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Users API v1");
-    c.RoutePrefix = "api-docs";
-});
+    app.UseSwagger();
+    app.UseSwaggerUI(c =>
+    {
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Users API v1");
+        c.RoutePrefix = "api-docs";
+    });
+}
 
 
 
-/// <summary>
-/// Registers a new user in the system
-/// </summary>
-/// <param name="request">User registration request containing Telegram ID, invitation code, and user details</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Registered user details with success status</returns>
-/// <response code="200">User registered successfully</response>
-/// <response code="400">Invalid request data or validation error</response>
+// Registers a new user in the system
+// request: User registration request containing Telegram ID, invitation code, and user details
+// userService: User service for business logic
+// Returns: Registered user details with success status
+// 200: User registered successfully
+// 400: Invalid request data or validation error
 app.MapPost("/api/user/register", async (RegisterUserRequest request, UserService userService) =>
 {
     // RegisterUserAsync throws a plain Exception with a user-facing message when the invitation
@@ -238,15 +232,13 @@ app.MapPost("/api/user/register", async (RegisterUserRequest request, UserServic
     }
 });
 
-/// <summary>
-/// Updates the phone number for an existing user
-/// </summary>
-/// <param name="request">Phone update request containing Telegram ID and new phone number</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Updated user details with success status</returns>
-/// <response code="200">Phone number updated successfully</response>
-/// <response code="400">Invalid request data or validation error</response>
-/// <response code="404">User not found</response>
+// Updates the phone number for an existing user
+// request: Phone update request containing Telegram ID and new phone number
+// userService: User service for business logic
+// Returns: Updated user details with success status
+// 200: Phone number updated successfully
+// 400: Invalid request data or validation error
+// 404: User not found
 app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserService userService) =>
 {
     // UpdateUserPhoneAsync throws InvalidOperationException with a user-facing "not found" message — a
@@ -262,14 +254,12 @@ app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserSer
     }
 });
 
-/// <summary>
-/// Retrieves user information by Telegram ID
-/// </summary>
-/// <param name="telegramId">Telegram ID of the user</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>User details if found</returns>
-/// <response code="200">User found and returned successfully</response>
-/// <response code="404">User not found</response>
+// Retrieves user information by Telegram ID
+// telegramId: Telegram ID of the user
+// userService: User service for business logic
+// Returns: User details if found
+// 200: User found and returned successfully
+// 404: User not found
 app.MapGet("/api/user/{telegramId}", async (long telegramId, UserService userService) =>
 {
     var user = await userService.GetUserByTelegramIdAsync(telegramId);
@@ -279,14 +269,12 @@ app.MapGet("/api/user/{telegramId}", async (long telegramId, UserService userSer
     return Results.Ok(ApiResponse<UserDto>.Ok(user, "User loaded successfully"));
 });
 
-/// <summary>
-/// Returns a user by id.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="userService">User service.</param>
-/// <returns>The user, if found.</returns>
-/// <response code="200">User found.</response>
-/// <response code="404">User not found.</response>
+// Returns a user by id.
+// userId: User id.
+// userService: User service.
+// Returns: The user, if found.
+// 200: User found.
+// 404: User not found.
 app.MapGet("/api/user/userId/{userId}", async (Guid userId, UserService userService) =>
 {
     var user = await userService.GetUserByIdAsync(userId);
@@ -304,14 +292,12 @@ app.MapGet("/api/user/userId/{userId}", async (Guid userId, UserService userServ
     );
 });
 
-/// <summary>
-/// Retrieves user information by phone number
-/// </summary>
-/// <param name="phone">phone of the user</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>User details if found</returns>
-/// <response code="200">User found and returned successfully</response>
-/// <response code="404">User not found</response>
+// Retrieves user information by phone number
+// phone: phone of the user
+// userService: User service for business logic
+// Returns: User details if found
+// 200: User found and returned successfully
+// 404: User not found
 app.MapGet("/api/userByPhone/{phone}", async (string phone, UserService userService) =>
 {
     var user = await userService.GetUserByPhoneNumberAsync(phone);
@@ -335,15 +321,13 @@ app.MapGet("/api/users/list", async (
     return Results.Ok(ApiResponse<PagedResult<UserDto>>.Ok(users, "کاربران دریافت شد"));
 });
 
-/// <summary>
-/// Updates the status of an existing user
-/// </summary>
-/// <param name="request">Status update request containing Telegram ID and new status</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Success status with confirmation message</returns>
-/// <response code="200">User status updated successfully</response>
-/// <response code="400">Invalid request data or validation error</response>
-/// <response code="404">User not found</response>
+// Updates the status of an existing user
+// request: Status update request containing Telegram ID and new status
+// userService: User service for business logic
+// Returns: Success status with confirmation message
+// 200: User status updated successfully
+// 400: Invalid request data or validation error
+// 404: User not found
 app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserService userService) =>
 {
     // UpdateUserStatusAsync throws InvalidOperationException with a user-facing "not found" message — a
@@ -359,15 +343,13 @@ app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserServi
     }
 });
 
-/// <summary>
-/// Gets user ID by invitation code
-/// </summary>
-/// <param name="invitationCode">Invitation code to lookup</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>User ID associated with the invitation code</returns>
-/// <response code="200">User ID found and returned</response>
-/// <response code="400">Invalid invitation code or error occurred</response>
-/// <response code="404">Invitation code not found</response>
+// Gets user ID by invitation code
+// invitationCode: Invitation code to lookup
+// userService: User service for business logic
+// Returns: User ID associated with the invitation code
+// 200: User ID found and returned
+// 400: Invalid invitation code or error occurred
+// 404: Invitation code not found
 app.MapGet("/api/user/getUserIdByInvitationCode/{invitationCode}", async (string invitationCode, UserService userService) =>
 {
     var userId = await userService.GetUserIdByInvitationCode(invitationCode);
@@ -380,43 +362,37 @@ app.MapGet("/api/user/getUserIdByPhoneNumber/{phonenumber}", async (string phone
     return Results.Ok(userId);
 });
 
-/// <summary>
-/// Validates an invitation code
-/// </summary>
-/// <param name="request">Invitation validation request containing the code to validate</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Validation result with success status and message</returns>
-/// <response code="200">Invitation code validated successfully</response>
-/// <response code="400">Invalid invitation code or error occurred</response>
+// Validates an invitation code
+// request: Invitation validation request containing the code to validate
+// userService: User service for business logic
+// Returns: Validation result with success status and message
+// 200: Invitation code validated successfully
+// 400: Invalid invitation code or error occurred
 app.MapPost("/api/user/validate-invitation", async (ValidateInvitationRequest request, UserService userService) =>
 {
     var result = await userService.ValidateInvitationCodeAsync(request.InvitationCode);
     return Results.Ok(new { isValid = result.isValid, message = result.message });
 });
 
-/// <summary>
-/// Registers a new user with invitation code
-/// </summary>
-/// <param name="request">User registration request with invitation code</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Registered user details with success status</returns>
-/// <response code="200">User registered successfully with invitation</response>
-/// <response code="400">Invalid request data or validation error</response>
+// Registers a new user with invitation code
+// request: User registration request with invitation code
+// userService: User service for business logic
+// Returns: Registered user details with success status
+// 200: User registered successfully with invitation
+// 400: Invalid request data or validation error
 app.MapPost("/api/user/register-with-invitation", async (RegisterUserWithInvitationRequest request, UserService userService) =>
 {
     var user = await userService.RegisterUserAsync(request.User);
     return Results.Ok(new { success = true, userId = user.Id });
 });
 
-/// <summary>
-/// Updates the role of an existing user
-/// </summary>
-/// <param name="request">Role update request containing user ID and new role</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Success status with confirmation message</returns>
-/// <response code="200">User role updated successfully</response>
-/// <response code="400">Invalid request data or validation error</response>
-/// <response code="404">User not found</response>
+// Updates the role of an existing user
+// request: Role update request containing user ID and new role
+// userService: User service for business logic
+// Returns: Success status with confirmation message
+// 200: User role updated successfully
+// 400: Invalid request data or validation error
+// 404: User not found
 app.MapPost("/api/user/update-role", async (UpdateUserRoleRequest request, UserService userService) =>
 {
     var user = await userService.UpdateUserRoleAsync(request.UserId, request.NewRole);
@@ -426,14 +402,12 @@ app.MapPost("/api/user/update-role", async (UpdateUserRoleRequest request, UserS
     return Results.Ok(new { success = true, message = "نقش کاربر با موفقیت به‌روزرسانی شد." });
 });
 
-/// <summary>
-/// Gets all users by role
-/// </summary>
-/// <param name="role">Role to filter users by</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>List of users with the specified role</returns>
-/// <response code="200">Users found and returned successfully</response>
-/// <response code="400">Invalid role or error occurred</response>
+// Gets all users by role
+// role: Role to filter users by
+// userService: User service for business logic
+// Returns: List of users with the specified role
+// 200: Users found and returned successfully
+// 400: Invalid role or error occurred
 app.MapGet("/api/users/by-role/{role}", async (string role, UserService userService) =>
 {
     if (!Enum.TryParse<UserRole>(role, true, out var userRole))
@@ -443,29 +417,25 @@ app.MapGet("/api/users/by-role/{role}", async (string role, UserService userServ
     return Results.Ok(users);
 });
 
-/// <summary>
-/// Checks if a user exists by Telegram ID
-/// </summary>
-/// <param name="telegramId">Telegram ID to check</param>
-/// <param name="userService">User service for business logic</param>
-/// <returns>Boolean indicating if user exists</returns>
-/// <response code="200">User existence check completed</response>
-/// <response code="400">Error occurred during check</response>
+// Checks if a user exists by Telegram ID
+// telegramId: Telegram ID to check
+// userService: User service for business logic
+// Returns: Boolean indicating if user exists
+// 200: User existence check completed
+// 400: Error occurred during check
 app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService userService) =>
 {
     var exists = await userService.UserExistsAsync(telegramId);
     return Results.Ok(new { exists = exists });
 });
 
-/// <summary>
-/// Creates the default wallets for an existing user.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="userService">User service.</param>
-/// <returns>Whether it succeeded.</returns>
-/// <response code="200">Default wallets created.</response>
-/// <response code="400">Wallet creation failed.</response>
-/// <response code="404">User not found.</response>
+// Creates the default wallets for an existing user.
+// userId: User id.
+// userService: User service.
+// Returns: Whether it succeeded.
+// 200: Default wallets created.
+// 400: Wallet creation failed.
+// 404: User not found.
 app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, UserService userService) =>
 {
     var user = await userService.GetUserByIdAsync(userId);

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -230,7 +230,8 @@ app.MapPost("/api/user/register", async (RegisterUserRequest request, UserServic
     {
         return ApiResponse<UserDto>.Fail(ex.Message);
     }
-});
+})
+.WithTags("Users");
 
 // Updates the phone number for an existing user
 // request: Phone update request containing Telegram ID and new phone number
@@ -252,7 +253,8 @@ app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserSer
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Users");
 
 // Retrieves user information by Telegram ID
 // telegramId: Telegram ID of the user
@@ -267,7 +269,8 @@ app.MapGet("/api/user/{telegramId}", async (long telegramId, UserService userSer
         return Results.BadRequest(ApiResponse<UserDto>.Fail("User not found"));
 
     return Results.Ok(ApiResponse<UserDto>.Ok(user, "User loaded successfully"));
-});
+})
+.WithTags("Users");
 
 // Returns a user by id.
 // userId: User id.
@@ -290,7 +293,8 @@ app.MapGet("/api/user/userId/{userId}", async (Guid userId, UserService userServ
     return Results.Json(
         ApiResponse<UserDto>.Ok(user, "اطلاعات کاربر با موفقیت دریافت شد.")
     );
-});
+})
+.WithTags("Users");
 
 // Retrieves user information by phone number
 // phone: phone of the user
@@ -305,7 +309,8 @@ app.MapGet("/api/userByPhone/{phone}", async (string phone, UserService userServ
         return Results.BadRequest(ApiResponse<UserDto>.Fail("User not found"));
 
     return Results.Ok(ApiResponse<UserDto>.Ok(user, "User loaded successfully"));
-});
+})
+.WithTags("Users");
 
 
 app.MapGet("/api/users/list", async (
@@ -319,7 +324,8 @@ app.MapGet("/api/users/list", async (
 
     var users = await userService.GetUsersAsync(q, page, size);
     return Results.Ok(ApiResponse<PagedResult<UserDto>>.Ok(users, "کاربران دریافت شد"));
-});
+})
+.WithTags("Users");
 
 // Updates the status of an existing user
 // request: Status update request containing Telegram ID and new status
@@ -341,7 +347,8 @@ app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserServi
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Users");
 
 // Gets user ID by invitation code
 // invitationCode: Invitation code to lookup
@@ -354,13 +361,15 @@ app.MapGet("/api/user/getUserIdByInvitationCode/{invitationCode}", async (string
 {
     var userId = await userService.GetUserIdByInvitationCode(invitationCode);
     return Results.Ok(userId);
-});
+})
+.WithTags("Invitations");
 
 app.MapGet("/api/user/getUserIdByPhoneNumber/{phonenumber}", async (string phonenumber, UserService userService) =>
 {
     var userId = await userService.GetUserIdByPhoneNumber(phonenumber);
     return Results.Ok(userId);
-});
+})
+.WithTags("Users");
 
 // Validates an invitation code
 // request: Invitation validation request containing the code to validate
@@ -372,7 +381,8 @@ app.MapPost("/api/user/validate-invitation", async (ValidateInvitationRequest re
 {
     var result = await userService.ValidateInvitationCodeAsync(request.InvitationCode);
     return Results.Ok(new { isValid = result.isValid, message = result.message });
-});
+})
+.WithTags("Invitations");
 
 // Registers a new user with invitation code
 // request: User registration request with invitation code
@@ -384,7 +394,8 @@ app.MapPost("/api/user/register-with-invitation", async (RegisterUserWithInvitat
 {
     var user = await userService.RegisterUserAsync(request.User);
     return Results.Ok(new { success = true, userId = user.Id });
-});
+})
+.WithTags("Invitations");
 
 // Updates the role of an existing user
 // request: Role update request containing user ID and new role
@@ -400,7 +411,8 @@ app.MapPost("/api/user/update-role", async (UpdateUserRoleRequest request, UserS
         return Results.NotFound(new { success = false, message = "کاربر یافت نشد." });
 
     return Results.Ok(new { success = true, message = "نقش کاربر با موفقیت به‌روزرسانی شد." });
-});
+})
+.WithTags("Users");
 
 // Gets all users by role
 // role: Role to filter users by
@@ -415,7 +427,8 @@ app.MapGet("/api/users/by-role/{role}", async (string role, UserService userServ
 
     var users = await userService.GetUsersByRoleAsync(userRole);
     return Results.Ok(users);
-});
+})
+.WithTags("Users");
 
 // Checks if a user exists by Telegram ID
 // telegramId: Telegram ID to check
@@ -427,7 +440,8 @@ app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService 
 {
     var exists = await userService.UserExistsAsync(telegramId);
     return Results.Ok(new { exists = exists });
-});
+})
+.WithTags("Users");
 
 // Creates the default wallets for an existing user.
 // userId: User id.
@@ -466,7 +480,8 @@ app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, Use
             statusCode: 500
         );
     }
-});
+})
+.WithTags("Users");
 
 static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironment environment, string fileName)
 {

--- a/src/User/Users.Api/Users.Api.csproj
+++ b/src/User/Users.Api/Users.Api.csproj
@@ -6,9 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-	  <!--رفع باگ افزایش عدد سوم
-	  افزودن ویژگی جدید افزایش عدد دوم
-	  تغییر دیتابیس یا تغییرات پایه ای افزایش عدد اول-->
+	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
+       a database or foundational change the first. -->
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -167,13 +167,15 @@ app.MapGet("/api/wallet/balance/{userId}/{asset}", async (Guid userId, string as
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Balances");
 
 app.MapGet("/api/wallet/balances/{userId}", async (Guid userId, IWalletService walletService) =>
 {
     var wallets = await walletService.GetUserWalletsAsync(userId);
     return Results.Ok(ApiResponse<IEnumerable<WalletDTO>>.Ok(wallets, "لیست کیف پول های کاربر"));
-});
+})
+.WithTags("Balances");
 
 app.MapPost("/api/wallet/deposit", async (WalletRequest request, IWalletService walletService) =>
 {
@@ -188,7 +190,8 @@ app.MapPost("/api/wallet/deposit", async (WalletRequest request, IWalletService 
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
     }
   
-});
+})
+.WithTags("Transactions");
 
 app.MapPost("/api/wallet/withdrawal", async (WalletRequest request, IWalletService walletService) =>
 {
@@ -203,7 +206,8 @@ app.MapPost("/api/wallet/withdrawal", async (WalletRequest request, IWalletServi
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
     }
   
-});
+})
+.WithTags("Transactions");
 
 app.MapPost("/api/wallet/lockBalance", async (WalletRequest request, IWalletService walletService) =>
 {
@@ -218,7 +222,8 @@ app.MapPost("/api/wallet/lockBalance", async (WalletRequest request, IWalletServ
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
   
-});
+})
+.WithTags("Locks");
 
 app.MapPost("/api/wallet/unlockBalance", async (WalletRequest request, IWalletService walletService) =>
 {
@@ -231,7 +236,8 @@ app.MapPost("/api/wallet/unlockBalance", async (WalletRequest request, IWalletSe
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Locks");
 
 app.MapPost("/api/wallet/increaseBalance", async (WalletRequest request, IWalletService walletService) =>
 {
@@ -245,7 +251,8 @@ app.MapPost("/api/wallet/increaseBalance", async (WalletRequest request, IWallet
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Transactions");
 
 // Trade settlement — called by the Orders outbox processor after a match.
 // Atomically consumes both sides' locked collateral, credits each side, and records
@@ -272,7 +279,8 @@ app.MapPost("/api/wallet/changeBalance", async (TradeDto trade, IWalletService w
         logger.LogError(ex, "Error settling trade {TradeId}", trade.Id);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Transactions");
 
 app.MapPost("/api/wallet/transaction/trade", async (TradeRequest request, IWalletService walletService, ILogger<Program> logger, IConfiguration configuration) =>
 {
@@ -305,7 +313,8 @@ app.MapPost("/api/wallet/transaction/trade", async (TradeRequest request, IWalle
         logger.LogError(ex, "Error in MakeTradeAsync for users {FromUserId} -> {ToUserId}", request.FromUserId, request.ToUserId);
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Transactions");
 
 // The withdraw, charge, transfer, internal/credit and internal/debit endpoints were commented
 // out here rather than deleted. Their service methods still exist and are now unreachable —
@@ -317,16 +326,15 @@ app.MapGet("/api/wallet/transactions/{userId}", async (Guid userId, string? asse
 {
     var transactions = await walletService.GetUserTransactionsAsync(userId, asset);
     return Results.Ok(transactions);
-});
+})
+.WithTags("Transactions");
 
-/// <summary>
-/// Creates the wallets a new user starts with: Toman, gold, and the gold credit ledger.
-/// </summary>
-/// <param name="userId">User id.</param>
-/// <param name="walletService">Wallet service.</param>
-/// <returns>The wallets that were created.</returns>
-/// <response code="200">Default wallets created.</response>
-/// <response code="400">Wallet creation failed.</response>
+// Creates the wallets a new user starts with: Toman, gold, and the gold credit ledger.
+// userId: User id.
+// walletService: Wallet service.
+// Returns: The wallets that were created.
+// 200: Default wallets created.
+// 400: Wallet creation failed.
 app.MapGet("/api/wallet/create-default/{userId}", async (Guid userId, IWalletService walletService) =>
 {
     try
@@ -338,7 +346,8 @@ app.MapGet("/api/wallet/create-default/{userId}", async (Guid userId, IWalletSer
     {
         return Results.BadRequest(ApiResponse<IEnumerable<WalletDTO>>.Fail(ex.Message));
     }
-});
+})
+.WithTags("Wallets");
 
 static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironment environment, string fileName)
 {

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -128,30 +128,32 @@ using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
     var context = services.GetRequiredService<WalletDbContext>();
-    await context.Database.MigrateAsync(); // اجرای مایگریشن‌ها
+    await context.Database.MigrateAsync();
 }
 
 // Authentication and authorization, Production only.
 if (app.Environment.IsProduction())
 {
     app.UseAuthentication();
-    app.MapGet("/api-docs/{**path}", (string path) => Results.Redirect($"/api-docs/{path}"))
-       .AllowAnonymous();
 }
 app.UseAuthorization();
 
 // Apply the CORS policy.
 app.UseTallaEggCors();
 
-
-
-// Add Swagger middleware
-app.UseSwagger();
-app.UseSwaggerUI(c =>
+// API documentation, Development only. Swagger has no consumer in Production: the APIs are
+// called by the Telegram bot through hand-written typed clients, and nothing generates a client
+// from the OpenAPI document. Publishing the endpoint map and schemas there is attack surface
+// bought for nothing.
+if (app.Environment.IsDevelopment())
 {
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Wallet API v1");
-    c.RoutePrefix = "api-docs";
-});
+    app.UseSwagger();
+    app.UseSwaggerUI(c =>
+    {
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Wallet API v1");
+        c.RoutePrefix = "api-docs";
+    });
+}
 
 // Wallet management endpoints
 app.MapGet("/api/wallet/balance/{userId}/{asset}", async (Guid userId, string asset, IWalletService walletService) =>

--- a/src/Wallet/Wallet.Api/Wallet.Api.csproj
+++ b/src/Wallet/Wallet.Api/Wallet.Api.csproj
@@ -4,16 +4,12 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <!--رفع باگ افزایش عدد سوم
-	  افزودن ویژگی جدید افزایش عدد دوم
-	  تغییر دیتابیس یا تغییرات پایه ای افزایش عدد اول-->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
+       a database or foundational change the first. -->
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="Users.Api.csproj" />
-    <None Include="Users.Application.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />


### PR DESCRIPTION
**Branch Name**: `chore/clear-mechanical-compiler-warnings`
**Linked Issue/Task**: none — follows the re-audit's "Code hygiene 4/10" row in `docs/operations/RE_AUDIT_2026-08.md`

---

## Description

A clean Release rebuild emitted **168 warnings**. Roughly half were noise with no behavioural
risk, and the volume was the real cost: at 168, the one warning that matters is invisible. This
clears every mechanical category and leaves the ones that need a judgment per site. It also
fixes the parts of the Swagger setup that were cheap to fix and cost nothing to keep.

**168 → 85 warnings, 0 errors, 483/483 tests pass.**

---

## Type of Change
- [ ] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [x] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [x] Documentation (docs/comments only)
- [x] Security (auth, encryption, secrets rotation) — Swagger is no longer exposed in Production

---

## Changes Made

### Warnings cleared (83)

**CS1587 (58)** — XML doc comments on `app.MapGet`/`app.MapPost`/`app.MapPut` statements. C#
only accepts `///` on a type or member declaration, so these never reached the XML file and
Swagger never saw them: the warning was paid for and the documentation was not delivered. The 38
endpoint blocks keep every word, rewritten as plain `//` comments with the tags unwrapped
(`<param name="x">` becomes `x:`, `<response code="200">` becomes `200:`). The other 20 sat on
record positional parameters in `Orders.Api` and only restated the parameter name; two were
actively wrong for a gold platform ("Trading asset symbol (e.g., BTC, ETH, USDT)") and one named
a `TradingType.Futures` that does not exist. Those are deleted. Record-level summaries, which
are in a valid position, are untouched.

**CS0168 (18)** — a caught exception bound to a name that is never read, meaning the detail was
discarded. Deleting the identifier would have silenced the compiler while leaving the swallow in
place, so the exception is now **logged** instead: 9 endpoints in `Orders.Api` via Serilog's
static `Log`, and 6 client/service sites via the `ILogger` each class already holds.
`TelegramLoggerService` is the exception — it is the logger, so logging its own failure would
recurse; both catches there now say so.

**CS1998 (4)** — four bot list builders were `async` with nothing to await, allocating a state
machine per call. They return `Task.FromResult` now; no caller changes.

**CS0162 / CS0219 (3)** — an unreachable `return false` behind a live return in
`IsTelegramAdmin` (with the pre-#48 commented-out admin check above it), an unused
`defaultAmount = 1000m` left over from the two-limit-order model that #48 replaced, and an
unreachable trace log after a try/catch whose every branch returns.

### One real defect found on the way

`TelegramLoggerService`'s error path caught the send failure as `eex` and then wrote the
**original** exception to `SendExceptions.txt`, so the file recorded what was being reported and
never why reporting failed. It now persists both.

### Swagger

- **Development only** in Orders, Users and Wallet. It had no `IsDevelopment()` guard, and each
  service deliberately punched an anonymous hole for it in Production — a `MapGet` on
  `/api-docs/{**path}` marked `.AllowAnonymous()` that redirects to itself. That exists only so
  the `FallbackPolicy` would not block Swagger UI, and it is an infinite redirect for any path
  SwaggerUI's own middleware does not serve. More Production-only code that has never executed
  (audit finding N-4). There is no consumer to justify it: the APIs are called by the Telegram
  bot through hand-written typed clients, with no generated client and no stored OpenAPI
  document.
- `Users.Api` registered the whole Swagger middleware **twice**, identically. The duplicate is
  gone.
- **All 50 endpoints now carry `.WithTags`.** Fetching the live OpenAPI document showed every
  `Users.Api` operation under a single auto-generated tag named after the assembly — a flat,
  unnavigable list, and the same in `Wallet.Api` and in 13 of `Orders.Api`'s 24 endpoints. Tags
  are Quotes, Auto-quote, Symbols, Orders, Trades, Positions, Market Data, Outbox, Users,
  Invitations, Balances, Transactions, Locks, Wallets.
- **`Wallet.Api`'s `IncludeXmlComments` was dead**: no `GenerateDocumentationFile`, so the .xml
  never existed, the `File.Exists` guard returned false, and the call silently did nothing —
  configuration that looked like it worked. The project now generates the file. That also
  explains why `Wallet.Api` reported none of the 58 CS1587 warnings: same defect, no
  documentation file, so no warning to reveal it. That block is fixed too, and the compiler will
  catch the next one.
- **Eleven `.WithSummary`/`.WithDescription` strings translated to English.** Per `CLAUDE.md`,
  Persian is for what users see in the bot; developer-facing documentation is English, and
  Swagger is developer-facing. Wording preserved, only the language changes.

### Small tidying

- Removed two `<None Include>` entries in `Wallet.Api.csproj` naming `Users.Api.csproj` and
  `Users.Application.csproj`, neither of which exists in that directory — copy-paste residue.
- The Persian versioning comment in four `.csproj` files is now English. `Affiliate.Api.csproj`
  still has it, left alone because that service is out of scope by standing instruction.

---

## Testing Completed

### Unit Tests
- [x] All tests pass

```
dotnet test TallaEgg.sln -c Release --no-build
Passed! - Failed: 0, Passed: 483, Skipped: 0, Total: 483
```

### Build
```
dotnet build TallaEgg.sln -c Release -t:Rebuild
0 errors, 85 warnings (was 168)
```

### Manual verification
- The three running services (5136, 5140, 60933) were unaffected throughout and still respond.
- The live OpenAPI document was fetched from `Users.Api` before the change to confirm the flat
  single-tag grouping this PR fixes.

**Limit of verification, stated plainly:** the new tags are verified by compilation, not by a
running instance. A temporary instance could not be started on a spare port because
`Services:<name>:Urls` in the shared config is applied through `builder.WebHost.UseUrls`, which
overrides `--urls`. That is itself worth noting for #105 — on a real server the port cannot be
set per instance from the environment or the command line.

---

## Deliberately not done

- **The 74 nullable warnings** (`CS8602`, `CS8604`, `CS8618`, and friends). These are not noise —
  each needs a judgment about whether it is a real bug, needs a `?? throw`, or is weak flow
  analysis. Silencing them with `!` would be worse than leaving them.
- **`CS8981` (6)** on EF migration class names. Safe, but it renames generated files and belongs
  in its own change given how easily cross-service migration history desyncs.
- **The 170 `catch (Exception)` blocks.** A behavioural change, not hygiene — removing one means
  an error that was swallowed now propagates. Best done incrementally while working in each file.
- **Documenting the 39 endpoints with no summary.** Weighed and declined: the only API consumer
  is the Telegram bot through hand-written typed clients, and the endpoint documentation now
  lives in comments directly above each registration. Worth revisiting if #97 (web interface) or
  an external consumer arrives.

## A correction worth recording

An earlier claim of mine was wrong: EF migration classes in the generated `.xml` do **not**
pollute Swagger. Swashbuckle only applies documentation to types that appear in the OpenAPI
document, and the live document confirmed no migration schema is present. There was nothing to
fix there.

---

## Security

- Reduces Production surface: the OpenAPI document and Swagger UI are no longer served outside
  Development, and the anonymous `/api-docs/{**path}` exemption is removed from three services.
- No secrets touched. The diff was scanned for credential-shaped additions; none.
- No change to authentication, authorization, or the CORS whitelist.

## Deployment / Rollback

No migrations, no configuration values to set, no data change. Rollback is a revert of the two
commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
