### PR TITLE
chore: delete the commented-out code, and settle the TODOs one at a time

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Core/Utilties/Utils.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Core/Utilties/Utils.cs
@@ -10,30 +10,6 @@ namespace TallaEgg.TelegramBot.Core.Utilties
     public static class Utils
     {
 
-        //public static string EscapeMarkdown(string text)
-        //{
-        //    if (string.IsNullOrEmpty(text))
-        //        return "";
-        //    return text
-        //        .Replace("_", "\\_")
-        //        .Replace("*", "\\*")
-        //        .Replace("[", "\\[")
-        //        .Replace("`", "\\`")
-        //        .Replace("(", "\\(")
-        //        .Replace(")", "\\)")
-        //        .Replace("~", "\\~")
-        //        .Replace(">", "\\>")
-        //        .Replace("#", "\\#")
-        //        .Replace("+", "\\+")
-        //        .Replace("-", "\\-")
-        //        .Replace("=", "\\=")
-        //        .Replace("|", "\\|")
-        //        .Replace("{", "\\{")
-        //        .Replace("}", "\\}")
-        //        .Replace(".", "\\.")
-        //        .Replace("!", "\\!");
-        //}
-
         public static string EscapeMarkdownV2(string text)
         {
             if (string.IsNullOrEmpty(text))

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandler.cs
@@ -206,8 +206,9 @@ namespace TallaEgg.TelegramBot
             }
             else
             {
-                // TODO: this should probably become an accountant role's job.
-                //if (await IsTelegramAdmin(user))
+                // Operator, not Telegram group administrator: who may run admin commands is the
+                // product's own answer, not a property of one chat. Splitting an accountant role
+                // out of it is an open design question, not a decision made here.
                 if (IsOperator(user))
                 {
                     // Check for admin commands first
@@ -257,16 +258,7 @@ namespace TallaEgg.TelegramBot
 
             if (regSuccess && userId.HasValue)
             {
-                // Then use the invitation
-                //   var (useSuccess, useMessage, invitationId) = await _affiliateApi.UseInvitationAsync(invitationCode, userId.Value);
-
-                //if (useSuccess)
-                //{
                 await _messenger.SendContactKeyboardAsync(chatId);
-
-                //else
-                //{
-                //}
             }
             else
             {
@@ -762,7 +754,6 @@ namespace TallaEgg.TelegramBot
             await _messenger.AnswerCallbackAsync(callbackQuery.Id);
         }
         /// <summary>
-        /// TODO: caching the user here would cut down the number of requests.
         /// </summary>
         /// <param name="chatId"></param>
         /// <returns></returns>
@@ -1183,7 +1174,9 @@ namespace TallaEgg.TelegramBot
                     _logger.LogInformation("Showing {Shown} out of {Total} trading pairs due to pagination limit",
                         maxButtonsPerPage, tradingPairs.Count);
 
-                    // TODO: add pagination buttons.
+                    // Symbols past this limit are simply not offered. With a handful of
+                    // symbols nobody notices; the day the list grows, a customer cannot reach
+                    // the ones that fell off, and there is no sign in the bot that they exist.
                 }
             }
             catch (Exception ex)

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -324,26 +324,6 @@ namespace TallaEgg.TelegramBot
             }
 
             return false;
-
-            //switch (msgText.ToLower())
-            //{
-            //    case "/admin_referral_on":
-            //        _requireReferralCode = true;
-            //        await _messenger.SendAsync(chatId,
-            //        return true;
-
-            //    case "/admin_referral_off":
-            //        _requireReferralCode = false;
-            //        await _messenger.SendAsync(chatId,
-            //        return true;
-
-            //    case "/admin_referral_status":
-            //        await _messenger.SendAsync(chatId,
-            //        return true;
-
-            //    default:
-            //        return false; // Not an admin command, continue with normal processing
-            //}
         }
 
         /// <summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -137,9 +137,12 @@ public class Program
                 services.AddSingleton<TelegramLoggerService>(provider =>
                 {
                     var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
-                   // var options = provider.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
 
-                    return new TelegramLoggerService(httpClientFactory, /*options.TelegramBotToken*/"7331560325:AAHgmgugtatg0XmoIMgTd7_Nj6G09jvo9g4");
+                    // A second bot, used only to deliver error reports — not the one customers talk
+                    // to, whose token is TelegramBotOptions.TelegramBotToken. There is no settings
+                    // key for this one, which is why it is a literal. Giving it a key of its own is
+                    // the fix; the value itself is dead and rotated, see CLAUDE.md.
+                    return new TelegramLoggerService(httpClientFactory, "7331560325:AAHgmgugtatg0XmoIMgTd7_Nj6G09jvo9g4");
                 });
 
                 services.AddSingleton<IVersionService, VersionService>();

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramNotificationApi.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramNotificationApi.cs
@@ -127,9 +127,10 @@ public class TelegramNotificationApi
             /// Called by the matching service. It validates the input, notifies both the buyer and
             /// the seller, and returns the outcome as an ApiResponse.
             /// 
-            /// TODO: add authentication and authorization.
-            /// TODO: add rate limiting.
-            /// TODO: add detailed logging.
+            /// This endpoint has no authentication, no rate limiting and no audit logging, and
+            /// it is live: Program.cs starts this application on a background task alongside the
+            /// bot. Anything that can reach the port can make the bot send trade notifications to
+            /// arbitrary users. Closing that is a change in its own right, not a comment.
             /// </remarks>
             async (TradeMatchNotificationDto notification, TradeNotificationService notificationService) =>
         {

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -99,12 +99,6 @@ public class OrderService
             _logger.LogInformation("Validating balance for user {UserId}: {Amount} {Asset}",
                 userId, amountToCheck, assetToCheck);
 
-            //var (balanceCheckSuccess, balanceMessage, hasSufficientBalance) =
-            //    await _walletApiClient.ValidateBalanceAsync(
-            //    userId,
-            //    assetToCheck,
-            //    amountToCheck);
-
             
             var validateCreditAndBalance =
                 await _walletApiClient.ValidateCreditAndBalanceAsync(request.UserId, request.Symbol, request.Quantity, request.Price);
@@ -326,8 +320,6 @@ public class OrderService
     {
         try
         {
-            // TODO: If database transaction support is needed, wrap in transaction
-            // using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
             
             var order = await _orderRepository.GetByIdAsync(orderId);
             
@@ -339,9 +331,6 @@ public class OrderService
                 return false;
             }
 
-            // TODO: Add business validation if needed
-            // var validationResult = await ValidateOrderForConfirmationAsync(order);
-            // if (!validationResult.IsValid) { return false; }
             
             // Change status from Pending to Confirmed
             var updateSuccess = await _orderRepository.UpdateStatusAsync(orderId, OrderStatus.Confirmed, "تایید شده");
@@ -350,8 +339,6 @@ public class OrderService
             {
                 _logger.LogInformation("Order {OrderId} status changed: Pending → Confirmed", orderId);
                 
-                // TODO: If transaction was used, commit here
-                // await transaction.CommitAsync(cancellationToken);
             }
             
             return updateSuccess;
@@ -360,8 +347,6 @@ public class OrderService
         {
             _logger.LogError(ex, "Error confirming order {OrderId}", orderId);
             
-            // TODO: If transaction was used, rollback here
-            // await transaction.RollbackAsync(cancellationToken);
             
             return false;
         }
@@ -408,8 +393,6 @@ public class OrderService
         }
 
         var orders = await _orderRepository.GetOrdersByAssetAsync(asset);
-
-        //Log.Information("orders:\n" + JsonConvert.SerializeObject(orders, Formatting.Indented));
 
         // The o.IsMaker() condition was removed.
         //

--- a/src/Order/Orders.Core/Order.cs
+++ b/src/Order/Orders.Core/Order.cs
@@ -22,10 +22,8 @@ public class Order
     public DateTime CreatedAt { get; private set; }
     public DateTime? UpdatedAt { get; private set; }
     public string? Notes { get; private set; }
-    public Guid? ParentOrderId { get; private set; } // برای Taker orders که به Maker order متصل می‌شوند
-
-    // Private constructor for EF Core
-    //private Order() { }
+    // Set on a taker order to point at the maker order it filled against.
+    public Guid? ParentOrderId { get; private set; }
 
     public static Order CreateMakerOrder(
         string asset, 

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -56,15 +56,8 @@ builder.Services.AddDbContext<OrdersDbContext>(options =>
     options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
         b => b.MigrationsAssembly("TallaEgg.Api")));
 
-// Connection to the main TallaEgg database.
-// builder.Services.AddDbContext<TallaEggDbContext>(options =>
-//     options.UseSqlServer(builder.Configuration.GetConnectionString("TallaEggDb") ??
-//         "Server=localhost;Database=TallaEgg;Trusted_Connection=True;TrustServerCertificate=True;",
-//         b => b.MigrationsAssembly("TallaEgg.Api")));
-
 // Only the Orders and Price services are registered.
 builder.Services.AddScoped<IOrderRepository, OrderRepository>();
-//builder.Services.AddScoped<IOrderService, OrderService>();
 // CreateOrderCommandHandler and CreateTakerOrderCommandHandler were removed: both classes were
 // entirely empty, with their whole bodies commented out, yet they were still registered in DI.
 

--- a/src/TallaEgg/TallaEgg.Core/Requests/Order/CreateMarketOrderRequest.cs
+++ b/src/TallaEgg/TallaEgg.Core/Requests/Order/CreateMarketOrderRequest.cs
@@ -18,32 +18,4 @@ namespace TallaEgg.Core.Requests.Order
         public string? Notes { get; set; }
     }
 
-//    /// <summary>
-//    /// Request model for creating a new market order
-//    /// </summary>
-//    public record CreateMarketOrderRequest(
-//    /// <summary>
-//    /// Trading asset symbol (e.g., BTC, ETH, USDT)
-//    /// </summary>
-//    string Asset,
-//    /// <summary>
-//    /// Order quantity/amount
-//    /// </summary>
-//    decimal Amount,
-//    /// <summary>
-//    /// Unique identifier of the user placing the order
-//    /// </summary>
-//    Guid UserId,
-//    /// <summary>
-//    /// Side of order (Buy or Sell)
-//    /// </summary>
-//    OrderSide Side,
-//    /// <summary>
-//    /// Trading type (Spot or Futures)
-//    /// </summary>
-//    TradingType TradingType,
-//    /// <summary>
-//    /// Optional notes for the order
-//    /// </summary>
-//    string? Notes = null);
 }

--- a/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
@@ -31,7 +31,6 @@ namespace TallaEgg.Core.Services
         /// 
         public async Task Notif(string message, string chatId= "-1002988196234", string parseMode = "")
         {
-            // Version version = Assembly.GetExecutingAssembly().GetName().Version;
             var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
@@ -62,7 +61,6 @@ namespace TallaEgg.Core.Services
         /// 
         public async Task Notif<T>(string message, T dto, string chatId = "-1002988196234", string parseMode = "")
         {
-            //Version version = Assembly.GetExecutingAssembly().GetName().Version;
             var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
@@ -88,7 +86,6 @@ namespace TallaEgg.Core.Services
 
         public async Task LogAsync<T>(string message, T dto, string chatId = "-822161060", string parseMode = "")
         {
-            //Version version = Assembly.GetExecutingAssembly().GetName().Version;
             var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
@@ -114,7 +111,6 @@ namespace TallaEgg.Core.Services
 
         public async Task LogAsync(string log, string chatId = "-822161060")
         {
-            //Version version = Assembly.GetExecutingAssembly().GetName().Version;
             var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
@@ -151,9 +147,7 @@ namespace TallaEgg.Core.Services
         /// <returns></returns>
         public async Task ErrorAsync(Exception ex, string message = "")
         {
-            //  await File.AppendAllTextAsync($"SendExceptions{DateTime.Now.Ticks}.txt",message +"\n \n"+ Newtonsoft.Json.JsonConvert.SerializeObject(ex, Newtonsoft.Json.Formatting.Indented));
 
-         //   Version version = Assembly.GetExecutingAssembly().GetName().Version;
             var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
@@ -198,70 +192,15 @@ namespace TallaEgg.Core.Services
 
         }
 
-        //public async Task SendFile(string filePath, string fileName)
-        //{
-        //    try
-        //    {
-
-        //        //  var APIURL = "https://tg-notif.chbk.app//file";
-        //        var APIURL = "https://tgnotif-production.up.railway.app/file";
-
-        //        using (var httpClient = _httpClientFactory.CreateClient())
-        //        using (var form = new MultipartFormDataContent())
-        //        using (var fileStream = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
-        //        {
-        //            form.Add(new StreamContent(fileStream), "file", fileName);
-        //            form.Add(new StringContent("ChatId"), _appSettings.SuccessChannelChatId);
-        //            HttpResponseMessage response = await httpClient.PostAsync(APIURL, form);
-        //            response.EnsureSuccessStatusCode();
-        //            httpClient.Dispose();
-        //            string sd = response.Content.ReadAsStringAsync().Result;
-        //        }
-
-
-        //        //            using (var fileStream = File.OpenRead(filePath))
-        //        //{
-        //        //	var fileName = File.ReadAllText(filePath);
-        //        //	var fileContent = new StreamContent(fileStream);
-
-        //        //	using (var formData = new MultipartFormDataContent())
-        //        //	{
-        //        //		formData.Add(fileContent, "file", fileName);
-        //        //		var httpClient = _httpClientFactory.CreateClient();
-        //        //		string APIURL = $"https://bewildered-moth-umbrella.cyclic.cloud/file";
-
-        //        //		var response = await httpClient.PostAsync(APIURL, formData);
-        //        //		var x = await response.Content.ReadAsStringAsync();
-        //        //	}
-        //        //}
-        //    }
-        //    catch (Exception ex)
-
-        //    {
-        //        await ErrorAsync(ex);
-        //        // throw;
-        //    }
-        //}
-
         private async Task Send(StringContent data)
         {
             try
             {
                 var httpClient = _httpClientFactory.CreateClient();
-                // httpClient.Timeout = TimeSpan.FromSeconds(15);
 
                 string APIURL = $"https://telegram-notifier.mldsalehi.workers.dev";
-                //string APIURL = $"https://tgnotif-production.up.railway.app/tgdigi";
-                // string APIURL = $"https://tg-notif.chbk.app/tgdigi";
-                // string APIURL = $"https://telenotif.onrender.com/tgdigi";
-                // string APIURL = $"https://bewildered-moth-umbrella.cyclic.cloud/tgdigi";
-                //string APIURL = $"https://tgnotif-7snesbpv.b4a.run/tgdigi";
 
-                /*var response =*/
                 await httpClient.PostAsync(APIURL, data);
-                //if (!response.IsSuccessStatusCode) throw new Exception();
-                //	var x = await response.Content.ReadAsStringAsync();
-
             }
             catch (Exception ex)
 
@@ -270,19 +209,6 @@ namespace TallaEgg.Core.Services
                 await File.AppendAllTextAsync("SendExceptions.txt", "====================================================");
 
                 Console.WriteLine(ex.Message);
-                //try
-                //{
-                //                var httpClient = _httpClientFactory.CreateClient();
-
-                //                var response = await httpClient.PostAsync(APIURL, data);
-                //                var x = await response.Content.ReadAsStringAsync();
-                //	Console.WriteLine(x);
-                //            }
-                //catch (Exception)
-                //{
-                //	//throw;
-                //}
-                //// throw;
             }
         }
 

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -312,9 +312,7 @@ public class WalletApiClient : IWalletApiClient
 
             if (response.IsSuccessStatusCode)
             {
-                //var result = JsonConvert.DeserializeObject<TallaEgg.Core.DTOs.ApiResponse<IEnumerable<WalletDTO>>>(respText);
 
-                // Parse the response which should be in the format: { success, message, hasSufficientBalance }
                 var result = JsonSerializer.Deserialize<ApiResponse<IEnumerable<WalletDTO>>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -367,9 +365,7 @@ public class WalletApiClient : IWalletApiClient
                 // Handle successful response
                 try
                 {
-                    //var walletDto = JsonConvert.DeserializeObject<ApiResponse<WalletDTO>>(responseContent);
                     
-                    // Parse the response which should be in the format: { success, message, hasSufficientBalance }
                     var walletDto = JsonSerializer.Deserialize<ApiResponse<WalletDTO>>(responseContent,
                         new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -415,9 +411,7 @@ public class WalletApiClient : IWalletApiClient
                 {
                     try
                     {
-                        //var errorResponse = JsonConvert.DeserializeObject<TallaEgg.Core.DTOs.ApiResponse<object>>(responseContent);
 
-                        // Parse the response which should be in the format: { success, message, hasSufficientBalance }
                         var errorResponse = JsonSerializer.Deserialize<ApiResponse<object>>(responseContent,
                             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -487,8 +481,6 @@ public class WalletApiClient : IWalletApiClient
     {
         try
         {
-            //var json = JsonConvert.SerializeObject(request);
-            //var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var json = JsonSerializer.Serialize(request);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -498,9 +490,7 @@ public class WalletApiClient : IWalletApiClient
 
             if (response.IsSuccessStatusCode)
             {
-                //var result = JsonConvert.DeserializeObject<TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>>(respText);
 
-                // Parse the response which should be in the format: { success, message, hasSufficientBalance }
                 var result = JsonSerializer.Deserialize<ApiResponse<WalletBallanceDTO>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
@@ -524,8 +514,6 @@ public class WalletApiClient : IWalletApiClient
     {
         try
         {
-            //var json = JsonConvert.SerializeObject(request);
-            //var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var json = JsonSerializer.Serialize(request);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -535,9 +523,7 @@ public class WalletApiClient : IWalletApiClient
 
             if (response.IsSuccessStatusCode)
             {
-                //var result = JsonConvert.DeserializeObject<TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>>(respText);
 
-                // Parse the response which should be in the format: { success, message, hasSufficientBalance }
                 var result = JsonSerializer.Deserialize<ApiResponse<WalletBallanceDTO>>(respText,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 

--- a/src/User/Users.Application/Mappers/UserMapper.cs
+++ b/src/User/Users.Application/Mappers/UserMapper.cs
@@ -32,10 +32,10 @@ namespace Users.Application.Mappers
         }
 
         /// <summary>
-        /// TODO: incomplete.
+        /// Rebuilds the entity from the DTO. Mirrors <see cref="Map"/> field for field; anything the
+        /// entity holds that the DTO does not carry cannot be restored here and is left at its
+        /// default, so the result is only safe to use as a projection, never to save.
         /// </summary>
-        /// <param name="dto"></param>
-        /// <returns></returns>
         public override User MapBack(UserDto dto)
         {
             if (dto == null) return null;

--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -118,14 +118,6 @@ public class UserService
             return id;
         }
 
-        // If not there, look in the Invitations table.
-        
-        //var invitation = await _userRepository.GetInvitationByCodeAsync(invitationCode);
-        //if (invitation != null)
-        //{
-        //    return invitation.CreatedByUserId;
-        //}
-
         return null;
     }
 
@@ -140,14 +132,6 @@ public class UserService
         {
             return id;
         }
-
-        // If not there, look in the Invitations table.
-        
-        //var invitation = await _userRepository.GetInvitationByCodeAsync(invitationCode);
-        //if (invitation != null)
-        //{
-        //    return invitation.CreatedByUserId;
-        //}
 
         return null;
     }

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -243,7 +243,6 @@ app.MapPost("/api/wallet/increaseBalance", async (WalletRequest request, IWallet
 {
     try
     {
-        // TODO: WalletEntity and WalletDTO carry nearly the same shape; consider collapsing them.
         var result = await walletService.IncreaseBalanceAsync(request.UserId, request.Asset, request.Amount);
         return Results.Ok(ApiResponse<(WalletEntity,Transaction)>.Ok(result, "عملیات با موفقیت انجام شد"));
     }

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -1,4 +1,4 @@
-
+﻿
 using TallaEgg.Core;
 using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.Enums.Order;
@@ -145,7 +145,6 @@ public class WalletService : IWalletService
             CreatedAt = DateTime.UtcNow,
             CompletedAt = DateTime.UtcNow
         };
-       // await _walletRepository.CreateTransactionAsync(transaction);
 
         return true;
     }
@@ -290,7 +289,6 @@ public class WalletService : IWalletService
             CreatedAt = DateTime.UtcNow,
             CompletedAt = DateTime.UtcNow
         };
-      //  await _walletRepository.CreateTransactionAsync(fromTransaction);
 
         var toTransaction = new WalletTransaction
         {
@@ -304,7 +302,6 @@ public class WalletService : IWalletService
             CreatedAt = DateTime.UtcNow,
             CompletedAt = DateTime.UtcNow
         };
-       // await _walletRepository.CreateTransactionAsync(toTransaction);
 
         return (true, "انتقال با موفقیت انجام شد.");
     }


### PR DESCRIPTION
**Branch Name**: `chore/remove-commented-code-and-todos`
**Linked Issue/Task**: phase 5 of the code-hygiene plan
**Stacked on**: #137 — it touches the same two files, so it is based on that branch. Its own diff is the second commit.

---

## Description

Sixty-two lines of commented-out code across fourteen files, and fourteen TODOs. Git holds every
removed line; keeping a second copy in the source only costs the next reader the work of deciding
whether it matters.

**230 lines removed, 21 added. No behaviour change. 486/486 tests pass, 55 warnings unchanged.**

---

## Type of Change
- [ ] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [x] Refactor (code organization, no behavior change)
- [x] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Commented-out code removed

| Where | What |
|---|---|
| `WalletApiClient` | a superseded Newtonsoft path kept beside the `System.Text.Json` one that replaced it, plus six copies of a header comment describing a line that was no longer there |
| `TelegramLoggerService` | a commented-out `SendFile` method and five superseded notifier URLs |
| `UserService` | a commented-out invitation lookup, duplicated in two methods |
| `WalletService` | three commented-out `CreateTransactionAsync` calls |
| `Utils` | a commented-out `EscapeMarkdown`, superseded by `EscapeMarkdownV2` beside it |
| `CreateMarketOrderRequest` | a commented-out record superseded by the class above it |
| `BotHandlerAdmin` | a commented-out admin command switch |
| `TallaEgg.Api/Program.cs` | a commented-out `DbContext` registration |
| `BotHandler` | a commented-out `IsTelegramAdmin` check that the `IsOperator` call beside it already replaced |
| `OrderService` | a commented-out balance check and four transaction TODO pairs |

Also: one Persian comment in `Order.cs` that the translation pass in #129 missed.

---

## The TODOs were read, not swept

**Two were stale and are gone.** `UserMapper`'s "incomplete" describes a `MapBack` that mirrors
`Map` field for field; what it cannot restore is whatever the DTO does not carry, which is a
property of the DTO rather than an omission — the doc says that now. The `Wallet.Api` one mused
about collapsing `WalletEntity` into `WalletDTO` and sat inside an unrelated `try` block.

**One was a performance idea with no measurement behind it** (caching a user lookup in
`BotHandler`).

**Two stay, because they are precise.** `WalletApiClient`'s balance check should take the quantity;
and `UserRole.User` is genuinely unexplained — that one is a question for the product owner, not
something to answer in a cleanup.

**Four became statements of consequence rather than intentions:**

- The symbol menu silently drops symbols past its button limit. Nobody notices at today's handful;
  the day the list grows, a customer cannot reach the rest and nothing in the bot says they exist.

- `TelegramNotificationApi`'s three — authentication, rate limiting, logging — **are not
  aspirations**. `Program.cs` line 39 starts that application on a background task alongside the
  bot:

  ```csharp
  _ = Task.Run(() => TelegramNotificationApi.RunNotificationApi(args));
  ```

  So `POST /api/telegram/notifications/trade-match` is live and open, and anything that can reach
  the port can make the bot send trade notifications to arbitrary users. The comment says so now.
  **Closing it is a change of its own and is not attempted here.**

---

## One more, in the bot's `Program.cs`

The `TelegramLoggerService` registration passed a literal token with the config lookup commented
out beside it. The commented lookup is gone and the situation is written down instead: this is a
**second** bot, used only for error reports, not the one customers talk to — and there is no
settings key for it. That, rather than the literal, is the thing to fix. The value itself is dead
and rotated (see `CLAUDE.md`).

---

## Testing Completed

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 55 warnings (unchanged)
dotnet test  TallaEgg.sln -c Release --no-build   →  486/486 passed
```

---

## Deployment / Rollback

No migrations, no configuration, no data change, no behaviour change. Rollback is a revert of the
commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
