### PR TITLE
feat(core): tell a rejected request apart from a broken one

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -262,10 +262,8 @@ app.MapPost("/api/quotes", async (PublishQuoteRequest request, IQuoteRepository 
 
         return Results.Ok(ApiResponse<QuoteDto>.Ok(ToQuoteDto(published), "مظنه منتشر شد."));
     }
-    catch (ArgumentException ex)
+    catch (BusinessRuleException ex)
     {
-        // Quote.Publish's messages are written for the user — a negative spread, for instance — so
-        // they are returned as-is rather than replaced with generic text.
         return Results.BadRequest(ApiResponse<QuoteDto>.Fail(ex.Message));
     }
     catch (Exception ex)
@@ -314,7 +312,7 @@ app.MapPost("/api/autoquote-settings/{Base}/{Quote}/spread", async (
 
         return Results.Ok(ApiResponse<AutoQuoteSettingsDto>.Ok(ToAutoQuoteSettingsDto(settings), "اسپرد به‌روزرسانی شد."));
     }
-    catch (ArgumentException ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<AutoQuoteSettingsDto>.Fail(ex.Message));
     }
@@ -457,11 +455,7 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
     {
         return Results.Json(ApiResponse<CreateOrderResponse>.Fail(ex.Message), statusCode: 401);
     }
-    catch (ArgumentException ex)
-    {
-        return Results.BadRequest(ApiResponse<CreateOrderResponse>.Fail(ex.Message));
-    }
-    catch (InvalidOperationException ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<CreateOrderResponse>.Fail(ex.Message));
     }
@@ -511,7 +505,7 @@ app.MapPost("/api/orders/{orderId}/cancel", async (Guid orderId, string? reason,
 
         return Results.Ok(new { success = true, message = "سفارش با موفقیت لغو شد", orderId });
     }
-    catch (InvalidOperationException ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(new { success = false, message = ex.Message });
     }
@@ -910,42 +904,34 @@ static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironm
 // queryable via includeAbandoned=true for reconciliation and audit.
 app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAbandoned = false) =>
 {
-    try
-    {
-        var query = db.OutboxMessages.AsNoTracking().Where(m => m.Status != OutboxMessageStatus.Completed);
-        if (!includeAbandoned)
-            query = query.Where(m => m.Status != OutboxMessageStatus.Abandoned);
+    var query = db.OutboxMessages.AsNoTracking().Where(m => m.Status != OutboxMessageStatus.Completed);
+    if (!includeAbandoned)
+        query = query.Where(m => m.Status != OutboxMessageStatus.Abandoned);
 
-        var stuck = await query
-            .OrderByDescending(m => m.CreatedAt)
-            .Select(m => new
-            {
-                m.Id,
-                TradeId = m.AggregateId,
-                m.Type,
-                Status = m.Status.ToString(),
-                m.RetryCount,
-                m.CreatedAt,
-                m.NextAttemptAt,
-                m.LastError,
-                m.AbandonReason,
-                m.AbandonedAt
-            })
-            .ToListAsync();
-
-        return Results.Ok(ApiResponse<object>.Ok(new
+    var stuck = await query
+        .OrderByDescending(m => m.CreatedAt)
+        .Select(m => new
         {
-            Count = stuck.Count,
-            FailedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Failed)),
-            AbandonedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Abandoned)),
-            Items = stuck
-        }, "فهرست تسویه‌های ناتمام"));
-    }
-    catch (Exception ex)
+            m.Id,
+            TradeId = m.AggregateId,
+            m.Type,
+            Status = m.Status.ToString(),
+            m.RetryCount,
+            m.CreatedAt,
+            m.NextAttemptAt,
+            m.LastError,
+            m.AbandonReason,
+            m.AbandonedAt
+        })
+        .ToListAsync();
+
+    return Results.Ok(ApiResponse<object>.Ok(new
     {
-        Log.Error(ex, "Error listing unsettled outbox messages");
-        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
-    }
+        Count = stuck.Count,
+        FailedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Failed)),
+        AbandonedCount = stuck.Count(s => s.Status == nameof(OutboxMessageStatus.Abandoned)),
+        Items = stuck
+    }, "فهرست تسویه‌های ناتمام"));
 })
 .WithTags("Outbox");
 
@@ -972,38 +958,25 @@ app.MapPost("/api/outbox/{messageId}/redrive", async (Guid messageId, OrdersDbCo
         // Raised when the message is not in a re-drivable state (Completed or Pending).
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Error re-driving outbox message {MessageId}", messageId);
-        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
-    }
 })
 .WithTags("Outbox");
 
 // Re-drives every failed settlement at once, for use after a fix that affects them all.
 app.MapPost("/api/outbox/redrive-all-failed", async (OrdersDbContext db) =>
 {
-    try
-    {
-        var failed = await db.OutboxMessages
-            .Where(m => m.Status == OutboxMessageStatus.Failed)
-            .ToListAsync();
+    var failed = await db.OutboxMessages
+        .Where(m => m.Status == OutboxMessageStatus.Failed)
+        .ToListAsync();
 
-        foreach (var message in failed)
-            message.ResetForRetry();
+    foreach (var message in failed)
+        message.ResetForRetry();
 
-        await db.SaveChangesAsync();
+    await db.SaveChangesAsync();
 
-        Log.Information("{Count} failed outbox message(s) were re-driven by an operator.", failed.Count);
+    Log.Information("{Count} failed outbox message(s) were re-driven by an operator.", failed.Count);
 
-        return Results.Ok(ApiResponse<int>.Ok(failed.Count,
-            $"{failed.Count} تسویهٔ ناموفق دوباره در صف قرار گرفت."));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Error re-driving all failed outbox messages");
-        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
-    }
+    return Results.Ok(ApiResponse<int>.Ok(failed.Count,
+        $"{failed.Count} تسویهٔ ناموفق دوباره در صف قرار گرفت."));
 })
 .WithTags("Outbox");
 
@@ -1037,11 +1010,6 @@ app.MapPost("/api/outbox/{messageId}/abandon", async (Guid messageId, AbandonOut
     catch (InvalidOperationException ex)
     {
         // Raised when the message is not in an abandonable state (only Failed qualifies).
-        return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "Error abandoning outbox message {MessageId}", messageId);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
     }
 })

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -11,6 +11,7 @@ using TallaEgg.Core.Requests.Order;
 using TallaEgg.Core.Responses.Order;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Orders.Application;
 
@@ -90,7 +91,7 @@ public class OrderService
             // RoundToCurrencyPrecision(Amount x Price) over the stored order, so it can be
             // recomputed without adding a column to persist it.
             if (request.Price <= 0)
-                throw new ArgumentException("قیمت باید بزرگ‌تر از صفر باشد");
+                throw new BusinessRuleException("قیمت باید بزرگ‌تر از صفر باشد");
 
             request.Price = CurrenciesConstant.RoundOrderPrice(request.Price);
 
@@ -117,14 +118,14 @@ public class OrderService
             if (!balanceCheckSuccess)
             {
                 _logger.LogWarning("Balance validation failed for user {UserId}: {Message}", userId, balanceMessage);
-                throw new InvalidOperationException($"خطا در بررسی موجودی: {balanceMessage}");
+                throw new BusinessRuleException($"خطا در بررسی موجودی: {balanceMessage}");
             }
 
             if (!isadmin)
             if (!hasSufficientBalance)
             {
                 _logger.LogWarning("Insufficient balance for user {UserId}: {Message}", userId, balanceMessage);
-                throw new InvalidOperationException($"موجودی ناکافی: {balanceMessage}");
+                throw new BusinessRuleException($"موجودی ناکافی: {balanceMessage}");
             }
 
             // 4. Create appropriate order command based on order type
@@ -135,7 +136,7 @@ public class OrderService
 
             if (request.Price == null)
             {
-                throw new ArgumentException("قیمت برای سفارش محدود الزامی است");
+                throw new BusinessRuleException("قیمت برای سفارش محدود الزامی است");
             }
 
             // Limit orders start as Makers
@@ -188,7 +189,7 @@ public class OrderService
         catch (Exception ex) when (ex is not UnauthorizedAccessException and not ArgumentException and not InvalidOperationException)
         {
             _logger.LogError(ex, "Error creating unified order for user {UserId}", request.UserId);
-            throw new InvalidOperationException("خطا در ایجاد سفارش", ex);
+            throw new BusinessRuleException("خطا در ایجاد سفارش", ex);
         }
     }
 
@@ -268,7 +269,7 @@ public class OrderService
             await _orderRepository.UpdateStatusAsync(createdOrder.Id, OrderStatus.Failed,
                 $"قفل وثیقه انجام نشد: {lockMessage}");
 
-            throw new InvalidOperationException($"خطا در قفل کردن موجودی: {lockMessage}");
+            throw new BusinessRuleException($"خطا در قفل کردن موجودی: {lockMessage}");
         }
 
         _logger.LogInformation("Locked {Amount} {Asset} for order {OrderId} (user {UserId}).",
@@ -456,7 +457,7 @@ public class OrderService
 
         if (order.Status == OrderStatus.Completed || order.Status == OrderStatus.Failed)
         {
-            throw new InvalidOperationException("سفارشات کامل شده یا رد شده قابل کنسل شدن نیستند");
+            throw new BusinessRuleException("سفارشات کامل شده یا رد شده قابل کنسل شدن نیستند");
         }
 
         var success = await _orderRepository.UpdateStatusAsync(orderId, OrderStatus.Cancelled, reason);

--- a/src/Order/Orders.Core/AutoQuoteSettings.cs
+++ b/src/Order/Orders.Core/AutoQuoteSettings.cs
@@ -1,3 +1,5 @@
+﻿using TallaEgg.Core.ErrorHandling;
+
 namespace Orders.Core;
 
 /// <summary>
@@ -45,7 +47,7 @@ public class AutoQuoteSettings
     public static AutoQuoteSettings CreateDefault(string symbol)
     {
         if (string.IsNullOrWhiteSpace(symbol))
-            throw new ArgumentException("نماد نمی‌تواند خالی باشد.", nameof(symbol));
+            throw new BusinessRuleException("نماد نمی‌تواند خالی باشد.");
 
         return new AutoQuoteSettings
         {
@@ -61,7 +63,7 @@ public class AutoQuoteSettings
     public void UpdateSpread(decimal spreadPercent, Guid updatedByUserId)
     {
         if (spreadPercent < 0)
-            throw new ArgumentException("اسپرد نمی‌تواند منفی باشد.", nameof(spreadPercent));
+            throw new BusinessRuleException("اسپرد نمی‌تواند منفی باشد.");
 
         SpreadPercent = spreadPercent;
         UpdatedByUserId = updatedByUserId;

--- a/src/Order/Orders.Core/Quote.cs
+++ b/src/Order/Orders.Core/Quote.cs
@@ -1,4 +1,5 @@
 ﻿using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Orders.Core;
 
@@ -61,23 +62,23 @@ public class Quote
     public static Quote Publish(string symbol, decimal buyPrice, decimal sellPrice, Guid publishedByUserId)
     {
         if (string.IsNullOrWhiteSpace(symbol))
-            throw new ArgumentException("نماد نمی‌تواند خالی باشد.", nameof(symbol));
+            throw new BusinessRuleException("نماد نمی‌تواند خالی باشد.");
 
         if (buyPrice <= 0)
-            throw new ArgumentException("قیمت خرید باید بزرگ‌تر از صفر باشد.", nameof(buyPrice));
+            throw new BusinessRuleException("قیمت خرید باید بزرگ‌تر از صفر باشد.");
 
         if (sellPrice <= 0)
-            throw new ArgumentException("قیمت فروش باید بزرگ‌تر از صفر باشد.", nameof(sellPrice));
+            throw new BusinessRuleException("قیمت فروش باید بزرگ‌تر از صفر باشد.");
 
         // A negative spread means the admin buys higher than they sell. A customer could buy and
         // sell endlessly, profiting on every round trip straight out of the shop's pocket. Catch
         // it here rather than after a few trades have already run.
         if (buyPrice > sellPrice)
-            throw new ArgumentException(
+            throw new BusinessRuleException(
                 $"قیمت خرید ({buyPrice}) نمی‌تواند از قیمت فروش ({sellPrice}) بیشتر باشد.");
 
         if (publishedByUserId == Guid.Empty)
-            throw new ArgumentException("شناسهٔ منتشرکننده الزامی است.", nameof(publishedByUserId));
+            throw new BusinessRuleException("شناسهٔ منتشرکننده الزامی است.");
 
         return new Quote
         {

--- a/src/Order/Orders.Core/SymbolSettings.cs
+++ b/src/Order/Orders.Core/SymbolSettings.cs
@@ -1,3 +1,5 @@
+﻿using TallaEgg.Core.ErrorHandling;
+
 namespace Orders.Core;
 
 /// <summary>
@@ -39,7 +41,7 @@ public class SymbolSettings
     public static SymbolSettings CreateDefault(string symbol)
     {
         if (string.IsNullOrWhiteSpace(symbol))
-            throw new ArgumentException("نماد نمی‌تواند خالی باشد.", nameof(symbol));
+            throw new BusinessRuleException("نماد نمی‌تواند خالی باشد.");
 
         return new SymbolSettings
         {

--- a/src/TallaEgg/TallaEgg.Core/ErrorHandling/BusinessRuleException.cs
+++ b/src/TallaEgg/TallaEgg.Core/ErrorHandling/BusinessRuleException.cs
@@ -1,0 +1,44 @@
+namespace TallaEgg.Core.ErrorHandling;
+
+/// <summary>
+/// A rule of the business said no, and <see cref="System.Exception.Message"/> is the sentence to
+/// show the customer.
+///
+/// <para>
+/// That contract is the whole point of the type. Every API endpoint used to end in
+/// <c>catch (Exception ex) =&gt; Fail(ex.Message)</c>, which returned the message of whatever had
+/// been thrown. Sometimes that was Persian text written for the customer — "کیف پول وجود ندارد" —
+/// and sometimes it was a developer's <c>ArgumentException("ReferenceId cannot be empty")</c>, or a
+/// <c>SqlException</c>, or a <c>NullReferenceException</c>. The endpoint could not tell them apart,
+/// because both kinds arrived as <c>ArgumentException</c>, so a Persian-speaking customer could be
+/// shown a .NET diagnostic. Throwing this type is the statement that a message is meant for them.
+/// </para>
+///
+/// <para>
+/// <b>What does not belong here:</b> a failure the customer did not cause and cannot act on. A
+/// database read that threw, an HTTP call that timed out, a bug. Those must reach
+/// <see cref="GlobalExceptionHandler"/>, which logs them with a trace id and returns the generic
+/// message. Wrapping one of them in Persian only makes an outage look like a rejected request.
+/// </para>
+///
+/// <para>
+/// Write the message the way <c>BotMsgs</c> writes messages: Persian, no Latin text, and specific
+/// enough that the customer knows what to do next.
+/// </para>
+/// </summary>
+public sealed class BusinessRuleException : Exception
+{
+    public BusinessRuleException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// For a rule broken because something underneath failed, where the customer still needs a
+    /// sentence of their own. The inner exception is for the log; only <paramref name="message"/>
+    /// is ever shown.
+    /// </summary>
+    public BusinessRuleException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -226,7 +226,7 @@ app.MapPost("/api/user/register", async (RegisterUserRequest request, UserServic
 
         return ApiResponse<UserDto>.Ok(user, "User loaded successfully");
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return ApiResponse<UserDto>.Fail(ex.Message);
     }
@@ -249,7 +249,7 @@ app.MapPost("/api/user/update-phone", async (UpdatePhoneRequest request, UserSer
         var response = await userService.UpdateUserPhoneAsync(request.TelegramId, request.PhoneNumber);
         return Results.Ok(ApiResponse<UserDto>.Ok(response, "Phone number updated successfully"));
     }
-    catch (InvalidOperationException ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }
@@ -343,7 +343,7 @@ app.MapPut("/api/user/status", async (UpdateUserStatusRequest request, UserServi
         var user = await userService.UpdateUserStatusAsync(request.TelegramId, request.NewStatus);
         return Results.Ok(ApiResponse<UserDto>.Ok(user, "وضعیت کاربر با موفقیت به‌روزرسانی شد."));
     }
-    catch (InvalidOperationException ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<UserDto>.Fail(ex.Message));
     }

--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -9,6 +9,7 @@ using TallaEgg.Core.Enums.User;
 using TallaEgg.Core.Utilties;
 using Users.Application.Mappers;
 using Users.Core;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Users.Application;
 
@@ -30,7 +31,7 @@ public class UserService
     public async Task<UserDto> RegisterUserAsync(long telegramId,string invitationCode, string? username, string? firstName, string? lastName)
     {
         var createdByUserId = await GetUserIdByInvitationCode(invitationCode);
-        if (createdByUserId == null) throw new Exception("کد دعوت معتبر نیست.");
+        if (createdByUserId == null) throw new BusinessRuleException("کد دعوت معتبر نیست.");
         var user = new User
         {
             Id = Guid.NewGuid(),
@@ -78,7 +79,7 @@ public class UserService
         var user = await _userRepository.GetByTelegramIdAsync(telegramId);
         if (user == null)
         {
-            throw new InvalidOperationException("کاربر یافت نشد.");
+            throw new BusinessRuleException("کاربر یافت نشد.");
         }
 
         user.PhoneNumber = phoneNumber;
@@ -97,7 +98,7 @@ public class UserService
         var user = await _userRepository.GetByTelegramIdAsync(telegramId);
         if (user == null)
         {
-            throw new InvalidOperationException("کاربر یافت نشد.");
+            throw new BusinessRuleException("کاربر یافت نشد.");
         }
 
         user.Status = status;

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -163,7 +163,7 @@ app.MapGet("/api/wallet/balance/{userId}/{asset}", async (Guid userId, string as
         var balance = await walletService.GetBalanceAsync(userId, asset);
         return Results.Ok(ApiResponse<WalletDTO>.Ok(balance, ""));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
@@ -185,7 +185,7 @@ app.MapPost("/api/wallet/deposit", async (WalletRequest request, IWalletService 
        return Results.Ok(ApiResponse<WalletBallanceDTO>.Ok(result, "عملیات با موفقیت انجام شد"));
 
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
     }
@@ -201,7 +201,7 @@ app.MapPost("/api/wallet/withdrawal", async (WalletRequest request, IWalletServi
        return Results.Ok(ApiResponse<WalletBallanceDTO>.Ok(result, "عملیات با موفقیت انجام شد"));
 
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
     }
@@ -217,7 +217,7 @@ app.MapPost("/api/wallet/lockBalance", async (WalletRequest request, IWalletServ
        return Results.Ok(ApiResponse<WalletDTO>.Ok(result, "عملیات با موفقیت انجام شد"));
 
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
@@ -232,7 +232,7 @@ app.MapPost("/api/wallet/unlockBalance", async (WalletRequest request, IWalletSe
         var result = await walletService.UnlockBalanceAsync(request.UserId, request.Asset, request.Amount);
         return Results.Ok(ApiResponse<WalletDTO>.Ok(result, "عملیات با موفقیت انجام شد"));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
@@ -246,7 +246,7 @@ app.MapPost("/api/wallet/increaseBalance", async (WalletRequest request, IWallet
         var result = await walletService.IncreaseBalanceAsync(request.UserId, request.Asset, request.Amount);
         return Results.Ok(ApiResponse<(WalletEntity,Transaction)>.Ok(result, "عملیات با موفقیت انجام شد"));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<WalletDTO>.Fail(ex.Message));
     }
@@ -273,7 +273,7 @@ app.MapPost("/api/wallet/changeBalance", async (TradeDto trade, IWalletService w
 
         return Results.Ok(ApiResponse<string>.Ok(result.Message, "Trade settled"));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         logger.LogError(ex, "Error settling trade {TradeId}", trade.Id);
         return Results.BadRequest(ApiResponse<string>.Fail(ex.Message));
@@ -307,7 +307,7 @@ app.MapPost("/api/wallet/transaction/trade", async (TradeRequest request, IWalle
         var result = await walletService.MakeTradeAsync(request.FromUserId, request.ToUserId, request.Asset, request.Amount, request.ReferenceId);
         return Results.Ok(ApiResponse<WalletBallanceDTO>.Ok(result, "Operation completed successfully"));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         logger.LogError(ex, "Error in MakeTradeAsync for users {FromUserId} -> {ToUserId}", request.FromUserId, request.ToUserId);
         return Results.BadRequest(ApiResponse<WalletBallanceDTO>.Fail(ex.Message));
@@ -341,7 +341,7 @@ app.MapGet("/api/wallet/create-default/{userId}", async (Guid userId, IWalletSer
         var wallets = await walletService.CreateDefaultWalletsAsync(userId);
         return Results.Ok(ApiResponse<IEnumerable<WalletDTO>>.Ok(wallets, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند"));
     }
-    catch (Exception ex)
+    catch (BusinessRuleException ex)
     {
         return Results.BadRequest(ApiResponse<IEnumerable<WalletDTO>>.Fail(ex.Message));
     }

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -6,6 +6,7 @@ using TallaEgg.Core.Enums.Wallet;
 using TallaEgg.Core.Utilties;
 using Wallet.Application.Mappers;
 using Wallet.Core;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Wallet.Application;
 
@@ -23,7 +24,7 @@ public class WalletService : IWalletService
     public async Task<WalletDTO> GetBalanceAsync(Guid userId, string asset)
     {
         var wallet = await _walletRepository.GetWalletAsync(userId, asset);
-        if (wallet == null) throw new Exception("کیف پول پیدا نشد");
+        if (wallet == null) throw new BusinessRuleException("کیف پول پیدا نشد");
         return _walletMapper.Map(wallet);
     }
 
@@ -49,7 +50,7 @@ public class WalletService : IWalletService
             // unknown asset code (a typo, not a real symbol) still fails loudly instead of
             // silently creating a phantom wallet.
             if (!CurrenciesConstant.IsValidCurrency(asset))
-                throw new ArgumentException("کیف پول وجود ندارد");
+                throw new BusinessRuleException("کیف پول وجود ندارد");
 
             wallet = await _walletRepository.CreateWalletAsync(WalletEntity.Create(userId, asset));
         }
@@ -90,7 +91,7 @@ public class WalletService : IWalletService
             // credited. Decreasing an empty, just-created wallet then behaves exactly like
             // decreasing any other zero-balance wallet — unrelated to this fix.
             if (!CurrenciesConstant.IsValidCurrency(asset))
-                throw new ArgumentException("کیف پول وجود ندارد");
+                throw new BusinessRuleException("کیف پول وجود ندارد");
 
             wallet = await _walletRepository.CreateWalletAsync(WalletEntity.Create(userId, asset));
         }
@@ -215,10 +216,10 @@ public class WalletService : IWalletService
         var toWallet = await _walletRepository.GetWalletAsync(toUserId, asset);
 
         if (fromWallet == null || toWallet == null)
-            throw new ArgumentException("کیف پول یکی از طرفین وجود ندارد");
+            throw new BusinessRuleException("کیف پول یکی از طرفین وجود ندارد");
 
         if (fromUserId == toUserId)
-            throw new ArgumentException("انتقال به خود امکان‌پذیر نیست.");
+            throw new BusinessRuleException("انتقال به خود امکان‌پذیر نیست.");
 
         // Never implemented: this returns an empty DTO, so a caller is told the trade succeeded
         // while no balance moves. That is audit finding C-8. The endpoint in front of it,

--- a/src/Wallet/Wallet.Core/Wallet.cs
+++ b/src/Wallet/Wallet.Core/Wallet.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using TallaEgg.Core.Enums.Wallet;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Wallet.Core;
 
@@ -46,7 +47,7 @@ public class WalletEntity
     public void IncreaseBalance(decimal amount)
     {
         if (amount <= 0)
-            throw new ArgumentException("مقدار باید بزرگتر از صفر باشد", nameof(amount));
+            throw new BusinessRuleException("مقدار باید بزرگتر از صفر باشد");
 
         Balance += amount;
         UpdatedAt = DateTime.UtcNow;
@@ -55,10 +56,10 @@ public class WalletEntity
     public void DecreaseBalance(decimal amount)
     {
         if (amount <= 0)
-            throw new ArgumentException("مقدار باید بزرگتر از صفر باشد", nameof(amount));
+            throw new BusinessRuleException("مقدار باید بزرگتر از صفر باشد");
 
         if (Balance - amount < 0)
-            throw new ArgumentException("مقدار کسر از حساب بیشتر از حد مجاز است");
+            throw new BusinessRuleException("مقدار کسر از حساب بیشتر از حد مجاز است");
 
         Balance -= amount;
         UpdatedAt = DateTime.UtcNow;
@@ -101,7 +102,7 @@ public class WalletEntity
     public void ConsumeLockedBalance(decimal amount)
     {
         if (amount <= 0)
-            throw new ArgumentException("مقدار باید بزرگتر از صفر باشد", nameof(amount));
+            throw new BusinessRuleException("مقدار باید بزرگتر از صفر باشد");
 
         LockedBalance -= amount;
         UpdatedAt = DateTime.UtcNow;

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using TallaEgg.Core;
 using TallaEgg.Core.Enums.Wallet;
 using Wallet.Core;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Wallet.Infrastructure;
 
@@ -131,7 +132,7 @@ public class WalletRepository : IWalletRepository
             // service. A genuinely unknown asset still fails instead of creating a phantom
             // wallet.
             if (!CurrenciesConstant.IsValidCurrency(asset))
-                throw new ArgumentNullException("کیف پول پیدا نشد", nameof(wallet));
+                throw new BusinessRuleException("کیف پول پیدا نشد");
 
             wallet = await CreateWalletAsync(WalletEntity.Create(userId, asset));
         }
@@ -165,7 +166,7 @@ public class WalletRepository : IWalletRepository
             // order-cancellation flow, a Lock always precedes the matching Unlock and so the
             // wallet already exists by then.
             if (!CurrenciesConstant.IsValidCurrency(asset))
-                throw new ArgumentNullException("کیف پول پیدا نشد", nameof(wallet));
+                throw new BusinessRuleException("کیف پول پیدا نشد");
 
             wallet = await CreateWalletAsync(WalletEntity.Create(userId, asset));
         }
@@ -183,7 +184,7 @@ public class WalletRepository : IWalletRepository
                 "Refusing to unlock {Amount} {Asset} for user {UserId}: only {Locked} is locked.",
                 amount, asset, userId, wallet.LockedBalance);
 
-            throw new InvalidOperationException(
+            throw new BusinessRuleException(
                 $"مقدار آزادسازی ({amount}) از موجودی قفل‌شده ({wallet.LockedBalance}) بیشتر است.");
         }
 
@@ -219,7 +220,7 @@ public class WalletRepository : IWalletRepository
             // "wallet not found" message (issue #39 territory: a stuck settlement, not just a
             // refused request).
             if (!CurrenciesConstant.IsValidCurrency(asset))
-                throw new ArgumentNullException("کیف پول پیدا نشد", nameof(wallet));
+                throw new BusinessRuleException("کیف پول پیدا نشد");
 
             wallet = await CreateWalletAsync(WalletEntity.Create(userId, asset));
         }

--- a/tests/TallaEgg.AllServices.Tests/AutoQuoteSettingsTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuoteSettingsTests.cs
@@ -1,4 +1,5 @@
-using Orders.Core;
+﻿using Orders.Core;
+using TallaEgg.Core.ErrorHandling;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -34,7 +35,7 @@ public class AutoQuoteSettingsTests
     {
         var settings = AutoQuoteSettings.CreateDefault("MAUA/IRT");
 
-        Assert.Throws<ArgumentException>(() => settings.UpdateSpread(-0.1m, Guid.NewGuid()));
+        Assert.Throws<BusinessRuleException>(() => settings.UpdateSpread(-0.1m, Guid.NewGuid()));
     }
 
     [Fact]

--- a/tests/TallaEgg.AllServices.Tests/QuarantinedStubTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/QuarantinedStubTests.cs
@@ -5,6 +5,7 @@ using Wallet.Application;
 using Wallet.Application.Mappers;
 using Wallet.Core;
 using Wallet.Infrastructure;
+using TallaEgg.Core.ErrorHandling;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -112,14 +113,14 @@ public class QuarantinedStubTests : IDisposable
     [Fact]
     public async Task MakeTradeAsync_StillRefusesATransferToSelf()
     {
-        await Assert.ThrowsAsync<ArgumentException>(() =>
+        await Assert.ThrowsAsync<BusinessRuleException>(() =>
             _service.MakeTradeAsync(_fromUserId, _fromUserId, Asset, 25m, "REF-3"));
     }
 
     [Fact]
     public async Task MakeTradeAsync_StillRefusesAMissingWallet()
     {
-        await Assert.ThrowsAsync<ArgumentException>(() =>
+        await Assert.ThrowsAsync<BusinessRuleException>(() =>
             _service.MakeTradeAsync(_fromUserId, Guid.NewGuid(), Asset, 25m, "REF-4"));
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/QuoteTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/QuoteTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Orders.Core;
 using Orders.Infrastructure;
 using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.ErrorHandling;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -65,7 +66,7 @@ public class QuoteTests : IDisposable
     [Fact]
     public void ANegativeSpreadIsRejected()
     {
-        var ex = Assert.Throws<ArgumentException>(() =>
+        var ex = Assert.Throws<BusinessRuleException>(() =>
             Quote.Publish(Symbol, buyPrice: 18_000_000m, sellPrice: 17_000_000m, Admin));
 
         Assert.Contains("قیمت خرید", ex.Message);
@@ -85,8 +86,8 @@ public class QuoteTests : IDisposable
     [InlineData(-1)]
     public void NonPositivePricesAreRejected(decimal badPrice)
     {
-        Assert.Throws<ArgumentException>(() => Quote.Publish(Symbol, badPrice, 17_500_000m, Admin));
-        Assert.Throws<ArgumentException>(() => Quote.Publish(Symbol, 17_000_000m, badPrice, Admin));
+        Assert.Throws<BusinessRuleException>(() => Quote.Publish(Symbol, badPrice, 17_500_000m, Admin));
+        Assert.Throws<BusinessRuleException>(() => Quote.Publish(Symbol, 17_000_000m, badPrice, Admin));
     }
 
     // ── Publishing ──────────────────────────────────────────────────────────────

--- a/tests/TallaEgg.AllServices.Tests/WalletLazyCreationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletLazyCreationTests.cs
@@ -1,10 +1,11 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
 using Wallet.Application;
 using Wallet.Application.Mappers;
 using Wallet.Infrastructure;
+using TallaEgg.Core.ErrorHandling;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -87,7 +88,7 @@ public class WalletLazyCreationTests : IDisposable
         var service = NewService(context);
         var userId = Guid.NewGuid();
 
-        var ex = await Assert.ThrowsAsync<ArgumentException>(
+        var ex = await Assert.ThrowsAsync<BusinessRuleException>(
             () => service.WithdrawalAsync(userId, CurrenciesConstant.Btc, 1m));
 
         Assert.DoesNotContain("وجود ندارد", ex.Message);
@@ -118,7 +119,7 @@ public class WalletLazyCreationTests : IDisposable
         using var context = NewContext();
         var service = NewService(context);
 
-        await Assert.ThrowsAsync<ArgumentException>(
+        await Assert.ThrowsAsync<BusinessRuleException>(
             () => service.DepositAsync(Guid.NewGuid(), "NOT_A_REAL_ASSET", 100m));
     }
 }


### PR DESCRIPTION
## Description

Every API endpoint used to end in `catch (Exception ex) => Fail(ex.Message)`. It returned the message of whatever had been thrown, and **the code could not tell what it was returning.**

A count across the services:

| | |
|---|---|
| throws carrying **Persian** text written for the customer | **49** |
| throws carrying **English** text written for a developer | **68** |

`"کیف پول وجود ندارد"` and `"ReferenceId cannot be empty"` both arrive as `ArgumentException`. And `catch (Exception)` also caught the `SqlException`, the `HttpRequestException` and the `NullReferenceException`, whose messages are for nobody but us.

So the same line either gave the customer a useful sentence or a .NET diagnostic, depending on what went wrong, with nothing in the code marking which.

## Type of Change
- [x] Hotfix (urgent bug fix)
- [x] Feature (new capability)
- [x] Refactor (code organization, no behavior change)

## `BusinessRuleException`

Its contract is the whole point: **the message is written for the customer, and returning it is safe.**

**24 throws** now use it — the domain validation in `Wallet`, `Quote`, `AutoQuoteSettings`, `SymbolSettings`, `WalletService`, `UserService` and `OrderService`.

**What stays untouched is as much of the point.** `OrderRepository`'s 18 Persian `InvalidOperationException`s wrap a failed database call:

```csharp
catch (Exception ex)
{
    _logger.LogError(ex, "Error creating order");
    throw new InvalidOperationException("خطا در ذخیره سفارش", ex);
}
```

That is not a rule anybody broke. It belongs to `GlobalExceptionHandler` and its trace id — a failed read should not read as a rejected request.

## The endpoints follow

- **14 generic clauses** became `catch (BusinessRuleException ex)`.
- **Six typed ones** standing in for the same idea (`ArgumentException`, `InvalidOperationException`) came with them.
- `UnauthorizedAccessException` **stays** — it means 401, not 400.
- **Four clauses on the outbox operator endpoints** were left catching a type nothing throws there, so they are removed and those failures reach the global handler. A failed re-drive is a 500 with a trace id, not a 400 with a message.

Every remaining `ex.Message` return is now inside a catch that names the type it expects.

## Two defects surfaced on the way

**1.** `WalletRepository` threw this in three places:

```csharp
throw new ArgumentNullException("کیف پول پیدا نشد", nameof(wallet));
```

The arguments are the wrong way round — the first parameter of that constructor is `paramName`. The customer was shown `wallet (Parameter 'کیف پول پیدا نشد')`.

**2.** Two Persian throws spanning two lines were missed by the first conversion pass. A test caught one; a search for the shape caught the other.

## The tests earned their keep

Seven failed on the type change, all asserting `Assert.Throws<ArgumentException>` against code whose **behaviour is unchanged**. They assert the new type now.

`OutboxMessageTests` keeps `ArgumentException`: `MarkAbandoned`'s "An abandon reason is required" is written for an operator, not a customer — which is exactly the distinction being drawn.

## Testing Completed

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 55 warnings
dotnet test  TallaEgg.sln -c Release --no-build   →  486/486 passed
```

## Deployment / Rollback

No migrations, no configuration, no data change. What a customer sees changes only where they were previously shown text not meant for them. Rollback is a revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)