### PR TITLE
docs(audit): stop v7 from overwriting an audit run in the same month

### DIFF
--- a/docs/audit/METHODOLOGY_v7.md
+++ b/docs/audit/METHODOLOGY_v7.md
@@ -341,6 +341,12 @@ silently dropping it. Continue the ID sequence for genuinely new findings.
 
 ## Write `docs/audit/AUDIT_YYYY-MM.md` — the only deliverable
 
+**Naming, and the one way to lose an audit:** `YYYY-MM` is the month the audit runs. If a
+file with that name already exists, **never overwrite it** — an archived audit is
+evidence, and a second run in the same month is a second measurement, not a correction.
+Append a letter instead: `AUDIT_2026-08b.md`, then `c`, and so on. Check before writing,
+not after.
+
 Required sections, in this order:
 
 1. **Audit Metadata & Disclosure** — who and what performed this audit, stated plainly

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -20,6 +20,9 @@ Follow [`METHODOLOGY_v7.md`](METHODOLOGY_v7.md). It is the current methodology; 
 to the auditor rather than pasting an older prompt. It detects re-audit mode from this
 file, so keep the table below current.
 
+A second audit in a month that already has one gets a letter suffix (`AUDIT_2026-08b.md`)
+rather than replacing the file that is there. Nothing in this directory is ever overwritten.
+
 An audit should be run by someone — or something — that did not write the code. The
 agent that made a change is not independent evidence about it.
 


### PR DESCRIPTION
**Branch Name**: `fix/audit-filename-collision`
**Linked Issue/Task**: follow-up to #154

## Description

`METHODOLOGY_v7.md` (merged in #154) names its deliverable `docs/audit/AUDIT_YYYY-MM.md`
and says nothing about the case where that file already exists. An audit run today would
be named `AUDIT_2026-08.md` and would silently overwrite the August 26 re-audit — losing
the archive the methodology exists to build, on its very first use.

Found while preparing to hand v7 to another session for the next audit run.

## Type of Change

- [x] Documentation (docs/comments only)

## Changes Made

- `docs/audit/METHODOLOGY_v7.md` — a naming rule in Session 4, immediately above the
  deliverable's section list: check before writing, append a letter (`AUDIT_2026-08b.md`)
  on collision, never overwrite. A second run in the same month is a second measurement,
  not a correction to the first.
- `docs/audit/README.md` — the same rule stated where a reader of the archive will see it.

## Testing Completed

Documentation only. Verified that every relative link in the two changed files still
resolves.

## Deployment / Rollback

No runtime impact. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
