### PR TITLE
feat(orders): enforce the size limits every trading pair already declares (#150)

### DIFF
--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -12,6 +12,7 @@ using TallaEgg.Core.Responses.Order;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
 using TallaEgg.Core.ErrorHandling;
+using TallaEgg.Core.Utilties;
 
 namespace Orders.Application;
 
@@ -94,6 +95,8 @@ public class OrderService
                 throw new BusinessRuleException("قیمت باید بزرگ‌تر از صفر باشد");
 
             request.Price = CurrenciesConstant.RoundOrderPrice(request.Price);
+
+            ValidateTradingLimits(request.Symbol, request.Quantity, request.Price);
 
             var (_, amountToCheck) = ComputeCollateral(request.Symbol, orderSide, request.Quantity, request.Price);
 
@@ -200,6 +203,48 @@ public class OrderService
     /// CeilingToCurrencyPrecision). The sell side needs no rounding, since its collateral is the
     /// order quantity itself.
     /// </summary>
+    /// <summary>
+    /// Enforces the symbol's own size limits. Every trading pair has carried
+    /// <c>MinQuantity</c>, <c>MaxQuantity</c> and <c>MinNotional</c> since the pair table was
+    /// written, and until now nothing read them — the only order-size rule in the product was
+    /// <c>Quantity &gt; 0</c> at the endpoint. Configured limits that are never applied are worse
+    /// than none, because the next reader takes them for protection that exists.
+    ///
+    /// <para>
+    /// Here rather than in the endpoint, on purpose. The endpoint is one caller; this is the one
+    /// path every order takes. #122 was the same lesson — a guard belongs where the rule lives,
+    /// not where one of today's callers happens to sit.
+    /// </para>
+    ///
+    /// <para>
+    /// A symbol with no entry in the pair table is left alone. <c>CreateOrderAsync</c> already
+    /// fails later for a genuinely unknown asset, and refusing here would report an unfamiliar
+    /// symbol as a size problem.
+    /// </para>
+    /// </summary>
+    private static void ValidateTradingLimits(string symbol, decimal quantity, decimal price)
+    {
+        var pair = CurrenciesConstant.GetTradingPairInfo(symbol);
+        if (pair is null) return;
+
+        if (pair.MinQuantity > 0 && quantity < pair.MinQuantity)
+            throw new BusinessRuleException(
+                $"مقدار سفارش نمی‌تواند کمتر از {PersianFormat.Number(pair.MinQuantity, 8).TrimEnd('۰').TrimEnd('٫')} " +
+                $"{pair.BaseUnit} باشد.");
+
+        if (pair.MaxQuantity > 0 && quantity > pair.MaxQuantity)
+            throw new BusinessRuleException(
+                $"مقدار سفارش نمی‌تواند بیشتر از {PersianFormat.Number(pair.MaxQuantity, 8).TrimEnd('۰').TrimEnd('٫')} " +
+                $"{pair.BaseUnit} باشد.");
+
+        // Notional is what the order is worth, which is the limit that actually matters: a
+        // quantity above MinQuantity can still be worth less than the cost of settling it.
+        if (pair.MinNotional > 0 && quantity * price < pair.MinNotional)
+            throw new BusinessRuleException(
+                $"ارزش سفارش نمی‌تواند کمتر از {PersianFormat.Amount(pair.MinNotional, pair.QuoteAsset)} " +
+                $"{PersianFormat.Unit(pair.QuoteAsset)} باشد.");
+    }
+
     private static (string Asset, decimal Amount) ComputeCollateral(
         string symbol, OrderSide side, decimal quantity, decimal price)
     {

--- a/tests/TallaEgg.AllServices.Tests/TradingLimitTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/TradingLimitTests.cs
@@ -1,0 +1,195 @@
+using System.Reflection;
+using TallaEgg.Core;
+using TallaEgg.Core.ErrorHandling;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// A symbol's size limits have to be enforced, not merely configured.
+///
+/// <para>
+/// Every trading pair has carried <c>MinQuantity</c>, <c>MaxQuantity</c> and <c>MinNotional</c>
+/// since the pair table was written, and the only tests that touched them checked that the values
+/// <i>load</i> correctly from configuration. Nothing checked that they <i>apply</i>, because
+/// nothing applied them: the product's whole order-size rule was <c>Quantity &gt; 0</c> at the
+/// endpoint. A customer could buy 0.00000001 BTC — worth about 160 rial — and the platform would
+/// lock collateral, create an order, settle a trade and write transaction rows for it, at the same
+/// cost as a trade a billion times larger. <c>MinNotional</c> exists to stop exactly that.
+/// </para>
+///
+/// <para>
+/// The failure mode is the one this codebase keeps hitting: configuration that reads as protection
+/// and enforces nothing. #143 was the same shape — a handler for an exception that could not be
+/// raised — and so was #150's sibling in the audit's own summary, "fixes applied at the call site
+/// rather than at the invariant".
+/// </para>
+/// </summary>
+public class TradingLimitTests
+{
+    /// <summary>
+    /// Invokes <c>OrderService.ValidateTradingLimits</c>, which is private because it is an
+    /// invariant of order creation rather than an API. Reflection keeps the test on the real
+    /// method: a reimplementation here would pass while the product did something else.
+    /// </summary>
+    private static void Validate(string symbol, decimal quantity, decimal price)
+    {
+        var method = typeof(Orders.Application.OrderService)
+            .GetMethod("ValidateTradingLimits", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        try
+        {
+            method!.Invoke(null, new object[] { symbol, quantity, price });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
+    }
+
+    private static TradingPairInfo Gold() =>
+        CurrenciesConstant.GetTradingPairInfo("MAUA/IRT")!;
+
+    // ── The three limits ────────────────────────────────────────────────────────
+
+    /// <summary>Below the symbol's minimum quantity is refused, in the customer's language.</summary>
+    [Fact]
+    public void AQuantityBelowTheMinimum_IsRefused()
+    {
+        var pair = Gold();
+        var tooSmall = pair.MinQuantity / 2m;
+
+        var ex = Assert.Throws<BusinessRuleException>(
+            () => Validate("MAUA/IRT", tooSmall, 20_000_000m));
+
+        Assert.Contains("کمتر از", ex.Message);
+        Assert.DoesNotContain("Exception", ex.Message);
+    }
+
+    /// <summary>
+    /// Above the maximum is refused. This limit is a typing guard more than a risk control — the
+    /// customer who meant 1 and entered 1000.
+    /// </summary>
+    [Fact]
+    public void AQuantityAboveTheMaximum_IsRefused()
+    {
+        var pair = Gold();
+
+        var ex = Assert.Throws<BusinessRuleException>(
+            () => Validate("MAUA/IRT", pair.MaxQuantity + 1m, 20_000_000m));
+
+        Assert.Contains("بیشتر از", ex.Message);
+    }
+
+    /// <summary>
+    /// The limit that does the real work: a quantity can clear <c>MinQuantity</c> and still be
+    /// worth less than it costs to settle. Priced at 1 rial, even a large quantity of gold is
+    /// worth almost nothing, and quantity alone cannot express that.
+    /// </summary>
+    [Fact]
+    public void AnOrderWorthLessThanTheMinimumNotional_IsRefused()
+    {
+        var pair = Gold();
+
+        var ex = Assert.Throws<BusinessRuleException>(
+            () => Validate("MAUA/IRT", pair.MinQuantity, price: 1m));
+
+        Assert.Contains("ارزش سفارش", ex.Message);
+    }
+
+    /// <summary>An ordinary order passes all three.</summary>
+    [Fact]
+    public void AnOrdinaryOrder_IsAccepted()
+    {
+        Validate("MAUA/IRT", 1m, 20_000_000m);
+    }
+
+    /// <summary>
+    /// Exactly at the boundary is allowed. A limit of "at least 0.1" that refuses 0.1 is a
+    /// different limit from the one the configuration states.
+    /// </summary>
+    [Fact]
+    public void ExactlyAtTheLimits_IsAccepted()
+    {
+        var pair = Gold();
+        var priceClearingNotional = (pair.MinNotional / pair.MinQuantity) + 1m;
+
+        Validate("MAUA/IRT", pair.MinQuantity, priceClearingNotional);
+        Validate("MAUA/IRT", pair.MaxQuantity, priceClearingNotional);
+    }
+
+    /// <summary>
+    /// A symbol with no entry in the pair table is not this method's business. Order creation
+    /// already refuses a genuinely unknown asset further along, and refusing here would report an
+    /// unfamiliar symbol as a size problem.
+    /// </summary>
+    [Fact]
+    public void AnUnknownSymbol_IsLeftToTheAssetCheck()
+    {
+        Validate("NOSUCH/IRT", 0.000001m, 1m);
+    }
+
+    // ── The reason this file exists ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Every limit the pair table defines must be enforced for every pair that defines it.
+    ///
+    /// <para>
+    /// The explicit tests above all use gold. That is the shape of gap that produced #146: the
+    /// simulator traded one symbol, a thousand times, and could not have found a defect that only
+    /// appears on a symbol with different precision. This walks the table instead, so a pair added
+    /// later is covered the day it is added rather than the day someone remembers to test it.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void EveryPairsLimits_AreActuallyEnforced()
+    {
+        var unenforced = new List<string>();
+
+        foreach (var pair in CurrenciesConstant.AllTradingPairs)
+        {
+            if (pair.MinQuantity > 0)
+            {
+                var below = pair.MinQuantity / 2m;
+                if (!Refuses(pair.Symbol, below, HighEnoughPrice(pair)))
+                    unenforced.Add($"{pair.Symbol}: MinQuantity {pair.MinQuantity} accepted {below}");
+            }
+
+            if (pair.MaxQuantity > 0)
+            {
+                var above = pair.MaxQuantity + 1m;
+                if (!Refuses(pair.Symbol, above, HighEnoughPrice(pair)))
+                    unenforced.Add($"{pair.Symbol}: MaxQuantity {pair.MaxQuantity} accepted {above}");
+            }
+
+            if (pair.MinNotional > 0 && pair.MinQuantity > 0)
+            {
+                if (!Refuses(pair.Symbol, pair.MinQuantity, price: 1m))
+                    unenforced.Add($"{pair.Symbol}: MinNotional {pair.MinNotional} accepted an order worth ~{pair.MinQuantity}");
+            }
+        }
+
+        Assert.True(unenforced.Count == 0,
+            "These limits are configured but not applied, so they read as protection and give " +
+            "none:" + Environment.NewLine +
+            string.Join(Environment.NewLine, unenforced.Select(u => "  " + u)));
+    }
+
+    /// <summary>A price high enough that the notional rule cannot be what refuses an order.</summary>
+    private static decimal HighEnoughPrice(TradingPairInfo pair) =>
+        pair.MinQuantity > 0 ? (pair.MinNotional / pair.MinQuantity) + 1m : 1m;
+
+    private static bool Refuses(string symbol, decimal quantity, decimal price)
+    {
+        try
+        {
+            Validate(symbol, quantity, price);
+            return false;
+        }
+        catch (BusinessRuleException)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Every pair in the table has carried `MinQuantity`, `MaxQuantity` and `MinNotional` since it was written:

```csharp
[BTC_IRT]  = new TradingPairInfo { MinQuantity = 0.0001m, MaxQuantity = 100m,  MinNotional = 1000000m, ... }
[MAUA_IRT] = new TradingPairInfo { MinQuantity = 0.1m,    MaxQuantity = 1000m, MinNotional = 100000m,  ... }
```

**Nothing read them.** The only readers were two tests, and those assert the values *load* correctly from configuration — not that anything *applies* them. The suite was green on limits that did nothing.

The product's entire order-size rule was `Quantity > 0`, at the endpoint.

Closes #150.

## Type of Change
- [x] Feature (new capability)
- [x] Hotfix (urgent bug fix)

## What that allowed

| | |
|---|---|
| **Dust** | 0.00000001 BTC — about 160 rial. Collateral locked, order created, trade matched, settlement queued, transaction rows written on both sides, at the same cost as a trade a billion times larger. `MinNotional` exists to stop exactly this. |
| **No cap** | `MaxQuantity` of 100 BTC while 10,000 would be accepted. This limit is a typing guard — the customer who meant 1 and entered 1000. |
| **False assurance** | Someone opening the pair table, or the README section on adding a symbol, sees three configured limits and reasonably concludes the platform enforces them. |

That last one is the same shape as #143: a handler for an exception that could not be raised.

## Where the guard went

`OrderService`, next to the price check — **not** the endpoint. The endpoint is one caller; this is the path every order takes. Same lesson as #122: the guard belongs where the rule lives, not where one of today's callers happens to sit.

A symbol absent from the pair table is left alone. Order creation already refuses a genuinely unknown asset further along, and refusing here would report an unfamiliar symbol as a size problem.

Messages are Persian, through `BusinessRuleException` (#140), so they are safe to show a customer:

```
مقدار سفارش نمی‌تواند کمتر از ۰٫۱ گرم باشد.
ارزش سفارش نمی‌تواند کمتر از ۱۰۰٬۰۰۰ تومان باشد.
```

## Tests

Seven. Six cover the three limits, the **boundary** — a limit of "at least 0.1" that refuses 0.1 is a different limit from the one configured — and the unknown-symbol case.

**The seventh is the one that matters.** It walks every pair in the table and asserts each declared limit is actually refused when crossed. The other six use gold, and gold is exactly how #146 hid: the simulator traded one symbol a thousand times and could not have found a defect that only appears on a symbol with different precision. Walking the table covers a pair added later on the day it is added, not the day someone remembers to test it.

Validation is invoked through reflection so the test exercises the real private method — a reimplementation in the test would pass while the product did something else.

## Verified against history before committing

Numbers unchanged, and confirmed by the product owner.

```
Asset      below_min_qty  above_max_qty  below_min_notional  total
MAUA/IRT              0              0                   0   2026
BTC/IRT               0              0                   0      6
```

**All 2032 orders in the database clear all three limits**, including the simulator's thousand. Nothing that works today starts failing.

```
dotnet build TallaEgg.sln -c Release -t:Rebuild   →  0 errors, 0 warnings
dotnet test  TallaEgg.sln -c Release --no-build   →  501/501 passed
```

## Deployment

No migration, no configuration change, no data change. Rollback is a revert of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)