### PR TITLE
chore: lock in the cleared warnings, and drop the catch blocks GlobalExceptionHandler already covers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,68 @@
+# TallaEgg editor configuration.
+#
+# Deliberately formatting-only. No analyzer severities are set here: turning rule sets on would
+# add hundreds of warnings overnight and undo the point of #132, which was to make the warning
+# count small enough that a real warning is visible. Style rules can be added later, one at a
+# time, each with its cleanup.
+#
+# This file changes what editors and `dotnet format` do to code as it is written. It does not
+# reformat anything on its own, and no existing file is touched by adding it.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{md,markdown}]
+# Two trailing spaces are a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.{csproj,props,targets,sln}]
+indent_size = 2
+
+[*.cs]
+indent_size = 4
+
+# Namespaces: the codebase uses both block-scoped and file-scoped. New files should prefer
+# file-scoped — one less level of indentation in a file that is usually one type.
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# `var` where the type is already obvious from the right-hand side, explicit where it is not.
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Braces on their own line, as the existing code does.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# `this.` is not used anywhere in this codebase.
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Private fields are _camelCase here.
+dotnet_naming_rule.private_fields_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_underscore.style = underscore_camel
+dotnet_naming_rule.private_fields_underscore.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.underscore_camel.required_prefix = _
+dotnet_naming_style.underscore_camel.capitalization = camel_case
+
+# Generated EF migrations are left exactly as the tooling writes them.
+[**/Migrations/*.cs]
+generated_code = true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,13 @@
 ﻿<Project>
+
+  <PropertyGroup>
+    <!-- Warning classes that were driven to zero in #132. As errors they cannot creep back one
+         file at a time, which is how the count reached 168 in the first place. Deliberately not
+         the nullable family (CS86xx): 74 of those remain, each needs a judgment about whether it
+         is a real bug, and failing the build on them would only invite silencing with `!`. -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS1587;CS0168;CS1998;CS0162;CS0219</WarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- config/appsettings.global.json is git-ignored (issue #33), so a fresh clone or CI
          checkout won't have it yet — only include it when a local copy actually exists. -->

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -465,11 +465,6 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
     {
         return Results.BadRequest(ApiResponse<CreateOrderResponse>.Fail(ex.Message));
     }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error creating an order.");
-        return Results.Json(ApiResponse<CreateOrderResponse>.Fail("خطای داخلی سرور"), statusCode: 500);
-    }
 })
 .WithName("CreateOrder")
 .WithSummary("Create an order")
@@ -486,19 +481,11 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
 // 404: Order not found.
 app.MapGet("/api/orders/{orderId}", async (Guid orderId, OrderService orderService) =>
 {
-    try
-    {
-        var order = await orderService.GetOrderByIdAsync(orderId);
-        if (order == null)
-            return Results.NotFound(new { success = false, message = $"سفارش با شناسه {orderId} یافت نشد" });
+    var order = await orderService.GetOrderByIdAsync(orderId);
+    if (order == null)
+        return Results.NotFound(new { success = false, message = $"سفارش با شناسه {orderId} یافت نشد" });
 
-        return Results.Ok(new { success = true, data = order });
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error fetching order {OrderId}.", orderId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    return Results.Ok(new { success = true, data = order });
 })
 .WithName("GetOrderById")
 .WithSummary("Get an order by id")
@@ -528,11 +515,6 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
     {
         return Results.BadRequest(new { success = false, message = ex.Message });
     }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error cancelling order {OrderId}.", orderId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
 })
 .WithName("CancelOrder")
 .WithSummary("Cancel an order")
@@ -552,19 +534,11 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
 // cancelled, wrapped in the standard ApiResponse shape.
 app.MapPost("/api/orders/user/{userId}/cancel-active", async (Guid userId, string? reason, OrderService orderService) =>
 {
-    try
-    {
-        var cancelledCount = await orderService.CancelAllActiveOrdersByUserIdAsync(userId, reason ?? "لغو همه سفارشات فعال");
-        
-        var response = new CancelActiveOrdersResponseDto { CancelledCount = cancelledCount };
-        
-        return Results.Ok(ApiResponse<CancelActiveOrdersResponseDto>.Ok(response, $"{cancelledCount} سفارش فعال لغو شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error cancelling the active orders of user {UserId}.", userId);
-        return Results.Json(ApiResponse<CancelActiveOrdersResponseDto>.Fail("خطای داخلی سرور"), statusCode: 500);
-    }
+    var cancelledCount = await orderService.CancelAllActiveOrdersByUserIdAsync(userId, reason ?? "لغو همه سفارشات فعال");
+    
+    var response = new CancelActiveOrdersResponseDto { CancelledCount = cancelledCount };
+    
+    return Results.Ok(ApiResponse<CancelActiveOrdersResponseDto>.Ok(response, $"{cancelledCount} سفارش فعال لغو شد"));
 })
 .WithName("CancelUserActiveOrders")
 .WithSummary("Cancel every active order of a user")
@@ -638,16 +612,8 @@ app.MapGet("/api/orders/user/{userId}", async (
     if (page < 1)
         return Results.BadRequest(new { success = false, message = "شماره صفحه باید بیشتر از صفر باشد" });
 
-    try
-    {
-        var orders = await orderService.GetOrdersByUserIdAsync(userId, page, size);
-        return Results.Ok(ApiResponse<PagedResult<OrderHistoryDto>>.Ok(orders, "سفارشات دریافت شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error fetching the orders of user {UserId}.", userId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    var orders = await orderService.GetOrdersByUserIdAsync(userId, page, size);
+    return Results.Ok(ApiResponse<PagedResult<OrderHistoryDto>>.Ok(orders, "سفارشات دریافت شد"));
 })
 .WithName("GetUserOrders")
 .WithSummary("Get a user's orders")
@@ -676,16 +642,8 @@ app.MapGet("/api/trades/user/{userId}", async (
     if (page < 1)
         return Results.BadRequest(new { success = false, message = "شماره صفحه باید بیشتر از صفر باشد" });
 
-    try
-    {
-        var trades = await tradeService.GetTradesByUserIdAsync(userId, page, size);
-        return Results.Ok(ApiResponse<PagedResult<TradeHistoryDto>>.Ok(trades, "معاملات دریافت شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error fetching the trades of user {UserId}.", userId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    var trades = await tradeService.GetTradesByUserIdAsync(userId, page, size);
+    return Results.Ok(ApiResponse<PagedResult<TradeHistoryDto>>.Ok(trades, "معاملات دریافت شد"));
 })
 .WithName("GetUserTrades")
 .WithSummary("Get a user's trades")
@@ -700,16 +658,8 @@ app.MapGet("/api/positions/user/{userId}", async (
     Guid userId,
     Orders.Application.Services.PositionService positionService) =>
 {
-    try
-    {
-        var positions = await positionService.GetPositionsAsync(userId);
-        return Results.Ok(ApiResponse<PositionsResponseDto>.Ok(positions, "سود و زیان دریافت شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Error computing positions for user {UserId}", userId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    var positions = await positionService.GetPositionsAsync(userId);
+    return Results.Ok(ApiResponse<PositionsResponseDto>.Ok(positions, "سود و زیان دریافت شد"));
 })
 .WithName("GetUserPositions")
 .WithSummary("Get a user's position and profit/loss across every symbol")
@@ -727,33 +677,25 @@ app.MapGet("/api/orders/active/user/{userId}", async (
     Guid userId,
     OrderService orderService) =>
 {
-    try
+    var orders = await orderService.GetActiveOrdersByUserIdAsync(userId);
+    var orderDtos = orders.Select(o => new OrderHistoryDto
     {
-        var orders = await orderService.GetActiveOrdersByUserIdAsync(userId);
-        var orderDtos = orders.Select(o => new OrderHistoryDto
-        {
-            Id = o.Id,
-            Asset = o.Asset,
-            Amount = o.Amount,
-            RemainingAmount = o.RemainingAmount,
-            Price = o.Price,
-            Type = o.Side,
-            Status = o.Status,
-            TradingType = o.TradingType,
-            Role = o.Role,
-            CreatedAt = o.CreatedAt,
-            UpdatedAt = o.UpdatedAt,
-            Notes = o.Notes,
-            ParentOrderId = o.ParentOrderId
-        }).ToList();
+        Id = o.Id,
+        Asset = o.Asset,
+        Amount = o.Amount,
+        RemainingAmount = o.RemainingAmount,
+        Price = o.Price,
+        Type = o.Side,
+        Status = o.Status,
+        TradingType = o.TradingType,
+        Role = o.Role,
+        CreatedAt = o.CreatedAt,
+        UpdatedAt = o.UpdatedAt,
+        Notes = o.Notes,
+        ParentOrderId = o.ParentOrderId
+    }).ToList();
 
-        return Results.Ok(ApiResponse<List<OrderHistoryDto>>.Ok(orderDtos, "سفارشات فعال دریافت شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error fetching the active orders of user {UserId}.", userId);
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    return Results.Ok(ApiResponse<List<OrderHistoryDto>>.Ok(orderDtos, "سفارشات فعال دریافت شد"));
 })
 .WithName("GetUserActiveOrders")
 .WithSummary("Get a user's active orders")
@@ -768,33 +710,25 @@ app.MapGet("/api/orders/active/user/{userId}", async (
 // 500: Internal server error.
 app.MapGet("/api/orders/active/all", async (OrderService orderService) =>
 {
-    try
+    var orders = await orderService.GetAllActiveOrdersAsync();
+    var orderDtos = orders.Select(o => new OrderHistoryDto
     {
-        var orders = await orderService.GetAllActiveOrdersAsync();
-        var orderDtos = orders.Select(o => new OrderHistoryDto
-        {
-            Id = o.Id,
-            Asset = o.Asset,
-            Amount = o.Amount,
-            RemainingAmount = o.RemainingAmount,
-            Price = o.Price,
-            Type = o.Side,
-            Status = o.Status,
-            TradingType = o.TradingType,
-            Role = o.Role,
-            CreatedAt = o.CreatedAt,
-            UpdatedAt = o.UpdatedAt,
-            Notes = o.Notes,
-            ParentOrderId = o.ParentOrderId
-        }).ToList();
+        Id = o.Id,
+        Asset = o.Asset,
+        Amount = o.Amount,
+        RemainingAmount = o.RemainingAmount,
+        Price = o.Price,
+        Type = o.Side,
+        Status = o.Status,
+        TradingType = o.TradingType,
+        Role = o.Role,
+        CreatedAt = o.CreatedAt,
+        UpdatedAt = o.UpdatedAt,
+        Notes = o.Notes,
+        ParentOrderId = o.ParentOrderId
+    }).ToList();
 
-        return Results.Ok(ApiResponse<List<OrderHistoryDto>>.Ok(orderDtos, "تمام سفارشات فعال دریافت شد"));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Unhandled error fetching all active orders.");
-        return Results.Json(new { success = false, message = "خطای داخلی سرور" }, statusCode: 500);
-    }
+    return Results.Ok(ApiResponse<List<OrderHistoryDto>>.Ok(orderDtos, "تمام سفارشات فعال دریافت شد"));
 })
 .WithName("GetAllActiveOrders")
 .WithSummary("Get every active order")


### PR DESCRIPTION
**Branch Name**: `chore/lock-in-warnings-and-use-global-handler`
**Linked Issue/Task**: follows #132 (warning cleanup) and #88 (`GlobalExceptionHandler`)

---

## Description

Two things, both about making previous work actually stick.

First, #132 drove five warning classes to zero. Nothing stopped them coming back one file at a
time — which is how the count reached 168 in the first place, since no single commit ever added a
hundred warnings. They are now build errors.

Second, nine endpoints in `Orders.Api` were hand-rolling what `GlobalExceptionHandler` has done
since #88, and doing it worse. They are gone.

---

## Type of Change
- [ ] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [x] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

### 1. Five warning classes are now errors

`Directory.Build.props`:

| Code | Meaning |
|---|---|
| `CS1587` | XML doc comment in an invalid position |
| `CS0168` | caught exception never read |
| `CS1998` | `async` method with nothing to `await` |
| `CS0162` | unreachable code |
| `CS0219` | assigned but never used |

All five are at zero today, so this changes no current build. It changes the next one.

**Verified rather than assumed.** A deliberate `catch (Exception probeEx) { }` was inserted into
`Orders.Application`, the build failed with `error CS0168`, and the probe was removed:

```
OrderService.cs(550,63): error CS0168: The variable 'probeEx' is declared but never used
    1 Error(s)
```

The nullable family (`CS86xx`) is **excluded on purpose**. 74 of those remain and each needs a
judgment — real bug, missing `?? throw`, or weak flow analysis. Failing the build on them would
not produce that judgment; it would produce a scattering of `!` operators, which is worse than
the warning.

> **Note:** `TelegramBot/TestRunner` has 8 `CS1998` and will now fail if built directly. It is not
> in the solution, so neither the local build nor CI touches it. That project is a separate open
> question.

### 2. `.editorconfig`, which the repo did not have

Formatting only — encoding, line endings, indentation, brace placement, `_camelCase` private
fields, file-scoped namespaces for new files. **No analyzer severities**: turning rule sets on
would add hundreds of warnings overnight and undo the point of #132. Adding the file reformats
nothing; it changes what editors and `dotnet format` do to code as it is written.

### 3. Nine duplicate catch blocks removed from `Orders.Api`

Each one was: log the exception, return `خطای داخلی سرور` with status 500.

`GlobalExceptionHandler` already does exactly that for every unhandled exception — and also
records `TraceId`, `Method` and `Path`, and sets an `X-Trace-Id` header the caller can quote when
reporting a fault. The local copies had none of that. The duplication was not merely redundant;
it was the worse of the two paths, and it shadowed the better one.

It also settles a response-shape inconsistency. Seven of the nine returned
`new { success = false, message = ... }` — an anonymous object, lower-cased, unlike every other
response in the API, which is `ApiResponse<T>` with `Success`/`Message`/`Data` (Orders.Api sets
`PropertyNamingPolicy = null`, so casing is preserved as written). Two returned a typed
`ApiResponse<T>.Fail`. All 500s are now identical.

**Safe for the bot:** its typed clients check `IsSuccessStatusCode` before deserializing, and the
one place that does read an error body — `OrderApiClient`, around the best-prices call — parses
it as `ApiResponse<object>`, which is the shape the global handler emits and *not* the shape
those seven produced.

Where a removed catch was the only one, the surrounding `try` goes with it and the body is
de-indented. Where it was the last clause of a typed ladder (`CreateOrder`, `CancelOrder`), only
the clause is removed and the ladder stands.

**Two generic-500 catches are deliberately kept**, because they say something the global handler
cannot: `ConfirmOrder` reports `خطای داخلی سرور در تایید سفارش`, and the best-prices endpoint adds
`لطفاً مجدداً تلاش کنید`. Both are user-facing Persian text with information in it, so they are not
duplication.

Net: **117 lines removed, 51 added.**

---

## Testing Completed

### Unit Tests
- [x] All tests pass

```
dotnet test TallaEgg.sln -c Release --no-build
Passed! - Failed: 0, Passed: 483, Skipped: 0, Total: 483
```

### Build
```
dotnet build TallaEgg.sln -c Release -t:Rebuild
0 errors, 85 warnings
```

Warning count is unchanged, as expected — this PR prevents future warnings and removes code, it
does not clear any remaining ones.

---

## Still outstanding, deliberately not in this PR

**26 catch blocks return `ex.Message` straight to the caller** — Orders (14), Wallet (9), Users
(3), Affiliate (1). These bypass the global handler too, and worse, they can put a raw .NET
exception string in front of a Persian-speaking user. But fixing them changes what a user is
shown, so it needs a decision rather than a sweep. Worth its own issue.

---

## Deployment / Rollback

No migrations, no configuration values, no data change. Rollback is a revert of the two commits.
The `WarningsAsErrors` change is the only one that can fail a future build, and only by catching
a newly introduced warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
