### PR TITLE
fix: stop showing .NET exception text to customers, and log what was being swallowed

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -748,6 +748,7 @@ namespace TallaEgg.TelegramBot
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Unexpected error while cancelling a user's active orders.");
                 return new CancelOrdersResult
                 {
                     HasError = true,

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
@@ -57,22 +57,22 @@ public class AffiliateApiClient : IAffiliateApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Affiliate API request timed out while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"پاسخ‌گویی سرویس افیلیت زمان‌بر شد: {ex.Message}");
+            return (false, "پاسخ‌گویی سرویس افیلیت زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Affiliate API communication error while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای ارتباط با سرویس افیلیت: {ex.Message}");
+            return (false, "خطای ارتباط با سرویس افیلیت");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Affiliate API returned invalid JSON while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"ساختار پاسخ سرویس افیلیت نامعتبر است: {ex.Message}");
+            return (false, "ساختار پاسخ سرویس افیلیت نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای غیرمنتظره: {ex.Message}");
+            return (false, "خطای غیرمنتظره");
         }
     }
     public async Task<(bool success, string message, Guid? invitationId)> UseInvitationAsync(string invitationCode, Guid usedByUserId)
@@ -116,22 +116,22 @@ public class AffiliateApiClient : IAffiliateApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Affiliate API request timed out while consuming invitation code {InvitationCode}", invitationCode);
-            return (false, $"پاسخ‌گویی سرویس افیلیت زمان‌بر شد: {ex.Message}", null);
+            return (false, "پاسخ‌گویی سرویس افیلیت زمان‌بر شد", null);
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Affiliate API communication error while consuming invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای ارتباط با سرویس افیلیت: {ex.Message}", null);
+            return (false, "خطای ارتباط با سرویس افیلیت", null);
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Affiliate API returned invalid JSON while consuming invitation code {InvitationCode}", invitationCode);
-            return (false, $"ساختار پاسخ سرویس افیلیت نامعتبر است: {ex.Message}", null);
+            return (false, "ساختار پاسخ سرویس افیلیت نامعتبر است", null);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while consuming invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای غیرمنتظره: {ex.Message}", null);
+            return (false, "خطای غیرمنتظره", null);
         }
     }
 
@@ -195,8 +195,9 @@ public class AffiliateApiClient : IAffiliateApiClient
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Unexpected error while updating a user's phone number.");
             // Log exception here if needed
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -83,22 +83,22 @@ public class OrderApiClient : IOrderApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Order API request timed out for user {UserId}", userId);
-            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail("پاسخ‌گویی سرویس سفارشات زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Order API communication error for user {UserId}", userId);
-            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail("خطای ارتباط با سرویس سفارشات");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Order API returned invalid JSON for user {UserId}", userId);
-            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail("ساختار پاسخ سرویس سفارشات نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching orders for user {UserId}", userId);
-            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<PagedResult<OrderHistoryDto>>.Fail("خطای غیرمنتظره");
         }
     }
     public async Task<ApiResponse<PagedResult<TradeHistoryDto>>> GetUserTradesAsync(
@@ -133,22 +133,22 @@ public class OrderApiClient : IOrderApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Order API request timed out while fetching trades for user {UserId}", userId);
-            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail("پاسخ‌گویی سرویس سفارشات زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Order API communication error while fetching trades for user {UserId}", userId);
-            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail("خطای ارتباط با سرویس سفارشات");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Order API returned invalid JSON while fetching trades for user {UserId}", userId);
-            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail("ساختار پاسخ سرویس سفارشات نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching trades for user {UserId}", userId);
-            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<PagedResult<TradeHistoryDto>>.Fail("خطای غیرمنتظره");
         }
     }
     public async Task<ApiResponse<List<OrderHistoryDto>>> GetUserActiveOrdersAsync(Guid userId)
@@ -180,22 +180,22 @@ public class OrderApiClient : IOrderApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Order API request timed out while fetching active orders for user {UserId}", userId);
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("پاسخ‌گویی سرویس سفارشات زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Order API communication error while fetching active orders for user {UserId}", userId);
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("خطای ارتباط با سرویس سفارشات");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Order API returned invalid JSON while fetching active orders for user {UserId}", userId);
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("ساختار پاسخ سرویس سفارشات نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching active orders for user {UserId}", userId);
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("خطای غیرمنتظره");
         }
     }
     public async Task<ApiResponse<List<OrderHistoryDto>>> GetAllActiveOrdersAsync()
@@ -225,22 +225,22 @@ public class OrderApiClient : IOrderApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Order API request timed out while fetching all active orders");
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("پاسخ‌گویی سرویس سفارشات زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Order API communication error while fetching all active orders");
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("خطای ارتباط با سرویس سفارشات");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Order API returned invalid JSON while fetching all active orders");
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("ساختار پاسخ سرویس سفارشات نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching all active orders");
-            return ApiResponse<List<OrderHistoryDto>>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<List<OrderHistoryDto>>.Fail("خطای غیرمنتظره");
         }
     }
 
@@ -387,8 +387,9 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Unexpected error while fetching the best prices.");
             // Catch-all for any other unexpected exceptions
-            return TallaEgg.Core.DTOs.ApiResponse<BestPricesDto>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<BestPricesDto>.Fail("خطای غیرمنتظره");
         }
         finally
         {
@@ -411,7 +412,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while submitting an order.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -442,7 +444,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while publishing a quote.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -485,7 +488,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while updating the auto-quote spread.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -507,7 +511,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while switching auto-quote on or off.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -549,7 +554,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while switching a symbol on or off.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -636,7 +642,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while accepting a quote.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -673,7 +680,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while cancelling an order.");
+            return (false, "خطا در ارتباط با سرور");
         }
     }
 
@@ -716,7 +724,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرور: {ex.Message}", 0);
+            _logger.LogError(ex, "Unexpected error while cancelling a user's active orders.");
+            return (false, "خطا در ارتباط با سرور", 0);
         }
     }
 
@@ -740,7 +749,8 @@ public class OrderApiClient : IOrderApiClient
         }
         catch (Exception ex)
         {
-            return ApiResponse<bool>.Fail($"خطا در ارتباط با سرور: {ex.Message}");
+            _logger.LogError(ex, "Unexpected error while notifying the matching engine.");
+            return ApiResponse<bool>.Fail("خطا در ارتباط با سرور");
         }
     }
 
@@ -773,22 +783,22 @@ public class OrderApiClient : IOrderApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Order API request timed out while fetching positions for user {UserId}", userId);
-            return ApiResponse<PositionsResponseDto>.Fail($"پاسخ‌گویی سرویس سفارشات زمان‌بر شد: {ex.Message}");
+            return ApiResponse<PositionsResponseDto>.Fail("پاسخ‌گویی سرویس سفارشات زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Order API communication error while fetching positions for user {UserId}", userId);
-            return ApiResponse<PositionsResponseDto>.Fail($"خطای ارتباط با سرویس سفارشات: {ex.Message}");
+            return ApiResponse<PositionsResponseDto>.Fail("خطای ارتباط با سرویس سفارشات");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Order API returned invalid JSON while fetching positions for user {UserId}", userId);
-            return ApiResponse<PositionsResponseDto>.Fail($"ساختار پاسخ سرویس سفارشات نامعتبر است: {ex.Message}");
+            return ApiResponse<PositionsResponseDto>.Fail("ساختار پاسخ سرویس سفارشات نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching positions for user {UserId}", userId);
-            return ApiResponse<PositionsResponseDto>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<PositionsResponseDto>.Fail("خطای غیرمنتظره");
         }
     }
 }

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.Enums.User;
@@ -356,7 +356,7 @@ public sealed class Simulation(
 
     private void RecordError(string action, Exception ex)
     {
-        var line = $"{action}: {ex.Message}";
+        var line = $"{action}";
         _errors.Add(line);
         logger.LogWarning(ex, "Simulation step failed: {Action}", action);
     }

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -237,7 +237,7 @@ public class OrderMatchingRepository
             await transaction.RollbackAsync();
             await DiscardUnpersistedChangesAsync(buyOrder, sellOrder);
             _logger.LogError(ex, "Error in atomic order matching");
-            return (false, null, $"خطا در تطبیق سفارشات: {ex.Message}");
+            return (false, null, "خطا در تطبیق سفارشات");
         }
     }
 

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -97,22 +97,22 @@ public class UsersApiClient : IUsersApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Users API request timed out while fetching users");
-            return ApiResponse<PagedResult<UserDto>>.Fail($"پاسخ‌گویی سرویس کاربران زمان‌بر شد: {ex.Message}");
+            return ApiResponse<PagedResult<UserDto>>.Fail("پاسخ‌گویی سرویس کاربران زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Users API communication error while fetching users");
-            return ApiResponse<PagedResult<UserDto>>.Fail($"خطای ارتباط با سرویس کاربران: {ex.Message}");
+            return ApiResponse<PagedResult<UserDto>>.Fail("خطای ارتباط با سرویس کاربران");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Users API returned invalid JSON while fetching users");
-            return ApiResponse<PagedResult<UserDto>>.Fail($"ساختار پاسخ سرویس کاربران نامعتبر است: {ex.Message}");
+            return ApiResponse<PagedResult<UserDto>>.Fail("ساختار پاسخ سرویس کاربران نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while fetching users");
-            return ApiResponse<PagedResult<UserDto>>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return ApiResponse<PagedResult<UserDto>>.Fail("خطای غیرمنتظره");
         }
     }
     public async Task<(bool isValid, string message)> ValidateInvitationCodeAsync(string invitationCode)
@@ -146,22 +146,22 @@ public class UsersApiClient : IUsersApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Users API request timed out while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"پاسخ‌گویی سرویس کاربران زمان‌بر شد: {ex.Message}");
+            return (false, "پاسخ‌گویی سرویس کاربران زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Users API communication error while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای ارتباط با سرویس کاربران: {ex.Message}");
+            return (false, "خطای ارتباط با سرویس کاربران");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Users API returned invalid JSON while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"ساختار پاسخ سرویس کاربران نامعتبر است: {ex.Message}");
+            return (false, "ساختار پاسخ سرویس کاربران نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while validating invitation code {InvitationCode}", invitationCode);
-            return (false, $"خطای غیرمنتظره: {ex.Message}");
+            return (false, "خطای غیرمنتظره");
         }
     }
     public async Task<(bool success, string message, Guid? userId)> RegisterUserAsync(long telegramId, string invitationCode, string? username, string? firstName, string? lastName)
@@ -212,22 +212,22 @@ public class UsersApiClient : IUsersApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Users API request timed out while registering user {TelegramId}", telegramId);
-            return (false, $"پاسخ‌گویی سرویس کاربران زمان‌بر شد: {ex.Message}", null);
+            return (false, "پاسخ‌گویی سرویس کاربران زمان‌بر شد", null);
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Users API communication error while registering user {TelegramId}", telegramId);
-            return (false, $"خطای ارتباط با سرویس کاربران: {ex.Message}", null);
+            return (false, "خطای ارتباط با سرویس کاربران", null);
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Users API returned invalid JSON while registering user {TelegramId}", telegramId);
-            return (false, $"ساختار پاسخ سرویس کاربران نامعتبر است: {ex.Message}", null);
+            return (false, "ساختار پاسخ سرویس کاربران نامعتبر است", null);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while registering user {TelegramId}", telegramId);
-            return (false, $"خطای غیرمنتظره: {ex.Message}", null);
+            return (false, "خطای غیرمنتظره", null);
         }
     }
     public async Task<UserDto?> GetUserAsync(long telegramId)
@@ -349,22 +349,22 @@ public class UsersApiClient : IUsersApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Users API request timed out while updating phone for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"پاسخ‌گویی سرویس کاربران زمان‌بر شد: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("پاسخ‌گویی سرویس کاربران زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Users API communication error while updating phone for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"خطای ارتباط با سرویس کاربران: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("خطای ارتباط با سرویس کاربران");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Users API returned invalid JSON while updating phone for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"ساختار پاسخ سرویس کاربران نامعتبر است: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("ساختار پاسخ سرویس کاربران نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while updating phone for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("خطای غیرمنتظره");
         }
     }
     public async Task<TallaEgg.Core.DTOs.ApiResponse<UserDto>> UpdateUserStatusAsync(long telegramId, TallaEgg.Core.Enums.User.UserStatus newStatus)
@@ -402,22 +402,22 @@ public class UsersApiClient : IUsersApiClient
         catch (TaskCanceledException ex)
         {
             _logger.LogError(ex, "Users API request timed out while updating user status for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"پاسخ‌گویی سرویس کاربران زمان‌بر شد: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("پاسخ‌گویی سرویس کاربران زمان‌بر شد");
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Users API communication error while updating user status for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"خطای ارتباط با سرویس کاربران: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("خطای ارتباط با سرویس کاربران");
         }
         catch (System.Text.Json.JsonException ex)
         {
             _logger.LogError(ex, "Users API returned invalid JSON while updating user status for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"ساختار پاسخ سرویس کاربران نامعتبر است: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("ساختار پاسخ سرویس کاربران نامعتبر است");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while updating user status for TelegramId {TelegramId}", telegramId);
-            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail($"خطای غیرمنتظره: {ex.Message}");
+            return TallaEgg.Core.DTOs.ApiResponse<UserDto>.Fail("خطای غیرمنتظره");
         }
     }
     /// <summary>

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -116,7 +116,7 @@ public class WalletApiClient : IWalletApiClient
         {
             _logger.LogError(ex, "Error locking balance for user {UserId}, asset {Asset}, amount {Amount}",
                 userId, asset, amount);
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}", null);
+            return (false, "خطا در ارتباط با سرویس کیف پول", null);
         }
     }
 
@@ -163,7 +163,7 @@ public class WalletApiClient : IWalletApiClient
         {
             _logger.LogError(ex, "Error unlocking balance for user {UserId}, asset {Asset}, amount {Amount}",
                 userId, asset, amount);
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}");
+            return (false, "خطا در ارتباط با سرویس کیف پول");
         }
     }
 
@@ -205,7 +205,7 @@ public class WalletApiClient : IWalletApiClient
         {
             _logger.LogError(ex, "Error increase balance for user {UserId}, asset {Asset}, amount {Amount}",
                 userId, asset, amount);
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}");
+            return (false, "خطا در ارتباط با سرویس کیف پول");
         }
     }
 
@@ -239,7 +239,7 @@ public class WalletApiClient : IWalletApiClient
         {
             _logger.LogError(ex, "Error validating balance for user {UserId}, asset {Asset}, amount {Amount}",
                 userId, asset, valume);
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}", false);
+            return (false, "خطا در ارتباط با سرویس کیف پول", false);
         }
     }
     /// <summary>
@@ -298,7 +298,8 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}", false, false);
+            _logger?.LogError(ex, "Unexpected error while validating a balance.");
+            return (false, "خطا در ارتباط با سرویس کیف پول", false, false);
         }
     }
 
@@ -467,8 +468,9 @@ public class WalletApiClient : IWalletApiClient
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "Unexpected error while fetching a balance.");
             // Catch-all for any other unexpected exceptions
-            return (false, $"خطای غیرمنتظره در ارتباط با سرور: {ex.Message}", null);
+            return (false, "خطای غیرمنتظره در ارتباط با سرور", null);
         }
         finally
         {
@@ -583,7 +585,7 @@ public class WalletApiClient : IWalletApiClient
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error settling trade {TradeId} against the wallet service.", trade.Id);
-            return (false, $"خطا در ارتباط با سرویس کیف پول: {ex.Message}");
+            return (false, "خطا در ارتباط با سرویس کیف پول");
         }
     }
 

--- a/src/User/Users.Infrastructure/UserRepository.cs
+++ b/src/User/Users.Infrastructure/UserRepository.cs
@@ -111,23 +111,26 @@ public class UserRepository : IUserRepository
             .ToListAsync();
     }
 
+    // Both select a nullable Guid on purpose. Selecting `u.Id` and calling FirstOrDefaultAsync
+    // yields Guid.Empty when nothing matches, not null — and every caller tests the result with
+    // `if (id != null)`, so an unknown code came back looking like a user whose id is all zeroes.
     public async Task<Guid?> GetUserIdByInvitationCodeAsync(string invitationCode)
     {
-        return await _context.Users.Where(u => u.InvitationCode == invitationCode).Select(u => u.Id)
+        return await _context.Users
+            .Where(u => u.InvitationCode == invitationCode)
+            .Select(u => (Guid?)u.Id)
             .FirstOrDefaultAsync();
     }
 
+    // FirstAsync throws when there is no match, and the catch that used to wrap this turned that
+    // into null — which also turned a database failure into "no such phone number". FirstOrDefault
+    // asks the question without raising anything, so a real fault is free to surface.
     public async Task<Guid?> GetUserIdByPhonenumberAsync(string phoneNumber)
     {
-        try
-        {
-            return await _context.Users.Where(u => u.PhoneNumber == phoneNumber).Select(u => u.Id)
-            .FirstAsync();
-        }
-        catch (Exception)
-        {
-            return null;
-        }
+        return await _context.Users
+            .Where(u => u.PhoneNumber == phoneNumber)
+            .Select(u => (Guid?)u.Id)
+            .FirstOrDefaultAsync();
     }
 
     Task<Invitation?> IUserRepository.GetInvitationByCodeAsync(string invitationCode)

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -362,7 +362,7 @@ public class WalletService : IWalletService
         }
         catch (Exception ex)
         {
-            throw new Exception($"خطا در ایجاد کیف پول‌های پیش‌فرض: {ex.Message}");
+            throw new InvalidOperationException("خطا در ایجاد کیف پول‌های پیش‌فرض", ex);
         }
     }
 

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -424,7 +424,7 @@ public class WalletRepository : IWalletRepository
         {
             await tx.RollbackAsync();
             _logger.LogError(ex, "Error settling trade {TradeId}", tradeId);
-            return (false, $"Settlement error: {ex.Message}");
+            return (false, "Settlement error");
         }
     }
 

--- a/tests/TallaEgg.AllServices.Tests/MatchFailureRecoveryTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/MatchFailureRecoveryTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orders.Core;
@@ -90,7 +90,14 @@ public class MatchFailureRecoveryTests : IDisposable
 
             Assert.False(success, "a failed save must not be reported as a successful match");
             Assert.Null(trade);
-            Assert.Contains("simulated save failure", error);
+
+            // The message goes to the customer: QuoteFillService returns this very string from
+            // AcceptQuoteAsync, and the bot shows it. So it must be the stable Persian sentence and
+            // must not carry the exception's own text — a customer accepting a quote during a
+            // database fault used to be shown the .NET message appended to it. The detail is not
+            // lost: ExecuteAtomicMatchAsync logs the exception before returning.
+            Assert.Equal("خطا در تطبیق سفارشات", error);
+            Assert.DoesNotContain("simulated save failure", error);
 
             // The whole point: these are the exact objects a caller (QuoteFillService) still
             // holds after the failure. If they show the mutation step 6 applied in memory


### PR DESCRIPTION
## Description

The instruction was to go at the 170 `catch (Exception)` blocks. **Counting them first changed what the work turned out to be.**

| | |
|---|---|
| `catch (Exception)` blocks remaining after earlier changes | **137** |
| of those, already log or rethrow | **110** |
| genuinely wrong | **the two classes below** |

A client that turns a network failure into a result rather than throwing at its caller is doing the right thing. Removing those would make the code worse, so they stay.

## 1. Seventy places put a .NET diagnostic in front of a customer

```csharp
return (false, $"خطا در ارتباط با سرور: {ex.Message}");
```

The Persian half is fine and specific — the affiliate service timed out, the response was malformed. **The half after the colon is a .NET diagnostic**, so a customer could be shown `The SSL connection could not be established` in the middle of a Persian sentence.

This is the client-side twin of what #140 fixed on the server. Gone across `OrderApiClient` (30), `UsersApiClient` (20), `AffiliateApiClient` (9), `WalletApiClient` (7) and four others.

## 2. Fourteen handlers then had nothing left of the failure

With the exception text no longer in the returned message, those handlers discarded it entirely. They log it now.

**`TreatWarningsAsErrors` from #141 found three of them for me.** Stripping `ex.Message` left `ex` unused, which is `CS0168`, which is now an error, which broke the build until the log call went in.

## Two repository defects found in the same sweep

```csharp
public async Task<Guid?> GetUserIdByPhonenumberAsync(string phoneNumber)
    => try { ... .FirstAsync(); } catch (Exception) { return null; }
```

`FirstAsync` **throws** when there is no match, so the catch was control flow for "not found" — and it read a database fault as "no such phone number" too.

Its sibling had the opposite defect: `Select(u => u.Id).FirstOrDefaultAsync()` yields `Guid.Empty` rather than `null` when nothing matches, and both callers test `if (id != null)` — so **an unknown invitation code came back looking like a user whose id is all zeroes.**

Both select `(Guid?)u.Id` now, and neither needs the exception.

`WalletService`'s default-wallet failure also rethrew without an inner exception, throwing the cause away. It carries it now.

## One test failed, and it was pinning the behaviour being removed

`MatchFailureRecoveryTests` asserted the error **contains** `"simulated save failure"`.

That string reaches a customer: `QuoteFillService` returns it from `AcceptQuoteAsync` and the bot shows it. So a database fault during a quote fill put the .NET message in front of them.

The test now asserts the opposite — the message is exactly `"خطا در تطبیق سفارشات"` and does **not** contain the exception text. The detail is not lost; `ExecuteAtomicMatchAsync` logs the exception before it returns.

## Twelve silent handlers remain, and are meant to

| Where | Why |
|---|---|
| `Simulation.cs` (9) | call `RecordError`, the simulator's own error-collection mechanism |
| `TelegramLoggerService` (2) | silent on purpose — logging the logger's own failure recurses. Both say so |
| `WalletService` (1) | wraps and rethrows |

## Testing Completed

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 0 warnings
dotnet test  TallaEgg.sln -c Release --no-build   →  486/486 passed
```

No message returned to a user carries exception text.

## Deployment / Rollback

No migrations, no configuration, no data change. What a customer sees changes only where they were previously shown text not meant for them. Rollback is a revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)