### PR TITLE
fix(orders): widen Amount, RemainingAmount and Price to (28, 8) so collateral is not stranded

### DIFF
--- a/src/Order/Orders.Infrastructure/Configurations/OrderConfigurations.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/OrderConfigurations.cs
@@ -14,9 +14,16 @@ namespace Orders.Infrastructure.Configurations
                 .IsRequired()
                 .HasMaxLength(50);
             
+            // (28, 8) to match Trades.Quantity and Wallets.Balance, which have always been that
+            // wide. At (18, 2) this column was narrower than the assets it stores: BTC's precision
+            // is 8 decimal places, so SQL Server rounded 2.111 to 2.11 on the way in. Collateral is
+            // locked from the quantity the caller supplied, and OrderCollateralReconciler recomputes
+            // the residue from the quantity that was stored — so the difference between the two was
+            // locked and never released. Gold never showed it: MAUA's precision is 2, exactly what
+            // the column held.
             builder.Property(o => o.Amount)
                 .IsRequired()
-                .HasPrecision(18, 2);
+                .HasPrecision(28, 8);
             
             // RemainingAmount is a concurrency token: every UPDATE to an order carries
             // "WHERE RemainingAmount = <the value that was read>", so a second writer whose
@@ -37,12 +44,12 @@ namespace Orders.Infrastructure.Configurations
             // TradeId made "settled exactly once" structural.
             builder.Property(o => o.RemainingAmount)
                 .IsRequired()
-                .HasPrecision(18, 2)
+                .HasPrecision(28, 8)
                 .IsConcurrencyToken();
             
             builder.Property(o => o.Price)
                 .IsRequired()
-                .HasPrecision(18, 2);
+                .HasPrecision(28, 8);
             
             builder.Property(o => o.UserId)
                 .IsRequired();

--- a/src/Order/Orders.Infrastructure/Migrations/20260827175732_WidenOrderAmountAndPriceTo28x8.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260827175732_WidenOrderAmountAndPriceTo28x8.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260827175732_WidenOrderAmountAndPriceTo28x8")]
+    partial class WidenOrderAmountAndPriceTo28x8
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260827175732_WidenOrderAmountAndPriceTo28x8.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260827175732_WidenOrderAmountAndPriceTo28x8.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenOrderAmountAndPriceTo28x8 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "RemainingAmount",
+                table: "Orders",
+                type: "decimal(28,8)",
+                precision: 28,
+                scale: 8,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price",
+                table: "Orders",
+                type: "decimal(28,8)",
+                precision: 28,
+                scale: 8,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Amount",
+                table: "Orders",
+                type: "decimal(28,8)",
+                precision: 28,
+                scale: 8,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "RemainingAmount",
+                table: "Orders",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(28,8)",
+                oldPrecision: 28,
+                oldScale: 8);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price",
+                table: "Orders",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(28,8)",
+                oldPrecision: 28,
+                oldScale: 8);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Amount",
+                table: "Orders",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(28,8)",
+                oldPrecision: 28,
+                oldScale: 8);
+        }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/OrderColumnPrecisionTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OrderColumnPrecisionTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// The Orders columns must hold at least as many decimal places as the assets they store.
+///
+/// <para>
+/// They did not. <c>Orders.Amount</c>, <c>RemainingAmount</c> and <c>Price</c> were
+/// <c>decimal(18, 2)</c> while <c>Trades.Quantity</c> and <c>Wallets.Balance</c> were
+/// <c>decimal(28, 8)</c>. Gold hid it: MAUA's precision is 2, exactly what the column held. Bitcoin
+/// exposed it — its precision is 8, so a sale of <c>2.111 BTC</c> was stored as <c>2.11</c>.
+/// </para>
+///
+/// <para>
+/// That one rounding stranded money. Collateral is locked from the quantity the caller supplied
+/// (2.111), the trade executes on the quantity that was stored (2.11), and
+/// <c>OrderCollateralReconciler</c> recomputes the residue from the stored order — so it computed
+/// <c>2.11 - 2.11 = 0</c>, released nothing, and left 0.001 BTC and its rial equivalent locked with
+/// no order holding them and no path in the product to get them back.
+/// </para>
+///
+/// <para>
+/// <b>Why a model test and not a behavioural one:</b> the tests run against SQLite, which ignores
+/// decimal scale entirely — it will happily round-trip 2.111 through a column declared
+/// <c>decimal(18, 2)</c>. No test that inserts and reads a row can fail on this, under any provider
+/// the suite can run. The scale only bites on SQL Server, in production. So the assertion is made
+/// against the configured model instead, where it holds for every provider.
+/// </para>
+/// </summary>
+public class OrderColumnPrecisionTests
+{
+    /// <summary>Columns holding a quantity or a price of a tradable asset.</summary>
+    private static readonly string[] DecimalColumns = ["Amount", "RemainingAmount", "Price"];
+
+    /// <summary>
+    /// Every one of them must have at least the scale of the most precise asset on the platform.
+    /// Adding a symbol with more decimal places than the column holds re-creates the bug, and this
+    /// is what says so.
+    /// </summary>
+    [Fact]
+    public void OrderDecimalColumns_HoldEveryTradableAssetsPrecision()
+    {
+        var required = CurrenciesConstant.AllTradingPairs.Max(p => p.BaseDecimalPlaces);
+
+        using var context = new OrdersDbContext(
+            new DbContextOptionsBuilder<OrdersDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options);
+
+        var order = context.Model.FindEntityType(typeof(Orders.Core.Order))!;
+
+        foreach (var column in DecimalColumns)
+        {
+            var scale = order.FindProperty(column)!.GetScale();
+
+            Assert.True(scale is not null && scale >= required,
+                $"Orders.{column} is configured with scale {scale?.ToString() ?? "(none)"}, but the " +
+                $"most precise tradable asset needs {required}. A quantity with more decimal places " +
+                "than the column holds is rounded on the way in, while the collateral was locked " +
+                "from the value the caller gave — and the difference is locked with nothing holding it.");
+        }
+    }
+
+    /// <summary>
+    /// And they must not be narrower than the wallet they settle against, whatever the assets
+    /// happen to need today: an order for a quantity the wallet can hold but the order cannot is
+    /// the same defect arriving from the other side.
+    /// </summary>
+    [Fact]
+    public void OrderDecimalColumns_AreNoNarrowerThanTheWalletTheySettleAgainst()
+    {
+        const int walletScale = 8;   // Wallets.Balance and LockedBalance, decimal(28, 8)
+
+        using var context = new OrdersDbContext(
+            new DbContextOptionsBuilder<OrdersDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options);
+
+        var order = context.Model.FindEntityType(typeof(Orders.Core.Order))!;
+
+        foreach (var column in DecimalColumns)
+        {
+            var scale = order.FindProperty(column)!.GetScale();
+
+            Assert.True(scale is not null && scale >= walletScale,
+                $"Orders.{column} has scale {scale?.ToString() ?? "(none)"} against the wallet's " +
+                $"{walletScale}. Money moves at the wallet's precision; an order that cannot express " +
+                "what the wallet can settle will always leave a remainder behind.");
+        }
+    }
+}


### PR DESCRIPTION
## What happened

Selling **2.111 BTC** locked collateral for 2.111 and traded 2.11. The difference stayed locked, with no order holding it and no way in the product to get it back.

```
Orders.Amount        decimal(18, 2)     ← two decimal places
Trades.Quantity      decimal(28, 8)
Wallets.Balance      decimal(28, 8)
```

**The order table was narrower than the assets it stores.**

## The chain

1. Collateral is computed from the quantity the caller supplied. `ComputeCollateral` rounds it at the asset's own precision — 8 places for BTC — so **2.111 stays 2.111** and that is what gets locked.
2. The order is persisted. SQL Server rounds to the column's scale: **2.11**.
3. Matching runs on the stored order, so the trade is for **2.11**.
4. `OrderCollateralReconciler` recomputes the residue **from the stored order**: `2.11 - 2.11 = 0`. It releases nothing.
5. **0.001 BTC and its rial equivalent stay locked for good.**

## Why nobody saw it

MAUA's precision is **2** — exactly what the column held — so every gold quantity round-tripped unchanged.

**1009 simulated MAUA trades came back clean. One manual BTC trade did not.** The defect has been there since Bitcoin was added; nothing about it is new.

## Type of Change
- [x] Hotfix (urgent bug fix)

## The fix

Widening to `(28, 8)` matches `Trades` and `Wallets`. It is a **widening conversion in both directions** — 20 integer digits against 16, 8 decimal places against 2 — so no stored value can be lost. The 2028 existing rows came through unchanged. EF's generic *"may result in the loss of data"* warning on `AlterColumn` does not apply here.

## The test asserts the model, not a round trip

`OrderColumnPrecisionTests` checks the configured scale rather than inserting a row, and that is deliberate:

> The suite runs on **SQLite, which ignores decimal scale entirely** and will happily return `2.111` from a column declared `decimal(18, 2)`. No test that writes and reads a row could ever have caught this, under any provider available here. It only bites on SQL Server.

- The first test compares the configured scale against the most precise asset in `CurrenciesConstant`, so **adding a symbol with more decimal places than the column holds fails immediately**.
- The second compares it against the wallet it settles into.

**Verified by reverting** the configuration to `(18, 2)` with the tests in place — both failed. Restored — both pass.

```
dotnet test TallaEgg.sln -c Debug   →  488/488 passed
dotnet build TallaEgg.sln           →  0 errors, 0 warnings
```

## The stranded balances on the live database

**16,048,847 IRT** and **0.001 BTC** were released through `POST /api/wallet/unlockBalance` rather than by touching rows directly, so each carries its own `UnLockBalance` transaction:

```
18:02:59  6389449308  IRT   16048847.00   -33895915158.00 → -33879866311.00
18:02:59  436507076   BTC          0.001          -2.11100 →        -2.11000
```

Every wallet still reconciles to its transaction history — 0 mismatches.

## Deployment / Rollback

**One migration** on the Orders database: `20260827175732_WidenOrderAmountAndPriceTo28x8`, applied at service startup. No configuration change, no data migration. Rollback is the `Down` method, which narrows the columns again — safe only while no order carries more than two decimal places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)