### PR TITLE
fix(wallet): LockBalance and UnLockBalance refuse a non-positive amount

### DIFF
--- a/src/Wallet/Wallet.Core/Wallet.cs
+++ b/src/Wallet/Wallet.Core/Wallet.cs
@@ -74,6 +74,14 @@ public class WalletEntity
     /// </summary>
     public void LockBalance(decimal amount)
     {
+        // A negative amount inverts both lines below: LockedBalance falls and Balance rises, so
+        // "locking" mints money. The sufficiency rule genuinely cannot live here, for the reason
+        // above — but that reasoning is about how much is available, not about which direction the
+        // arithmetic runs, and it was silently extended to cover both. IncreaseBalance,
+        // DecreaseBalance and ConsumeLockedBalance all carry this check already.
+        if (amount <= 0)
+            throw new BusinessRuleException("مقدار باید بزرگتر از صفر باشد");
+
         LockedBalance += amount;
         Balance -= amount;
         UpdatedAt = DateTime.UtcNow;
@@ -87,6 +95,13 @@ public class WalletEntity
     /// </summary>
     public void UnLockBalance(decimal amount)
     {
+        // WalletRepository.UnlockBalanceAsync refuses a negative amount, so today nothing reaches
+        // here with one. That is a guard on the path rather than on the operation: a second caller
+        // reaching the entity directly would not meet it. The invariant belongs where it cannot be
+        // walked around.
+        if (amount <= 0)
+            throw new BusinessRuleException("مقدار باید بزرگتر از صفر باشد");
+
         LockedBalance -= amount;
         Balance += amount;
         UpdatedAt = DateTime.UtcNow;

--- a/tests/TallaEgg.AllServices.Tests/WalletAmountSignTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletAmountSignTests.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using TallaEgg.Core.ErrorHandling;
+using Wallet.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Every method on <see cref="WalletEntity"/> that moves an amount must refuse a non-positive one.
+///
+/// <para>
+/// <c>LockBalance</c> did not (#122). Its two lines are <c>LockedBalance += amount</c> and
+/// <c>Balance -= amount</c>, so a negative argument runs them backwards: the reservation shrinks
+/// and the spendable balance grows. "Locking" minus a million adds a million.
+/// </para>
+///
+/// <para>
+/// The method carries a long comment explaining why the <i>sufficiency</i> rule is absent — the
+/// credit ceiling lives in a separate <c>CREDIT_</c> row this entity cannot see, so only the caller
+/// can evaluate it. That reasoning is correct and still stands. It is about <i>how much</i> is
+/// available, and it had been quietly extended to cover <i>which direction the arithmetic runs</i>,
+/// which it says nothing about. <c>IncreaseBalance</c>, <c>DecreaseBalance</c> and
+/// <c>ConsumeLockedBalance</c> had the check the whole time; only the two halves of the lock pair
+/// were missing it.
+/// </para>
+///
+/// <para>
+/// <b>Why the reflection test below matters more than the explicit ones:</b> nobody wrote the check
+/// wrongly here — a method was added without it and nothing noticed. Tests naming each method
+/// reproduce exactly that gap for the next method someone adds. The reflection test covers methods
+/// that do not exist yet, which is the only kind of coverage that would have caught this one.
+/// </para>
+/// </summary>
+public class WalletAmountSignTests
+{
+    private static WalletEntity NewWallet() =>
+        WalletEntity.Create(Guid.NewGuid(), "IRT");
+
+    // ── The specific defect ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The exact shape of #122: locking a negative amount raised the spendable balance.
+    /// </summary>
+    [Fact]
+    public void LockingANegativeAmount_DoesNotMintMoney()
+    {
+        var wallet = NewWallet();
+        wallet.IncreaseBalance(1_000m);
+
+        Assert.Throws<BusinessRuleException>(() => wallet.LockBalance(-1_000_000m));
+
+        Assert.Equal(1_000m, wallet.Balance);
+        Assert.Equal(0m, wallet.LockedBalance);
+    }
+
+    /// <summary>
+    /// The mirror operation, which was guarded in WalletRepository but not in the entity.
+    /// </summary>
+    [Fact]
+    public void UnlockingANegativeAmount_DoesNotDrainTheBalance()
+    {
+        var wallet = NewWallet();
+        wallet.IncreaseBalance(1_000m);
+        wallet.LockBalance(400m);
+
+        Assert.Throws<BusinessRuleException>(() => wallet.UnLockBalance(-1_000m));
+
+        Assert.Equal(600m, wallet.Balance);
+        Assert.Equal(400m, wallet.LockedBalance);
+    }
+
+    /// <summary>
+    /// Zero is refused too. It is not a money bug on its own, but a zero lock produces an order
+    /// with no collateral behind it — the situation the C-5 ordering exists to prevent — and it is
+    /// reachable: a sell of 0.004 MAUA rounds to 0.00 at the asset's two decimal places.
+    /// </summary>
+    [Fact]
+    public void LockingZero_IsRefusedRatherThanTreatedAsANoOp()
+    {
+        var wallet = NewWallet();
+        wallet.IncreaseBalance(1_000m);
+
+        Assert.Throws<BusinessRuleException>(() => wallet.LockBalance(0m));
+
+        Assert.Equal(1_000m, wallet.Balance);
+        Assert.Equal(0m, wallet.LockedBalance);
+    }
+
+    /// <summary>A positive lock still works exactly as before.</summary>
+    [Fact]
+    public void APositiveLock_MovesTheAmountFromBalanceToLocked()
+    {
+        var wallet = NewWallet();
+        wallet.IncreaseBalance(1_000m);
+
+        wallet.LockBalance(250m);
+
+        Assert.Equal(750m, wallet.Balance);
+        Assert.Equal(250m, wallet.LockedBalance);
+    }
+
+    // ── The one that covers methods nobody has written yet ──────────────────────
+
+    /// <summary>
+    /// Fails naming any public method taking a single <see cref="decimal"/> amount that accepts a
+    /// negative or zero value.
+    ///
+    /// <para>
+    /// Reflection rather than a list of names on purpose. A list is a copy of what exists today,
+    /// and #122 was not a method with a wrong check — it was a method with no check that no list
+    /// happened to mention.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData(-1_000_000)]
+    [InlineData(0)]
+    public void EveryAmountTakingMethod_RefusesANonPositiveAmount(decimal badAmount)
+    {
+        var methods = typeof(WalletEntity)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName)
+            .Where(m =>
+            {
+                var parameters = m.GetParameters();
+                return parameters.Length == 1 && parameters[0].ParameterType == typeof(decimal);
+            })
+            .ToList();
+
+        Assert.NotEmpty(methods);
+
+        var accepted = new List<string>();
+
+        foreach (var method in methods)
+        {
+            // Funded well past the bad amount, so nothing is refused for lack of balance and the
+            // only reason to throw is the sign.
+            var wallet = NewWallet();
+            wallet.IncreaseBalance(10_000_000m);
+            wallet.LockBalance(5_000_000m);
+
+            try
+            {
+                method.Invoke(wallet, new object[] { badAmount });
+                accepted.Add(method.Name);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is BusinessRuleException)
+            {
+                // Refused, which is the point.
+            }
+        }
+
+        Assert.True(accepted.Count == 0,
+            $"These WalletEntity methods accepted an amount of {badAmount}, which lets a caller " +
+            "move money in the wrong direction or record a no-op reservation:" + Environment.NewLine +
+            string.Join(Environment.NewLine, accepted.Select(n => "  WalletEntity." + n)) +
+            Environment.NewLine +
+            "Add `if (amount <= 0) throw new BusinessRuleException(...)` as the first statement.");
+    }
+}


### PR DESCRIPTION
Closes #122.

## The defect

`LockBalance` was two statements with nothing in front of them:

```csharp
public void LockBalance(decimal amount)
{
    LockedBalance += amount;
    Balance -= amount;
}
```

A negative argument runs both backwards:

| | with `amount = -1,000,000` |
|---|---|
| `LockedBalance += amount` | reservation **falls** by 1,000,000 |
| `Balance -= amount` | spendable balance **rises** by 1,000,000 |

"Locking" minus a million adds a million. `POST /api/wallet/lockBalance` passes `request.Amount` through untouched, and in Development that endpoint has no authentication at all.

## Why it survived review

The comment above the method explains — correctly, and at length — why the *sufficiency* rule cannot live in this entity: the credit ceiling is a separate `CREDIT_` wallet row that a single-asset entity cannot read, so only the caller can evaluate it.

That reasoning is about **how much is available**. It says nothing about **which direction the arithmetic runs**, and it had been quietly extended to cover both. `IncreaseBalance`, `DecreaseBalance` and `ConsumeLockedBalance` all carried the sign check the whole time; only the two halves of the lock pair were missing it.

## Changes

- **`LockBalance`** rejects `amount <= 0`.
- **`UnLockBalance`** gets the same guard. `WalletRepository.UnlockBalanceAsync` already refused a negative amount, so nothing reaches the entity with one today — but that is a guard on the *path*, not on the *operation*, and a second caller reaching the entity directly would not meet it.

## Checking the callers first turned up why zero matters

`ComputeCollateral` rounds a sell's quantity with `RoundToCurrencyPrecision`, which rounds **to nearest**. At MAUA's two decimal places a sell of **0.004 grams becomes 0.00**. That order was then created and confirmed with **no collateral behind it** — the exact situation the C-5 ordering exists to prevent. Refusing the lock turns it into a rejected order instead.

The reason 0.004 can be submitted at all is that `MinQuantity` and `MinNotional` are configured on every trading pair and **enforced nowhere**. Filed separately — it needs a message written for the customer, not the generic one this guard produces.

## The test that matters

Not the four explicit ones. **The reflection one.**

Nobody wrote this check wrongly — a method was added without it and nothing noticed. A test naming each method reproduces exactly that gap for the next method someone adds.

`EveryAmountTakingMethod_RefusesANonPositiveAmount` walks `WalletEntity`'s public single-`decimal` methods, funds a wallet well past the bad amount so the only possible reason to throw is the sign, and fails naming any that accept it.

**Verified by removing the new guard:**

```
These WalletEntity methods accepted an amount of -1000000, which lets a caller move money
in the wrong direction or record a no-op reservation:
  WalletEntity.LockBalance
```

It named the method for both `-1,000,000` and `0`, then passed again once the guard was restored.

## Testing

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 0 warnings
dotnet test  TallaEgg.sln -c Release --no-build   →  494/494 passed  (was 488)
```

## Deployment / Rollback

No migrations, no configuration, no data change. A caller that was previously passing zero or a negative amount now gets a `BusinessRuleException`; no such caller exists in the repository — all three upstream call sites already guard `> 0` or compute a strictly positive amount. Rollback is a revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)