### PR TITLE
fix: null references in WalletApiClient and BotHandler (85 -> 55 warnings)

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -152,7 +152,11 @@ namespace TallaEgg.TelegramBot
             await _telegramLogger.LogAsync<Message>($"✔➕ new message:",message);
 
 
-            message.Text = TallaEgg.Core.Utilties.Utils.ConvertPersianDigitsToEnglish(message.Text);
+            // Absent on a contact, photo or sticker message, all of which reach this handler.
+            if (message.Text is not null)
+            {
+                message.Text = TallaEgg.Core.Utilties.Utils.ConvertPersianDigitsToEnglish(message.Text);
+            }
 
             // Check if user exists
             var user = await _usersApi.GetUserAsync(telegramId);
@@ -272,9 +276,9 @@ namespace TallaEgg.TelegramBot
 
         private async Task HandlePhoneNumberRequestAsync(long chatId, long telegramId, Message message)
         {
-            if (message.Contact?.PhoneNumber != null)
+            var phoneNumber = message.Contact?.PhoneNumber;
+            if (phoneNumber != null)
             {
-                var phoneNumber = message.Contact?.PhoneNumber;
                 if (phoneNumber.StartsWith("98"))//98938621990
                 {
                     phoneNumber = phoneNumber.Replace("98", "0");
@@ -338,11 +342,22 @@ namespace TallaEgg.TelegramBot
                     var adminIds = (await _usersApi.GetOperatorTelegramIdsAsync())
                         .Union(_ownerTelegramIds)
                         .ToList();
-                    await _messenger.SendApproveOrRejectUserToAdminsKeyboard(adminIds, response.Data);
+                    if (response.Data is not null)
+                    {
+                        await _messenger.SendApproveOrRejectUserToAdminsKeyboard(adminIds, response.Data);
+                    }
+                    else
+                    {
+                        // A success with no user in it is a contract violation by the Users API,
+                        // not something the customer can act on, so it is logged rather than shown.
+                        _logger.LogError(
+                            "Users API reported a successful registration for {TelegramId} but returned no user.",
+                            telegramId);
+                    }
                 }
                 else
                 {
-                    await _messenger.SendAsync(chatId, response.Message);
+                    await _messenger.SendAsync(chatId, response.Message ?? BotMsgs.MsgUnexpectedError);
                 }
             }
             else
@@ -443,9 +458,21 @@ namespace TallaEgg.TelegramBot
 
         public async Task HandleCallbackQueryAsync(CallbackQuery callbackQuery)
         {
-            var chatId = callbackQuery.Message?.Chat.Id ?? 0;
-            var telegramId = callbackQuery.From?.Id ?? 0;
+            // Telegram omits Message for callbacks raised from an inline message, and for any
+            // message older than 48 hours. Every branch below edits or deletes that message, and
+            // the chat id used to fall back to 0, which no send can reach — so none of them could
+            // do anything useful anyway. Answering the callback stops the client's spinner and
+            // says why, instead of an unhandled NullReferenceException on the first old button
+            // somebody taps.
+            if (callbackQuery.Message is null)
+            {
+                await _messenger.AnswerCallbackAsync(callbackQuery.Id, BotMsgs.MsgCallbackMessageGone);
+                return;
+            }
+
             var message = callbackQuery.Message;
+            var chatId = message.Chat.Id;
+            var telegramId = callbackQuery.From?.Id ?? 0;
             var data = callbackQuery.Data ?? "";
 
             switch (data)
@@ -526,18 +553,23 @@ namespace TallaEgg.TelegramBot
                         // Both prices come from the same published Quote (issue #48) — always
                         // both present or both absent — so either one missing means there is no
                         // quote for this symbol at all, not merely a one-sided book.
-                        var hasQuote = apiResponse is { Success: true, Data: not null }
+                        // The published quote, or null when there is none. Held as the value
+                        // rather than a bool so the branch below reads it without having to assert
+                        // it is there.
+                        var quote = apiResponse is { Success: true, Data: not null }
                             && apiResponse.Data.BestBidPrice.HasValue
-                            && apiResponse.Data.BestAskPrice.HasValue;
+                            && apiResponse.Data.BestAskPrice.HasValue
+                                ? apiResponse.Data
+                                : null;
 
                         if (apiResponse != null && apiResponse.Success)
                         {
                             await _messenger.DeleteAsync(chatId, message.Id);
 
                             await _messenger.SendAsync(chatId, BestPricesMessage.Build(
-                                apiResponse.Data.BestBidPrice, apiResponse.Data.BestAskPrice, asset));
+                                apiResponse.Data?.BestBidPrice, apiResponse.Data?.BestAskPrice, asset));
 
-                            if (hasQuote)
+                            if (quote is not null)
                             {
                                 // Stored for the market-order path (HandleOrderTypeSelectionAsync),
                                 // which feeds this straight into HandleOrderPriceInputAsync — the same
@@ -547,11 +579,11 @@ namespace TallaEgg.TelegramBot
                                 // such internal/display split and is stored as-is.
                                 var isGold = asset == CurrenciesConstant.MAUA_IRT;
                                 assetConversation.BestBidPrice = isGold
-                                    ? apiResponse.Data.BestBidPrice * CurrenciesConstant.GramsPerMesghal
-                                    : apiResponse.Data.BestBidPrice;
+                                    ? quote.BestBidPrice * CurrenciesConstant.GramsPerMesghal
+                                    : quote.BestBidPrice;
                                 assetConversation.BestAskPrice = isGold
-                                    ? apiResponse.Data.BestAskPrice * CurrenciesConstant.GramsPerMesghal
-                                    : apiResponse.Data.BestAskPrice;
+                                    ? quote.BestAskPrice * CurrenciesConstant.GramsPerMesghal
+                                    : quote.BestAskPrice;
                             }
                         }
 
@@ -559,7 +591,7 @@ namespace TallaEgg.TelegramBot
                         // asks for a price, so with no quote it has nothing to trade on. The
                         // order-book (limit) path is unaffected: it asks the customer for a
                         // price itself and never depended on GetBestPricesAsync succeeding.
-                        if (hasQuote || assetConversation.OrderType != OrderType.Market)
+                        if (quote is not null || assetConversation.OrderType != OrderType.Market)
                         {
                             await _messenger.SendSpotSideMenuKeyboard(chatId);
                         }
@@ -607,8 +639,8 @@ namespace TallaEgg.TelegramBot
 
                             // Edit the previous message.
                             await _messenger.EditTextAsync(
-                                chatId: callbackQuery.Message.Chat.Id,
-                                messageId: callbackQuery.Message.MessageId,
+                                chatId: message.Chat.Id,
+                                messageId: message.MessageId,
                                 text: text,
                                 replyMarkup: OrderListHandler.BuildPagingKeyboard(page.Data!, pageNum, uid)
                             );
@@ -635,8 +667,8 @@ namespace TallaEgg.TelegramBot
 
                             // Edit the previous message.
                             await _messenger.EditTextAsync(
-                                chatId: callbackQuery.Message.Chat.Id,
-                                messageId: callbackQuery.Message.MessageId,
+                                chatId: message.Chat.Id,
+                                messageId: message.MessageId,
                                 text: text,
                                 replyMarkup: TradeListHandler.BuildPagingKeyboard(page.Data!, pageNum, uid)
                             );
@@ -666,8 +698,8 @@ namespace TallaEgg.TelegramBot
                             var quotePageResult = await _orderApi.GetQuoteHistoryAsync(symbol, quotePage, pageSize: 5);
 
                             await _messenger.EditTextAsync(
-                                chatId: callbackQuery.Message.Chat.Id,
-                                messageId: callbackQuery.Message.MessageId,
+                                chatId: message.Chat.Id,
+                                messageId: message.MessageId,
                                 text: QuoteHistoryHandler.BuildQuoteHistoryAsync(quotePageResult, quotePage, isAdmin, symbol),
                                 replyMarkup: QuoteHistoryHandler.BuildPagingKeyboard(quotePageResult, quotePage, symbol));
 
@@ -686,8 +718,8 @@ namespace TallaEgg.TelegramBot
                                 
                                 // Delete the message or update it.
                                 await _messenger.EditTextAsync(
-                                    chatId: callbackQuery.Message.Chat.Id,
-                                    messageId: callbackQuery.Message.MessageId,
+                                    chatId: message.Chat.Id,
+                                    messageId: message.MessageId,
                                     text: "✅ سفارش لغو شد و از فهرست حذف گردید.",
                                     replyMarkup: null
                                 );
@@ -713,8 +745,8 @@ namespace TallaEgg.TelegramBot
 
                             // Edit the previous message.
                             await _messenger.EditTextAsync(
-                                chatId: callbackQuery.Message.Chat.Id,
-                                messageId: callbackQuery.Message.MessageId,
+                                chatId: message.Chat.Id,
+                                messageId: message.MessageId,
                                 text: text,
                                 parseMode: ParseMode.MarkdownV2,
                                 replyMarkup: UserListHandler.BuildPagingKeyboard(page.Data!, newPage, query)
@@ -970,7 +1002,7 @@ namespace TallaEgg.TelegramBot
             var res = await _walletApi.GetUserWalletsBalanceAsync(userId);
             if (res.Success)
             {
-                if (res.Data.Any())
+                if (res.Data?.Any() == true)
                 {
                     // A failed positions fetch must not block the balance screen the customer
                     // actually asked for -- WalletBalanceMessage treats a null positions
@@ -990,7 +1022,7 @@ namespace TallaEgg.TelegramBot
             else
             {
 
-                await _messenger.SendAsync(chatId, res.Message);
+                await _messenger.SendAsync(chatId, res.Message ?? BotMsgs.MsgUnexpectedError);
             }
 
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -461,6 +461,14 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string MsgNotAuthorized = "شما اجازهٔ این کار را ندارید.";
 
         /// <summary>
+        /// Reply when a button is pressed on a message Telegram no longer sends us — an inline
+        /// message, or anything older than 48 hours. Every callback branch edits or deletes that
+        /// message, so there is nothing to act on and the customer needs to start again.
+        /// </summary>
+        public const string MsgCallbackMessageGone =
+            "این پیام قدیمی است. لطفاً از منوی اصلی دوباره شروع کنید.";
+
+        /// <summary>
         /// The generic reply when handling a user's message stops on an unexpected error with no
         /// specific response from the handler (issue #99). This is what keeps a raw exception message
         /// from ever reaching a user.

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -128,7 +128,8 @@ public class Program
                 services.AddSingleton<WalletApiClient>(provider =>
                 {
                     var options = provider.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
-                    return new WalletApiClient(options.WalletApiUrl);
+                    return new WalletApiClient(options.WalletApiUrl,
+                        provider.GetRequiredService<ILogger<WalletApiClient>>());
                 });
 
                 services.AddSingleton<TradeNotificationService>();

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -80,7 +80,8 @@ services.AddSingleton<AffiliateApiClient>(p =>
 services.AddSingleton<WalletApiClient>(p =>
 {
     var options = p.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
-    return new WalletApiClient(options.WalletApiUrl!);
+    return new WalletApiClient(options.WalletApiUrl!,
+        p.GetRequiredService<ILogger<WalletApiClient>>());
 });
 
 // Same wiring the real bot uses (issue #65) — only IBotMessenger, ITelegramLogger and

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -579,9 +579,7 @@ public class WalletApiClient : IWalletApiClient
 
             if (response.IsSuccessStatusCode)
             {
-                // _logger is called with ?. deliberately: one of this class's constructors takes no
-                // logger and leaves it null.
-                _logger?.LogInformation(
+                _logger.LogInformation(
                     "Trade {TradeId} settled by the wallet service. Symbol: {Symbol}, quantity: {Quantity}, quote: {QuoteQuantity}.",
                     trade.Id, trade.Symbol, trade.Quantity, trade.QuoteQuantity);
 
@@ -590,7 +588,7 @@ public class WalletApiClient : IWalletApiClient
 
             var reason = parsed ?? $"سرویس کیف پول کد {(int)response.StatusCode} برگرداند.";
 
-            _logger?.LogWarning(
+            _logger.LogWarning(
                 "Wallet service rejected settlement of trade {TradeId} with status {StatusCode}: {Reason}",
                 trade.Id, (int)response.StatusCode, reason);
 
@@ -598,7 +596,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error settling trade {TradeId} against the wallet service.", trade.Id);
+            _logger.LogError(ex, "Error settling trade {TradeId} against the wallet service.", trade.Id);
             return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}");
         }
     }
@@ -622,7 +620,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (JsonException)
         {
-            _logger?.LogDebug("Wallet settlement response was not a parsable ApiResponse: {Body}", body);
+            _logger.LogDebug("Wallet settlement response was not a parsable ApiResponse: {Body}", body);
             return null;
         }
     }

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Text;
 using System.Text.Json;
 using TallaEgg.Core;
@@ -18,11 +19,19 @@ namespace TallaEgg.Infrastructure.Clients;
 public class WalletApiClient : IWalletApiClient
 {
     private readonly HttpClient _httpClient;
-    private readonly ILogger<WalletApiClient>? _logger;
+    private readonly ILogger<WalletApiClient> _logger;
     private readonly string? _walletApiUrl;
 
-    public WalletApiClient(string? apiUrl)
+    /// <summary>
+    /// Builds its own <see cref="HttpClient"/> for callers outside a DI container. The logger is
+    /// optional only so existing call sites keep compiling; pass one. Without it the field falls
+    /// back to <see cref="NullLogger{T}"/> rather than staying null, because every log call in
+    /// this class is unconditional and a null field would turn a successful lock into a
+    /// <see cref="NullReferenceException"/>.
+    /// </summary>
+    public WalletApiClient(string? apiUrl, ILogger<WalletApiClient>? logger = null)
     {
+        _logger = logger ?? NullLogger<WalletApiClient>.Instance;
 
         var handler = new HttpClientHandler();
 #if DEBUG
@@ -309,7 +318,10 @@ public class WalletApiClient : IWalletApiClient
                 var result = JsonSerializer.Deserialize<ApiResponse<IEnumerable<WalletDTO>>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-                return result;
+                // Deserialize returns null for a literal "null" body. The signature promises a
+                // response, so a caller reading .Success on it would get a NullReferenceException
+                // instead of a failure it can report.
+                return result ?? ApiResponse<IEnumerable<WalletDTO>>.Fail("خطا در دریفات اطلاعات");
             }
 
             return TallaEgg.Core.DTOs.ApiResponse<IEnumerable<WalletDTO>>.Fail("خطا در دریفات اطلاعات");
@@ -317,7 +329,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error fetching the wallet balances of user {UserId}.", userId);
+            _logger.LogError(ex, "Error fetching the wallet balances of user {UserId}.", userId);
             return TallaEgg.Core.DTOs.ApiResponse<IEnumerable<WalletDTO>>.Fail("خطا در ارتباط با سرور");
 
         }
@@ -358,14 +370,27 @@ public class WalletApiClient : IWalletApiClient
                     //var walletDto = JsonConvert.DeserializeObject<ApiResponse<WalletDTO>>(responseContent);
                     
                     // Parse the response which should be in the format: { success, message, hasSufficientBalance }
-                    var walletDto = JsonSerializer.Deserialize<ApiResponse<WalletDTO>> (responseContent,
+                    var walletDto = JsonSerializer.Deserialize<ApiResponse<WalletDTO>>(responseContent,
                         new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+                    // A body of "null", or one shaped like the envelope but carrying no wallet,
+                    // parses without throwing. Reaching through it would raise a
+                    // NullReferenceException, which this JsonException handler does not catch, so
+                    // an unreadable payload would escape the method instead of being reported as
+                    // one.
+                    if (walletDto?.Data is null)
+                    {
+                        _logger.LogError(
+                            "Balance response for user {UserId}, asset {Asset} parsed but carried no wallet.",
+                            userId, asset);
+                        return (false, "خطا در پردازش اطلاعات دریافتی: پاسخ سرور قابل تفسیر نیست.", null);
+                    }
 
                     return (true, "موجودی دریافت شد.", walletDto.Data.Balance);
                 }
                 catch (JsonException jsonEx)
                 {
-                    _logger?.LogError(jsonEx, "Unreadable balance payload for user {UserId}, asset {Asset}.", userId, asset);
+                    _logger.LogError(jsonEx, "Unreadable balance payload for user {UserId}, asset {Asset}.", userId, asset);
                     return (false, $"خطا در پردازش اطلاعات دریافتی: پاسخ سرور قابل تفسیر نیست.", null);
                 }
             }
@@ -432,7 +457,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (JsonException jsonEx)
         {
-            _logger?.LogError(jsonEx, "Unreadable error payload for user {UserId}, asset {Asset}.", userId, asset);
+            _logger.LogError(jsonEx, "Unreadable error payload for user {UserId}, asset {Asset}.", userId, asset);
             // JSON parsing errors
             return (false, "خطا در پردازش اطلاعات دریافتی از سرور.", null);
         }
@@ -479,7 +504,9 @@ public class WalletApiClient : IWalletApiClient
                 var result = JsonSerializer.Deserialize<ApiResponse<WalletBallanceDTO>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-                return result;
+                // Deserialize returns null for a literal "null" body; see the note in
+                // GetUserWalletsBalanceAsync.
+                return result ?? ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
             }
 
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
@@ -487,7 +514,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error depositing to the wallet of user {UserId}.", request.UserId);
+            _logger.LogError(ex, "Error depositing to the wallet of user {UserId}.", request.UserId);
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در ارتباط با سرور");
 
         }
@@ -514,7 +541,9 @@ public class WalletApiClient : IWalletApiClient
                 var result = JsonSerializer.Deserialize<ApiResponse<WalletBallanceDTO>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
-                return result;
+                // Deserialize returns null for a literal "null" body; see the note in
+                // GetUserWalletsBalanceAsync.
+                return result ?? ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
             }
 
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
@@ -522,7 +551,7 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Error withdrawing from the wallet of user {UserId}.", request.UserId);
+            _logger.LogError(ex, "Error withdrawing from the wallet of user {UserId}.", request.UserId);
             return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در ارتباط با سرور");
 
         }


### PR DESCRIPTION
**Branch Name**: `fix/wallet-client-null-logger`
**Linked Issue/Task**: phase 4 of the code-hygiene plan; follows #132 and #134

---

## Description

The nullable warnings were deliberately left out of #134 because each needs a judgment rather than
a sweep. This works through the two files that carried the most of them —
`WalletApiClient.cs` (14) and `BotHandler.cs` (16) — and they were not noise. Two are latent
`NullReferenceException`s on paths that will be reached, and several more turn an unreadable API
response into a crash instead of a reported failure.

**85 → 55 warnings. Both files are now at zero. 486/486 tests pass.**

---

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [x] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## 1. `WalletApiClient` — a null logger that would throw on the first successful lock

The class has two constructors. The DI one takes an `ILogger` and assigns it. The one that takes a
URL and builds its own `HttpClient` **left the field null**. The field was declared
`ILogger<WalletApiClient>?` to make that compile, and then **ten call sites used it
unconditionally**. Those are extension methods, so a null receiver is passed through as an
argument and throws inside the extension — which is why the compiler reported `CS8604` on the
argument rather than a dereference.

The URL constructor is the one the bot uses:

```csharp
services.AddSingleton<WalletApiClient>(provider =>
{
    var options = provider.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
    return new WalletApiClient(options.WalletApiUrl);   // no logger
});
```

`BotHandlerRegistration` then resolves `IWalletApiClient` to that same instance. The simulator does
the same. `Orders.Api` registers through `AddHttpClient`, so DI picks the three-argument
constructor and its logger is fine.

**Why nothing has crashed yet:** all ten unconditional sites live in `LockBalanceAsync`,
`UnlockBalanceAsync`, `IncreaseBalanceAsync` and `ValidateBalanceAsync` — and the bot calls none
of those four. It calls `ValidateCreditAndBalanceAsync`, `GetUserWalletsBalanceAsync`,
`DepositeAsync` and `WithdrawalAsync`.

**Why it still matters:** one of the ten is on the *success* path of `LockBalanceAsync`. The day
anything on the bot side locks collateral, a lock that worked reports a `NullReferenceException`.

The field is non-nullable now; the URL constructor takes an optional logger and falls back to
`NullLogger<T>` rather than null; and **both the bot and the simulator pass a real one**, so their
wallet calls are finally observable. The five sites made conditional in #132 go back to plain
calls.

### Two more null defects in the same file, both on financial paths

- Three methods returned `JsonSerializer.Deserialize<ApiResponse<T>>(...)` straight to the caller.
  `Deserialize` returns null for a literal `null` body, and the signatures promise a response — so
  a caller reading `.Success` would get a `NullReferenceException` instead of a failure it could
  report. Each now falls back to the same `Fail(...)` the non-success branch already uses.
- `GetBalanceAsync` read `walletDto.Data.Balance` inside a `try` that catches `JsonException`. A
  body of `null`, or one shaped like the envelope but carrying no wallet, **parses without
  throwing** — so reaching through it raises a `NullReferenceException`, which that handler does
  not catch, and an unreadable payload escapes the method instead of being reported as one.

---

## 2. `BotHandler` — sixteen sites, nine of them one cause

`HandleCallbackQueryAsync` read `callbackQuery.Message` as though it were always present. Telegram
**omits it** for callbacks raised from an inline message, and for any message older than 48 hours.
The chat id already fell back to `0` — an id no send can reach — and every branch then deletes or
edits that message. So an old button meant an unhandled `NullReferenceException` rather than
anything useful.

The method now returns early when `Message` is absent, answering the callback so the client's
spinner stops and the customer is told to start again. That is **one guard**, and the five
`callbackQuery.Message.Chat.Id` / `.MessageId` pairs below it read the local it establishes.

The rest, each on its own merits:

| Site | Problem |
|---|---|
| `message.Text` → `ConvertPersianDigitsToEnglish` | absent on a contact, photo or sticker message — all of which reach that handler |
| `HandlePhoneNumberRequestAsync` | checked `message.Contact?.PhoneNumber != null`, then re-read the same property through `?.` into a local — the check guaranteed nothing about the value actually used |
| `SendApproveOrRejectUserToAdminsKeyboard(adminIds, response.Data)` | a success with no user in it is a contract violation by the Users API, not something a customer can act on — logged, not shown |
| two `SendAsync(chatId, response.Message)` | could send a null body; they fall back to `MsgUnexpectedError`, which exists for exactly this |
| best-prices reply | read `apiResponse.Data.BestBidPrice` in a branch that had only checked `Success`. `BestPricesMessage.Build` takes nullable prices and renders "no quote" from them, so the fix lets the nulls through rather than stopping the send |
| `ShowWalletsBalance` | `res.Data.Any()` on a `Success` response whose collection could be null; a null list now reads as no wallets |

### One follow-on

`hasQuote` was a `bool` computed from `apiResponse is { Data: not null }`, and the compiler cannot
carry that through a bool — so three later reads of `apiResponse.Data` still warned. Rather than
assert with `!`, **the flag is now the value itself**: `quote`, the published quote or null, which
the three branches read directly. Shorter and more honest than the bool it replaces.

---

## Changes Made

- `WalletApiClient.cs` — non-nullable logger with a `NullLogger` fallback; optional logger on the
  URL constructor; three `?? Fail(...)` guards; one parsed-but-empty payload check.
- `TelegramBot/.../Program.cs` and `Simulator/Program.cs` — both pass a real `ILogger`.
- `BotHandler.cs` — the callback guard and the seven individual fixes above.
- `Constants.cs` — adds `MsgCallbackMessageGone`. Everything else reuses existing copy.

---

## Testing Completed

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 55 warnings (was 85)
dotnet test  TallaEgg.sln -c Release --no-build   →  486/486 passed
```

`WalletApiClient.cs`: 14 → 0. `BotHandler.cs`: 16 → 0.

---

## What is left of phase 4

55 warnings across **36 files**, now genuinely thin — the largest is 5. No `!` was used anywhere in
this change and none should be used to finish it.

| Code | Count | Shape |
|---|---|---|
| `CS8618` | 13 | non-nullable DTO properties with no initialiser — a contract question per type |
| `CS8602` | 12 | dereferences, one or two per file |
| `CS8620` | 7 | nullability mismatch on generic arguments |
| `CS8981` | 6 | EF migration class names — its own change, as noted in #134 |
| `CS8604` | 5 | |
| others | 12 | including 2 `CS0618` in `ApiKeyAuthenticationHandler`, which belong with #105 rather than here — that is the production auth path that has never executed |

---

## Deployment / Rollback

No migrations, no configuration, no data change. One new user-facing Persian string. Rollback is a
revert of the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
