### PR TITLE
docs: record that the tokens still visible in tracked files are already dead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,12 @@ The rules that get skipped most often:
   with no ceiling (that balance is the shop's book — alerting is #124), and commission is
   deliberately `0.00` on every trade because the revenue model is the spread. Fee code is dormant,
   not dead. Fuller list in [`AGENT.md`](AGENT.md) under "Business rules that look like bugs".
+- **The bot tokens still visible in tracked files are dead. Do not report them as a leak.** Two
+  literals remain in git — `TelegramBot/TestRunner/testsettings.json`, and the
+  `TelegramLoggerService` registration in `TallaEgg.TelegramBot.Infrastructure/Program.cs` where
+  the config lookup is commented out. Both values were rotated under #33 and confirmed dead by the
+  product owner (2026-08-27); the same is true of every other credential that ever reached this
+  repo. History is deliberately **not** rewritten — #105 records that decision and the reasoning,
+  and the constraint still holds. Grep will keep finding these strings, and every fresh session
+  rediscovers them and raises an incident; it is a false alarm each time. Deleting the literals
+  while working in those files is welcome, but it is cleanup, not a security response.


### PR DESCRIPTION
## Description

Two bot-token literals remain in tracked files — `TelegramBot/TestRunner/testsettings.json` and the `TelegramLoggerService` registration in `TallaEgg.TelegramBot.Infrastructure/Program.cs`, where the config lookup is commented out and a literal is passed instead. Both were rotated under #33 and are dead.

Every fresh session (human or agent) greps the repo, finds them, reads a live credential in a public repo, and escalates. It is a false alarm each time. `CLAUDE.md` is loaded automatically at the start of every session, which makes it the one place a note like this prevents the question instead of answering it afterwards.

The note also restates the constraint recorded in #105: history is deliberately **not** rewritten. The values are already dead, and a force-push over `main` would break every clone, fork and open branch for no security gain. Re-proposing a history scrub is the other half of the same false alarm.

## Type of Change
- [x] Documentation (docs/comments only)

## Changes Made
- One bullet added to `CLAUDE.md` under "Things that are easy to get wrong".

## Testing Completed
Documentation only — no code, no build impact.

## Security
No secrets added or removed. This documents the status of already-rotated values; it does not change them. Cleaning the literals out of those two files remains welcome as ordinary cleanup when someone is working there.

## Related
- #33 — the rotation
- #105 — the decision not to rewrite history, and why

🤖 Generated with [Claude Code](https://claude.com/claude-code)