### PR TITLE
fix(nullable): clear the last 54 warnings and turn every warning into an error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,14 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <!-- Warning classes that were driven to zero in #132. As errors they cannot creep back one
-         file at a time, which is how the count reached 168 in the first place. Deliberately not
-         the nullable family (CS86xx): 74 of those remain, each needs a judgment about whether it
-         is a real bug, and failing the build on them would only invite silencing with `!`. -->
-    <WarningsAsErrors>$(WarningsAsErrors);CS1587;CS0168;CS1998;CS0162;CS0219</WarningsAsErrors>
+    <!-- The count reached 168 because no single commit ever added a hundred warnings; they
+         arrived one file at a time. It is at zero now, and TreatWarningsAsErrors is what keeps it
+         there: the next one fails a build instead of joining a list nobody reads.
+
+         The nullable family is included, which it could not be while 74 of them were outstanding.
+         Each was resolved by making a signature honest or by handling the null, never by `!` — if
+         a fix ever needs that operator, the fix is wrong. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TelegramBot/TallaEgg.TelegramBot.Core/Utilties/Utils.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Core/Utilties/Utils.cs
@@ -10,7 +10,7 @@ namespace TallaEgg.TelegramBot.Core.Utilties
     public static class Utils
     {
 
-        public static string EscapeMarkdownV2(string text)
+        public static string EscapeMarkdownV2(string? text)
         {
             if (string.IsNullOrEmpty(text))
                 return "";

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -65,7 +65,6 @@ namespace TallaEgg.TelegramBot
                     return true;
                 }
 
-                var info = CurrenciesConstant.GetCurrencyInfo(currency);
                 var userDto = await _usersApi.GetUserAsync(phone);
                 if (userDto != null)
                 {
@@ -82,13 +81,13 @@ namespace TallaEgg.TelegramBot
                         // rather than "balance"; the previous message confused the two. Markdown
                         // formatting also clashed with ParseMode.Html and rendered the asterisks and
                         // backticks literally, so the text is now plain.
-                        var amountText = $"{PersianFormat.Amount(amount, currency)} {info.Unit}";
-                        var newCreditText = $"{PersianFormat.Amount(result.Data.BalanceAfter, currency)} {info.Unit}";
+                        var amountText = $"{PersianFormat.Amount(amount, currency)} {PersianFormat.Unit(currency)}";
+                        var newCreditText = $"{PersianFormat.Amount(result.Data?.BalanceAfter ?? 0m, currency)} {PersianFormat.Unit(currency)}";
 
                         await _messenger.SendAsync(
                            message.Chat.Id,
                            string.Format(BotMsgs.MsgAdminChargeDone,
-                               info.PersianName,
+                               PersianFormat.Asset(currency),
                                amountText,
                                PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
                                newCreditText));
@@ -96,7 +95,7 @@ namespace TallaEgg.TelegramBot
                         await _messenger.SendAsync(
                            userDto.TelegramId,
                            string.Format(BotMsgs.MsgUserCreditIncreased,
-                               info.PersianName,
+                               PersianFormat.Asset(currency),
                                amountText,
                                newCreditText));
                     }
@@ -148,7 +147,6 @@ namespace TallaEgg.TelegramBot
                     return true;
                 }
 
-                var info = CurrenciesConstant.GetCurrencyInfo(currency);
                 var userDto = await _usersApi.GetUserAsync(phone);
                 if (userDto != null)
                 {
@@ -165,13 +163,13 @@ namespace TallaEgg.TelegramBot
                         // The message sent to the user used to say the wallet had been topped up
                         // when the amount had in fact been deducted. It also hard-coded the currency
                         // unit regardless of the asset, and displayed the asset's Latin code.
-                        var deductAmountText = $"{PersianFormat.Amount(amount, currency)} {info.Unit}";
-                        var newBalanceText = $"{PersianFormat.Amount(result.Data.BalanceAfter, currency)} {info.Unit}";
+                        var deductAmountText = $"{PersianFormat.Amount(amount, currency)} {PersianFormat.Unit(currency)}";
+                        var newBalanceText = $"{PersianFormat.Amount(result.Data?.BalanceAfter ?? 0m, currency)} {PersianFormat.Unit(currency)}";
 
                         await _messenger.SendAsync(
                                message.Chat.Id,
                                string.Format(BotMsgs.MsgAdminDeductDone,
-                                   info.PersianName,
+                                   PersianFormat.Asset(currency),
                                    deductAmountText,
                                    PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
                                    newBalanceText));
@@ -179,7 +177,7 @@ namespace TallaEgg.TelegramBot
                         await _messenger.SendAsync(
                                userDto.TelegramId,
                                string.Format(BotMsgs.MsgUserBalanceDeducted,
-                                   info.PersianName,
+                                   PersianFormat.Asset(currency),
                                    deductAmountText,
                                    newBalanceText));
 
@@ -222,7 +220,7 @@ namespace TallaEgg.TelegramBot
                         replyMarkup: UserListHandler.BuildPagingKeyboard(page.Data!, 1, q)
                     );
                 }
-                else await _messenger.SendAsync(chatId, page.Message);
+                else await _messenger.SendAsync(chatId, page.Message ?? BotMsgs.MsgUnexpectedError);
                 return true;
             }
             if (msgText.StartsWith("م "))

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -66,11 +66,11 @@ public class Program
                 var prefix = $"Services:{applicationName}:";
                 var flattened = serviceSection.AsEnumerable(true)
                     .Where(pair => pair.Value is not null)
-                    .Select(pair => new KeyValuePair<string, string>(
+                    .Select(pair => new KeyValuePair<string, string?>(
                         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
                             ? pair.Key[prefix.Length..]
                             : pair.Key,
-                        pair.Value!))
+                        pair.Value))
                     .Where(pair => !string.IsNullOrWhiteSpace(pair.Key));
 
                 configBuilder.AddInMemoryCollection(flattened);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
@@ -189,7 +189,7 @@ public class TelegramBotHostedService : BackgroundService
                 _logger.LogInformation("Received message from {User}: {Preview}", update.Message.From?.Username ?? "Unknown", preview);
                 await _botHandler.HandleMessageAsync(update.Message);
             }
-            else if (update.CallbackQuery is not null && update.CallbackQuery.Message.Chat.Type == ChatType.Private)
+            else if (update.CallbackQuery?.Message?.Chat.Type == ChatType.Private)
             {
                 _logger.LogInformation("Received callback query from {User}: {Data}", update.CallbackQuery.From?.Username ?? "Unknown", update.CallbackQuery.Data);
                 await _botHandler.HandleCallbackQueryAsync(update.CallbackQuery);

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TestBotToken.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TestBotToken.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -21,6 +21,15 @@ namespace TallaEgg.TelegramBot
                 if (response.IsSuccessStatusCode)
                 {
                     var result = JsonConvert.DeserializeObject<dynamic>(content);
+                    if (result is null)
+                    {
+                        // A 2xx that does not parse means we are not talking to the Telegram API —
+                        // a proxy or captive portal answering for it, most likely. Treating that as
+                        // a valid token would start the bot against something that is not Telegram.
+                        Console.WriteLine("❌ getMe returned a success status with an unreadable body");
+                        return false;
+                    }
+
                     Console.WriteLine($"✅ Bot is valid: {result.ok}");
                     Console.WriteLine($"Bot Username: {result.result.username}");
                     Console.WriteLine($"Bot Name: {result.result.first_name}");

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -1,4 +1,4 @@
-using Affiliate.Application;
+﻿using Affiliate.Application;
 using Affiliate.Core;
 using Affiliate.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
@@ -28,7 +28,7 @@ if (!serviceSection.Exists())
 var prefix = $"Services:{applicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)
-    .Select(pair => new KeyValuePair<string, string>(
+    .Select(pair => new KeyValuePair<string, string?>(
         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             ? pair.Key[prefix.Length..]
             : pair.Key,

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -444,7 +444,7 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
         if (request.Quantity <= 0)
             return Results.BadRequest(new { success = false, message = "مقدار سفارش باید بیشتر از صفر باشد" });
         
-        if ((request.Price == null || request.Price <= 0))
+        if (request.Price <= 0)
             return Results.BadRequest(new { success = false, message = "قیمت برای سفارش محدود الزامی است" });
 
         var response = await orderService.CreateOrderAsync(request);

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -44,7 +44,7 @@ if (!serviceSection.Exists())
 var prefix = $"Services:{applicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)
-    .Select(pair => new KeyValuePair<string, string>(
+    .Select(pair => new KeyValuePair<string, string?>(
         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             ? pair.Key[prefix.Length..]
             : pair.Key,

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -134,11 +134,6 @@ public class OrderService
             List<TradeDto> executedTrades = new();
 
 
-            if (request.Price == null)
-            {
-                throw new BusinessRuleException("قیمت برای سفارش محدود الزامی است");
-            }
-
             // Limit orders start as Makers
             var limitCommand = new CreateOrderCommand(
                 request.Symbol,

--- a/src/Order/Orders.Core/Order.cs
+++ b/src/Order/Orders.Core/Order.cs
@@ -6,7 +6,7 @@ namespace Orders.Core;
 public class Order
 {
     public Guid Id { get; private set; }
-    public string Asset { get; private set; }
+    public string Asset { get; private set; } = string.Empty;
     public decimal Amount { get; private set; } // مقدار اولیه سفارش - تغییر نمی‌کند
     public decimal RemainingAmount { get; private set; } // مقدار باقی‌مانده سفارش
     public decimal Price { get; private set; }

--- a/src/TallaEgg/TallaEgg.Api/Migrations/20250804085118_seed-users.Designer.cs
+++ b/src/TallaEgg/TallaEgg.Api/Migrations/20250804085118_seed-users.Designer.cs
@@ -13,7 +13,7 @@ namespace TallaEgg.Api.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
     [Migration("20250804085118_seed-users")]
-    partial class seedusers
+    partial class SeedUsers
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/TallaEgg/TallaEgg.Api/Migrations/20250804085118_seed-users.cs
+++ b/src/TallaEgg/TallaEgg.Api/Migrations/20250804085118_seed-users.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace TallaEgg.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class seedusers : Migration
+    public partial class SeedUsers : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -32,7 +32,7 @@ if (!serviceSection.Exists())
 var prefix = $"Services:{applicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)
-    .Select(pair => new KeyValuePair<string, string>(
+    .Select(pair => new KeyValuePair<string, string?>(
         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             ? pair.Key[prefix.Length..]
             : pair.Key,

--- a/src/TallaEgg/TallaEgg.Core/ApiKeyAuthenticationHandler.cs
+++ b/src/TallaEgg/TallaEgg.Core/ApiKeyAuthenticationHandler.cs
@@ -13,14 +13,14 @@ namespace TallaEgg.Core
 {
     public class ApiKeyAuthenticationSchemeOptions : AuthenticationSchemeOptions
     {
-        public string ApiKey { get; set; }
+        public string ApiKey { get; set; } = string.Empty;
     }
 
     public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationSchemeOptions>
     {
         public ApiKeyAuthenticationHandler(IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> options,
-            ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
-            : base(options, logger, encoder, clock)
+            ILoggerFactory logger, UrlEncoder encoder)
+            : base(options, logger, encoder)
         {
         }
 

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -407,9 +407,9 @@ namespace TallaEgg.Core
 
     public class CurrencyInfo
     {
-        public string Code { get; set; }          // مثل "MAUA" یا "IRT"
-        public string PersianName { get; set; }   // نام فارسی ارز
-        public string Unit { get; set; }          // واحد نمایش
+        public string Code { get; set; } = string.Empty;          // مثل "MAUA" یا "IRT"
+        public string PersianName { get; set; } = string.Empty;   // نام فارسی ارز
+        public string Unit { get; set; } = string.Empty;          // واحد نمایش
         public int DecimalPlaces { get; set; }    // تعداد اعشار
         public bool IsTradable { get; set; }      // قابل معامله بودن
     }

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -204,8 +204,8 @@ namespace TallaEgg.Core
         public static List<string> GetAllCodes() =>
             _currencies.Values.Select(c => c.Code).ToList();
 
-        // Look up a currency, case-insensitively.
-        public static CurrencyInfo GetCurrencyInfo(string code) =>
+        // Look up a currency, case-insensitively. Null when the code is not one we trade.
+        public static CurrencyInfo? GetCurrencyInfo(string code) =>
             _currencies.TryGetValue(code, out var info) ? info : null;
 
         // Whether a currency code is valid, case-insensitively.

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -12,7 +12,7 @@ namespace TallaEgg.Core.DTOs.Order
     public class OrderHistoryDto
     {
         public Guid Id { get; set; }
-        public string Asset { get; set; }
+        public string Asset { get; set; } = string.Empty;
         public decimal Amount { get; set; }
         public decimal RemainingAmount { get; set; }
         public decimal Price { get; set; }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/TradeDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/TradeDto.cs
@@ -17,7 +17,7 @@ namespace TallaEgg.Core.DTOs.Order
         public Guid SellOrderId { get; set; }
         public Guid MakerOrderId { get; set; }
         public Guid TakerOrderId { get; set; }
-        public string Symbol { get; set; }
+        public string Symbol { get; set; } = string.Empty;
         public decimal Price { get; set; }
         public decimal Quantity { get; set; }
         public decimal QuoteQuantity { get; set; }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
@@ -13,7 +13,7 @@ namespace TallaEgg.Core.DTOs.Wallet
         public decimal LockedBalance { get; set; } = 0; // For pending orders
         public DateTime UpdatedAt { get; set; }
         public decimal BalanceAfter { get; set; }
-        public string TrackingCode { get; set; }
+        public string TrackingCode { get; set; } = string.Empty;
     }
 
   

--- a/src/TallaEgg/TallaEgg.Core/Mappers/BaseMapper.cs
+++ b/src/TallaEgg/TallaEgg.Core/Mappers/BaseMapper.cs
@@ -8,17 +8,31 @@ namespace TallaEgg.Core.Mappers
 {
     public abstract class BaseMapper<TEntity, TDto> : IMapper<TEntity, TDto>
     {
-        public abstract TDto Map(TEntity entity);
-        public abstract TEntity MapBack(TDto dto);
+        public abstract TDto? Map(TEntity? entity);
+        public abstract TEntity? MapBack(TDto? dto);
 
+        /// <summary>
+        /// For an entity the caller has already established exists — one it just created, or one
+        /// it guarded with a not-found check. A null back from <see cref="Map"/> here would mean
+        /// the mapper broke its own contract, not that the entity was missing, so it throws rather
+        /// than passing a null on to code that has no reason to expect one.
+        /// </summary>
+        public TDto MapRequired(TEntity entity)
+        {
+            return Map(entity) ?? throw new InvalidOperationException(
+                $"{GetType().Name}.Map returned null for a {typeof(TEntity).Name} that is not null.");
+        }
+
+        // OfType drops anything Map returned null for, so a list never carries holes a caller
+        // would have to check for one by one.
         public IEnumerable<TDto> MapList(IEnumerable<TEntity> entities)
         {
-            return entities?.Select(Map).ToList() ?? new List<TDto>();
+            return entities?.Select(Map).OfType<TDto>().ToList() ?? new List<TDto>();
         }
 
         public IEnumerable<TEntity> MapBackList(IEnumerable<TDto> dtos)
         {
-            return dtos?.Select(MapBack).ToList() ?? new List<TEntity>();
+            return dtos?.Select(MapBack).OfType<TEntity>().ToList() ?? new List<TEntity>();
         }
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/Mappers/IMapper.cs
+++ b/src/TallaEgg/TallaEgg.Core/Mappers/IMapper.cs
@@ -8,8 +8,14 @@ namespace TallaEgg.Core.Mappers
 {
     public interface IMapper<TEntity, TDto>
     {
-        TDto Map(TEntity entity);
-        TEntity MapBack(TDto dto);
+        /// <summary>
+        /// Maps an entity, or returns null when given null. Callers already rely on that — every
+        /// UserService lookup returns UserDto? and passes a repository result straight through —
+        /// so the signature says it rather than leaving each caller to discover it.
+        /// </summary>
+        TDto? Map(TEntity? entity);
+
+        TEntity? MapBack(TDto? dto);
 
         IEnumerable<TDto> MapList(IEnumerable<TEntity> entities);
         IEnumerable<TEntity> MapBackList(IEnumerable<TDto> dtos);

--- a/src/TallaEgg/TallaEgg.Core/Requests/Trade/TradeRequest.cs
+++ b/src/TallaEgg/TallaEgg.Core/Requests/Trade/TradeRequest.cs
@@ -11,9 +11,9 @@ namespace TallaEgg.Core.Requests.Trade
         
         public Guid FromUserId { get; set; }
         public Guid ToUserId { get; set; }
-        public string Asset { get; set; }
+        public string Asset { get; set; } = string.Empty;
         public decimal Amount { get; set; }
-        public string ReferenceId { get; set; }
+        public string ReferenceId { get; set; } = string.Empty;
 
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/Requests/User/RegisterUserRequest.cs
+++ b/src/TallaEgg/TallaEgg.Core/Requests/User/RegisterUserRequest.cs
@@ -34,6 +34,6 @@ namespace TallaEgg.Core.Requests.User
         /// <summary>
         /// Invitation code for registration (required)
         /// </summary>
-        public string InvitationCode { get; set; }
+        public string InvitationCode { get; set; } = string.Empty;
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/Requests/User/UpdatePhoneRequest.cs
+++ b/src/TallaEgg/TallaEgg.Core/Requests/User/UpdatePhoneRequest.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// New phone number to set for the user (required)
         /// </summary>
-        public string PhoneNumber { get; set; }
+        public string PhoneNumber { get; set; } = string.Empty;
         
         /// <summary>
         /// Telegram ID of the user to update (required)

--- a/src/TallaEgg/TallaEgg.Core/Requests/Wallet/WalletRequest.cs
+++ b/src/TallaEgg/TallaEgg.Core/Requests/Wallet/WalletRequest.cs
@@ -5,7 +5,7 @@ namespace TallaEgg.Core.Requests.Wallet
     public class WalletRequest
     {
         public Guid UserId { get; set; }
-        public string Asset { get; set; }
+        public string Asset { get; set; } = string.Empty;
         public decimal Amount { get; set; }
         public string? ReferenceId { get; set; }
     }

--- a/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs
@@ -22,6 +22,21 @@ namespace TallaEgg.Core.Services
         }
 
         /// <summary>
+        /// The version line appended to every message, or nothing when the entry assembly has no
+        /// version — which is the case under a test host, where GetEntryAssembly is the runner.
+        /// Computed once: it cannot change while the process lives.
+        /// </summary>
+        private static readonly string VersionSuffix = BuildVersionSuffix();
+
+        private static string BuildVersionSuffix()
+        {
+            var assemblyVersion = Assembly.GetEntryAssembly()?.GetName().Version;
+            return assemblyVersion is null
+                ? string.Empty
+                : $"\n V:{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}";
+        }
+
+        /// <summary>
         /// Send To Main Chanell
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -31,7 +46,6 @@ namespace TallaEgg.Core.Services
         /// 
         public async Task Notif(string message, string chatId= "-1002988196234", string parseMode = "")
         {
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
             string text = /*$"StoreName:{_appSettings.StoreName}\n" +*/ message;
@@ -42,7 +56,7 @@ namespace TallaEgg.Core.Services
                 WriteIndented = true
             };
 
-            text += $"\n V:{version.Major}.{version.Minor}.{version.Build}";
+            text += VersionSuffix;
 
             string _message = JsonSerializer.Serialize(new { Message = text, BotId = _botToken, ChatId = chatId, ParseMode = parseMode }, _options);
 
@@ -61,7 +75,6 @@ namespace TallaEgg.Core.Services
         /// 
         public async Task Notif<T>(string message, T dto, string chatId = "-1002988196234", string parseMode = "")
         {
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
             string text = /*$"StoreName:{_appSettings.StoreName}\n" +*/ message;
@@ -74,7 +87,7 @@ namespace TallaEgg.Core.Services
             };
 
             text += JsonSerializer.Serialize(dto, _options);
-            text += $"\n V:{version.Major}.{version.Minor}.{version.Build}";
+            text += VersionSuffix;
 
             string _message = JsonSerializer.Serialize(new { Message = text, BotId = _botToken, ChatId = chatId, ParseMode = parseMode }, _options);
 
@@ -86,7 +99,6 @@ namespace TallaEgg.Core.Services
 
         public async Task LogAsync<T>(string message, T dto, string chatId = "-822161060", string parseMode = "")
         {
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
             string text = /*$"StoreName:{_appSettings.StoreName}\n" +*/ message;
@@ -99,7 +111,7 @@ namespace TallaEgg.Core.Services
             };
 
             text += JsonSerializer.Serialize(dto, _options);
-            text += $"\n V:{version.Major}.{version.Minor}.{version.Build}";
+            text += VersionSuffix;
 
             string _message = JsonSerializer.Serialize(new { Message = text, BotId = _botToken, ChatId = chatId, ParseMode = parseMode }, _options);
 
@@ -111,7 +123,6 @@ namespace TallaEgg.Core.Services
 
         public async Task LogAsync(string log, string chatId = "-822161060")
         {
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
             try
@@ -124,7 +135,7 @@ namespace TallaEgg.Core.Services
                 string text = /*$"StoreName:{_appSettings.StoreName}\n" +*/ log + "\n";
              
                 
-                    text += $"\n V:{version.Major}.{version.Minor}.{version.Build}";
+                    text += VersionSuffix;
                     var _text = JsonSerializer.Serialize(new { Message = text, BotId = _botToken, ChatId = chatId }, _options);
                 
 
@@ -148,7 +159,6 @@ namespace TallaEgg.Core.Services
         public async Task ErrorAsync(Exception ex, string message = "")
         {
 
-            var version = Assembly.GetEntryAssembly()?.GetName().Version;
 
 
             try
@@ -164,7 +174,7 @@ namespace TallaEgg.Core.Services
                 text += "\n" + JsonSerializer.Serialize(string.IsNullOrEmpty(ex.Source) ? "no source" : ex.Source, _options);
                 //text += "\n" + ex.InnerException != null ? "Inner:" + JsonSerializer.Serialize(ex.InnerException?.Message) : "No Inner";
 
-                text += $"\n V:{version.Major}.{version.Minor}.{version.Build}";
+                text += VersionSuffix;
 
 
                 string _ex = JsonSerializer.Serialize(

--- a/src/User/Users.Api/Migrations/20250918224949_init.Designer.cs
+++ b/src/User/Users.Api/Migrations/20250918224949_init.Designer.cs
@@ -13,7 +13,7 @@ namespace Users.Api.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
     [Migration("20250918224949_init")]
-    partial class init
+    partial class Init
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/User/Users.Api/Migrations/20250918224949_init.cs
+++ b/src/User/Users.Api/Migrations/20250918224949_init.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Users.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class init : Migration
+    public partial class Init : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -43,7 +43,7 @@ if (!serviceSection.Exists())
 var prefix = $"Services:{applicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)
-    .Select(pair => new KeyValuePair<string, string>(
+    .Select(pair => new KeyValuePair<string, string?>(
         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             ? pair.Key[prefix.Length..]
             : pair.Key,

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -470,7 +470,7 @@ app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, Use
     {
         var content = await response.Content.ReadAsStringAsync();
         return Results.Json(
-            ApiResponse<object>.Ok(null, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند.")
+            ApiResponse<object?>.Ok(null, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند.")
         );
     }
     else

--- a/src/User/Users.Application/Mappers/UserMapper.cs
+++ b/src/User/Users.Application/Mappers/UserMapper.cs
@@ -11,7 +11,7 @@ namespace Users.Application.Mappers
 {
     public class UserMapper : BaseMapper<User, UserDto>
     {
-        public override UserDto Map(User entity)
+        public override UserDto? Map(User? entity)
         {
             if (entity == null) return null;
 
@@ -36,7 +36,7 @@ namespace Users.Application.Mappers
         /// entity holds that the DTO does not carry cannot be restored here and is left at its
         /// default, so the result is only safe to use as a projection, never to save.
         /// </summary>
-        public override User MapBack(UserDto dto)
+        public override User? MapBack(UserDto? dto)
         {
             if (dto == null) return null;
 

--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -53,7 +53,7 @@ public class UserService
         // Create the user's default wallets.
         await CreateDefaultWalletsAsync(user.Id);
         
-        return _userMapper.Map(user);
+        return _userMapper.MapRequired(user);
     }
 
     public async Task<UserDto?> GetUserByTelegramIdAsync(long telegramId)
@@ -85,7 +85,7 @@ public class UserService
         user.PhoneNumber = phoneNumber;
         user.LastActiveAt = DateTime.UtcNow;
          await _userRepository.UpdateAsync(user);
-        return _userMapper.Map(user);
+        return _userMapper.MapRequired(user);
     }
 
     public async Task<bool> UserExistsAsync(long telegramId)
@@ -104,7 +104,7 @@ public class UserService
         user.Status = status;
         user.LastActiveAt = DateTime.UtcNow;
         await _userRepository.UpdateAsync(user);
-        return _userMapper.Map(user);
+        return _userMapper.MapRequired(user);
     }
 
     public async Task<Guid?> GetUserIdByInvitationCode(string invitationCode)

--- a/src/User/Users.Infrastructure/UserRepository.cs
+++ b/src/User/Users.Infrastructure/UserRepository.cs
@@ -1,4 +1,4 @@
-using Affiliate.Core;
+﻿using Affiliate.Core;
 using Microsoft.EntityFrameworkCore;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
@@ -67,9 +67,9 @@ public class UserRepository : IUserRepository
         if (!string.IsNullOrEmpty(q))
         {
             query = query.Where(u =>
-            u.FirstName.Contains(q) ||
-            u.LastName.Contains(q) ||
-            u.PhoneNumber.Contains(q)
+            (u.FirstName != null && u.FirstName.Contains(q)) ||
+            (u.LastName != null && u.LastName.Contains(q)) ||
+            (u.PhoneNumber != null && u.PhoneNumber.Contains(q))
             );
         }
         var totalCount = await query.CountAsync();

--- a/src/Wallet/Wallet.Api/Migrations/20250821151423_add-sth.Designer.cs
+++ b/src/Wallet/Wallet.Api/Migrations/20250821151423_add-sth.Designer.cs
@@ -13,7 +13,7 @@ namespace Wallet.Api.Migrations
 {
     [DbContext(typeof(WalletDbContext))]
     [Migration("20250821151423_add-sth")]
-    partial class addsth
+    partial class AddSth
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/Wallet/Wallet.Api/Migrations/20250821151423_add-sth.cs
+++ b/src/Wallet/Wallet.Api/Migrations/20250821151423_add-sth.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Wallet.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class addsth : Migration
+    public partial class AddSth : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -40,7 +40,7 @@ if (!serviceSection.Exists())
 var prefix = $"Services:{applicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)
-    .Select(pair => new KeyValuePair<string, string>(
+    .Select(pair => new KeyValuePair<string, string?>(
         pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             ? pair.Key[prefix.Length..]
             : pair.Key,

--- a/src/Wallet/Wallet.Application/Mappers/WalletMapper.cs
+++ b/src/Wallet/Wallet.Application/Mappers/WalletMapper.cs
@@ -11,7 +11,7 @@ namespace Wallet.Application.Mappers
 {
     public class WalletMapper : BaseMapper<WalletEntity, WalletDTO>
     {
-        public override WalletDTO Map(WalletEntity entity)
+        public override WalletDTO? Map(WalletEntity? entity)
         {
             if (entity == null) return null;
 
@@ -29,12 +29,12 @@ namespace Wallet.Application.Mappers
             List<WalletDTO> walletDTOs = new List<WalletDTO>();
             foreach (var entity in entities)
             { 
-                walletDTOs.Add(Map(entity));
+                walletDTOs.Add(MapRequired(entity));
             }
             return walletDTOs;
         }
 
-        public override WalletEntity MapBack(WalletDTO dto)
+        public override WalletEntity? MapBack(WalletDTO? dto)
         {
             throw new NotImplementedException();
         }

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -209,7 +209,7 @@ public class WalletService : IWalletService
         };
     }
 
-    public async Task<WalletBallanceDTO> MakeTradeAsync(Guid fromUserId, Guid toUserId,string asset, decimal amount, string referenceId)
+    public async Task<WalletBallanceDTO> MakeTradeAsync(Guid fromUserId, Guid toUserId, string asset, decimal amount, string? referenceId)
     {
         
         var fromWallet = await _walletRepository.GetWalletAsync(fromUserId, asset);

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -25,7 +25,7 @@ public class WalletService : IWalletService
     {
         var wallet = await _walletRepository.GetWalletAsync(userId, asset);
         if (wallet == null) throw new BusinessRuleException("کیف پول پیدا نشد");
-        return _walletMapper.Map(wallet);
+        return _walletMapper.MapRequired(wallet);
     }
 
     /// <summary>
@@ -153,14 +153,14 @@ public class WalletService : IWalletService
     public async Task<WalletDTO> LockBalanceAsync(Guid userId, string asset, decimal amount)
     {
         var wallet = await _walletRepository.LockBalanceAsync(userId, asset, amount);
-        return _walletMapper.Map(wallet);
+        return _walletMapper.MapRequired(wallet);
 
     }
 
     public async Task<WalletDTO> UnlockBalanceAsync(Guid userId, string asset, decimal amount)
     {
         var wallet = await _walletRepository.UnlockBalanceAsync(userId, asset, amount);
-        return _walletMapper.Map(wallet);
+        return _walletMapper.MapRequired(wallet);
     }
 
     public async Task<IEnumerable<WalletDTO>> GetUserWalletsAsync(Guid userId)
@@ -338,7 +338,7 @@ public class WalletService : IWalletService
                  CurrenciesConstant.Toman
             );
             var irrResult = await _walletRepository.CreateWalletAsync(irrWallet);
-            wallets.Add(_walletMapper.Map(irrWallet));
+            wallets.Add(_walletMapper.MapRequired(irrWallet));
 
 
             var mauaWallet = WalletEntity.Create
@@ -347,7 +347,7 @@ public class WalletService : IWalletService
                  CurrenciesConstant.Maua
             );
             var mauaResult = await _walletRepository.CreateWalletAsync(mauaWallet);
-            wallets.Add(_walletMapper.Map(mauaWallet));
+            wallets.Add(_walletMapper.MapRequired(mauaWallet));
 
 
             var creditMauaWallet = WalletEntity.Create
@@ -356,7 +356,7 @@ public class WalletService : IWalletService
                  CurrenciesConstant.Credit_MAUA
             );
             var creditMauaResult = await _walletRepository.CreateWalletAsync(creditMauaWallet);
-            wallets.Add(_walletMapper.Map(creditMauaWallet));
+            wallets.Add(_walletMapper.MapRequired(creditMauaWallet));
 
             return wallets;
         }

--- a/src/Wallet/Wallet.Core/IWalletRepository.cs
+++ b/src/Wallet/Wallet.Core/IWalletRepository.cs
@@ -1,4 +1,4 @@
-namespace Wallet.Core;
+﻿namespace Wallet.Core;
 
 public interface IWalletRepository
 {
@@ -6,7 +6,7 @@ public interface IWalletRepository
     Task<WalletEntity?> GetWalletAsync(Guid userId, string asset);
     Task<IEnumerable<WalletEntity>> GetUserWalletsAsync(Guid userId);
     Task<WalletEntity> CreateWalletAsync(WalletEntity wallet);
-    Task<WalletEntity> UpdateWalletAsync(WalletEntity wallet,Transaction transaction= null);
+    Task<WalletEntity> UpdateWalletAsync(WalletEntity wallet, Transaction? transaction = null);
     Task<WalletEntity> LockBalanceAsync(Guid userId, string asset, decimal amount);
     Task<WalletEntity> UnlockBalanceAsync(Guid userId, string asset, decimal amount);
     

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -78,7 +78,7 @@ public class WalletRepository : IWalletRepository
             throw;
         }
     }
-    public async Task<WalletEntity> UpdateWalletAsync(WalletEntity wallet, Transaction transaction = null)
+    public async Task<WalletEntity> UpdateWalletAsync(WalletEntity wallet, Transaction? transaction = null)
     {
         if (wallet == null)
         {


### PR DESCRIPTION
## Description

**The warning count is zero.** `TreatWarningsAsErrors` is on, so it stays there.

```
168  ──────────────────────────────────────────────────────►  0
```

## Type of Change
- [x] Hotfix (urgent bug fix)
- [x] Refactor (code organization, no behavior change)

## Two clusters accounted for eleven

**Six sites, one cause.** Every service flattened its configuration into a `Dictionary<string, string>` and handed it to `AddInMemoryCollection`, which wants `string?` values. The code already filtered nulls out and then wrote `pair.Value!` to get past the mismatch. The dictionary is `string?` now, and the null-forgiving operator is gone with it.

**Five more, another.** `TelegramLoggerService` read `Assembly.GetEntryAssembly()?.GetName().Version` and then `version.Major` in five separate methods. One `VersionSuffix`, computed once, replaces all five — and it handles the null case those five ignored, which is a test host, where `GetEntryAssembly` is the runner rather than the bot.

## The mappers were the interesting ones

`IMapper` declared `TDto Map(TEntity entity)` while **both** implementations opened with:

```csharp
if (entity == null) return null;
```

The signature said one thing and the body did another. Making it `TDto? Map(TEntity?)` **raised the count from 16 to 21** rather than lowering it — the honest contract exposed nine call sites that had been using a possibly-null result unchecked.

All nine turned out to be places where the entity was already known to exist: just created, or past a not-found guard. They call `MapRequired` now, which maps and throws if the mapper returns null anyway — because at those sites a null would mean the mapper broke its own contract, not that anything was missing. `MapList` filters with `OfType` instead of carrying holes.

## The rest, one at a time

| Site | What it was |
|---|---|
| `CurrenciesConstant.GetCurrencyInfo` | now returns `CurrencyInfo?`, which is what its body always did |
| `BotHandlerAdmin` | looked up a `CurrencyInfo` only to read `.Unit` and `.PersianName`; `PersianFormat.Unit` and `PersianFormat.Asset` already do that safely. It also read `result.Data.BalanceAfter` behind a `Success` check, which does not promise a payload |
| `UserRepository` | searched on `u.FirstName.Contains(q)` across three nullable columns. EF translates the null check into SQL, so nothing changes at the database; it stops being a lie in memory |
| `TelegramBotHostedService` | dereferenced `update.CallbackQuery.Message`, absent for an inline callback or one older than 48 hours — the same defect fixed inside `BotHandler` in #137, reaching through it **before** the handler's guard could run |
| `EscapeMarkdownV2` | takes `string?`, which its first line already handled |
| `TestBotToken` | deserialised `getMe`'s body as `dynamic` and read `.ok` without checking. A 2xx that does not parse means something other than Telegram answered — a proxy or a captive portal — and treating that as a valid token starts the bot against it |

Plus, from the first commit: 13 uninitialised string properties, 2 null checks on non-nullable decimals (one of them dead validation, already enforced twice over elsewhere), 3 `null` defaults on non-nullable parameters, 1 interface/implementation nullability mismatch, the obsolete `ISystemClock` base constructor, and 3 EF migration classes named in lower case.

## The lock

```xml
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
```

The nullable family is included, which it could not be while 74 of them were outstanding. **Every one was resolved by making a signature honest or by handling the null, never by `!`.** If a future fix needs that operator, the fix is wrong.

**Verified rather than assumed.** A probe method dereferencing a possibly-null string was added to `Orders.Application`:

```
OrderService.cs(528,49): error CS8602: Dereference of a possibly null reference.
    1 Error(s)
```

The probe was then removed. The migration renames were verified the same way — `dotnet ef migrations list` still reports `20250918224949_init` as applied, not pending, because a migration is identified by its `[Migration]` attribute and not by its class name.

## Testing Completed

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 0 warnings
dotnet test  TallaEgg.sln -c Release --no-build   →  486/486 passed
```

## Deployment / Rollback

No migrations, no configuration, no data change. Rollback is a revert of the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)