### PR TITLE
docs(audit): archive the original July audit prompt as methodology v1

### DIFF
--- a/docs/audit/METHODOLOGY_v1.md
+++ b/docs/audit/METHODOLOGY_v1.md
@@ -1,0 +1,773 @@
+# TallaEgg — Code Audit Prompt (v1)
+
+**Methodology Version:** 1 (assigned retrospectively — it carried no version when it was used)
+**Used for:** the 2026-07-08 audit — [`AUDIT_2026-07.md`](AUDIT_2026-07.md) and
+[`AUDIT_2026-07.html`](AUDIT_2026-07.html)
+**Status:** historical. Current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+Archived so the trend table in [`README.md`](README.md) means something: a score is only
+comparable to another score if you can see what was asked for. This is what was asked for in
+July, and it explains most of what that audit looks like — fifty-odd dimensions weighted
+equally, a score for every one of them, and a Persian HTML deliverable, which is why
+`AUDIT_2026-07.html` exists and why every methodology since has said "no HTML".
+
+The prompt text below is unaltered. It was originally written as three chat messages, and the
+three lines that marked where one message ended and the next began have been removed — they
+were delivery artifacts, not part of the method, and one of them fell in the middle of the
+Performance list, which is now whole again. Nothing else was corrected, reordered or tidied.
+
+---
+
+# Role
+
+You are a Principal Software Architect, Senior ASP.NET Core Engineer, and Software Quality Auditor.
+
+Your task is to perform a COMPLETE architecture and code review of my ASP.NET Core project.
+
+Do NOT just look for bugs.
+Review the project exactly like an experienced software architect performing a professional code audit before releasing a production system.
+
+---
+
+# Objective
+
+Analyze the entire solution and produce a comprehensive report including:
+
+* Architecture
+* Design Quality
+* Maintainability
+* Scalability
+* Extensibility
+* Testability
+* Debuggability
+* Readability
+* Consistency
+* Performance
+* Security
+* Code Smells
+* SOLID
+* Clean Architecture principles
+* Domain Driven Design (if applicable)
+* Dependency Injection usage
+* Error Handling
+* Logging
+* Configuration
+* API Design
+* Validation
+* Folder Structure
+* Naming
+* Async usage
+* Database layer
+* EF Core usage
+* Caching
+* Middleware
+* Background Services
+* HTTP Clients
+* DTO Mapping
+* Separation of Concerns
+* Code Duplication
+* Dead Code
+* Technical Debt
+
+---
+
+# Review Style
+
+Think like a senior reviewer at Microsoft.
+
+Be brutally honest.
+
+Do NOT try to be nice.
+
+Every criticism must explain:
+
+* Why it is a problem
+* Possible risks
+* Long-term impact
+* Recommended solution
+* Priority
+
+---
+
+# Scoring
+
+Score each section from 0 to 10.
+
+Example:
+
+Architecture ............ 8.5/10
+
+Testability ............. 6/10
+
+Maintainability ......... 9/10
+
+Debuggability ........... 5/10
+
+Performance ............. 8/10
+
+Consistency ............. 7/10
+
+Security ................ 8/10
+
+Scalability ............. 8/10
+
+Readability ............. 9/10
+
+Extensibility ........... 7/10
+
+SOLID ................... 8/10
+
+Dependency Injection .... 9/10
+
+Logging ................. 4/10
+
+Validation .............. 7/10
+
+Error Handling .......... 5/10
+
+Configuration ........... 8/10
+
+Overall Project ......... 8.1/10
+
+---
+
+# Things to Inspect
+
+## Solution Structure
+
+Review whether the solution structure is appropriate.
+
+Could folders be organized better?
+
+Should projects be separated?
+
+Should class libraries exist?
+
+Should interfaces move elsewhere?
+
+---
+
+## Architecture
+
+Determine which architecture is currently used.
+
+Examples:
+
+* Layered
+* Clean Architecture
+* Onion
+* Vertical Slice
+* Modular Monolith
+* Feature Based
+* N-Tier
+
+Evaluate whether the architecture is appropriate.
+
+Explain improvements.
+
+---
+
+## Dependency Injection
+
+Inspect every registration.
+
+Look for:
+
+* Singleton misuse
+* Scoped misuse
+* Transient misuse
+* Missing interfaces
+* Service Locator
+* Circular dependencies
+
+---
+
+## SOLID
+
+Evaluate every principle separately.
+
+Single Responsibility
+
+Open Closed
+
+Liskov
+
+Interface Segregation
+
+Dependency Inversion
+
+Provide examples from the project.
+
+---
+
+## DRY
+
+Find duplicated code.
+
+Suggest refactoring.
+
+---
+
+## KISS
+
+Identify unnecessary complexity.
+
+---
+
+## YAGNI
+
+Find code that probably should not exist.
+
+---
+
+## Naming
+
+Review names of:
+
+Classes
+
+Methods
+
+Properties
+
+Variables
+
+Namespaces
+
+Folders
+
+Projects
+
+Controllers
+
+Services
+
+Repositories
+
+DTOs
+
+Commands
+
+Queries
+
+Enums
+
+Interfaces
+
+Explain inconsistent naming.
+
+---
+
+## Folder Structure
+
+Review whether folders are consistent.
+
+Suggest improvements.
+
+---
+
+## API Design
+
+Review:
+
+Controllers
+
+Minimal APIs
+
+Routing
+
+Response types
+
+HTTP status codes
+
+REST principles
+
+Versioning
+
+DTO usage
+
+ProblemDetails
+
+Pagination
+
+Filtering
+
+Sorting
+
+---
+
+## Exception Handling
+
+Inspect:
+
+try/catch usage
+
+global exception middleware
+
+custom exceptions
+
+logging
+
+error responses
+
+---
+
+## Logging
+
+Evaluate:
+
+ILogger usage
+
+structured logging
+
+missing logs
+
+log levels
+
+sensitive information
+
+---
+
+## Validation
+
+Review:
+
+FluentValidation
+
+DataAnnotations
+
+manual validation
+
+duplicate validation
+
+---
+
+## EF Core
+
+Inspect:
+
+DbContext
+
+Migrations
+
+Tracking
+
+AsNoTracking
+
+Lazy loading
+
+N+1 queries
+
+Indexes
+
+Transactions
+
+Unit of Work
+
+Repositories
+
+Performance
+
+---
+
+## Async
+
+Review every async method.
+
+Find:
+
+missing async
+
+blocking calls
+
+.Result
+
+.Wait()
+
+ConfigureAwait issues
+
+---
+
+## Performance
+
+Look for:
+
+allocations
+LINQ inefficiencies
+
+multiple enumerations
+
+boxing
+
+reflection
+
+large object allocations
+
+caching opportunities
+
+memory usage
+
+---
+
+## Security
+
+Review:
+
+Authentication
+
+Authorization
+
+Secrets
+
+Connection strings
+
+CORS
+
+Cookies
+
+CSRF
+
+XSS
+
+SQL Injection
+
+File Uploads
+
+Input validation
+
+Rate limiting
+
+Headers
+
+Sensitive logging
+
+HTTPS
+
+---
+
+## Testability
+
+Review:
+
+Dependency injection
+
+Interfaces
+
+Mockability
+
+Static classes
+
+Extension methods
+
+Pure functions
+
+Coupling
+
+Suggest where unit tests are difficult.
+
+---
+
+## Debuggability
+
+Review:
+
+Logging
+
+Exception messages
+
+Method sizes
+
+Magic values
+
+Nested conditions
+
+Readability
+
+Diagnostic information
+
+Breakpoints friendliness
+
+Stack traces
+
+---
+
+## Maintainability
+
+Evaluate:
+
+Code organization
+
+Class size
+
+Method size
+
+Cyclomatic complexity
+
+Long parameter lists
+
+Large constructors
+
+God classes
+
+Feature coupling
+
+---
+
+## Extensibility
+
+Can new features be added easily?
+
+What parts are tightly coupled?
+
+Which abstractions are missing?
+
+---
+
+## Consistency
+
+Inspect consistency of:
+
+Naming
+
+Formatting
+
+Dependency Injection
+
+DTOs
+
+Async
+
+Controllers
+
+Repositories
+
+Services
+
+Error handling
+
+Logging
+
+Patterns
+
+Coding style
+
+Folder structure
+
+---
+
+## Code Smells
+
+Find:
+
+God Object
+
+Long Method
+
+Large Class
+
+Shotgun Surgery
+
+Feature Envy
+
+Primitive Obsession
+
+Magic Numbers
+
+Temporary Fields
+
+Duplicate Code
+
+Data Clumps
+
+Middle Man
+
+Message Chains
+
+Inappropriate Intimacy
+
+Dead Code
+
+---
+
+## Atomicity
+
+Review whether methods are atomic.
+
+Identify methods doing multiple unrelated responsibilities.
+
+Suggest decomposition.
+
+---
+
+## Readability
+
+Evaluate:
+
+Comments
+
+Method names
+
+Expression clarity
+
+Variable names
+
+Indentation
+
+Control flow
+
+Nested ifs
+
+Early returns
+
+Pattern matching opportunities
+
+---
+
+## Best Practices
+
+Compare code against modern ASP.NET Core and C# best practices.
+
+Recommend modern language features where beneficial.
+
+Examples:
+
+Primary Constructors
+
+Collection Expressions
+
+Required Members
+
+File Scoped Namespaces
+
+Records
+
+Pattern Matching
+
+Minimal APIs
+
+Keyed Services
+
+IOptions
+
+Typed HttpClient
+
+ProblemDetails
+
+CancellationToken
+
+---
+
+# Severity Levels
+
+Categorize every finding:
+
+🔴 Critical
+
+🟠 High
+
+🟡 Medium
+
+🟢 Low
+
+---
+
+# Positive Findings
+
+Don't only criticize.
+
+Mention good architectural decisions.
+
+Explain why they are good.
+
+---
+
+# Technical Debt
+
+Estimate overall technical debt.
+
+Explain:
+
+Current impact
+
+Future impact
+
+Estimated refactoring effort
+
+---
+
+# Refactoring Roadmap
+
+Produce a prioritized roadmap.
+
+Phase 1
+
+Phase 2
+
+Phase 3
+
+Quick Wins
+
+Long-term Improvements
+
+---
+
+# Final Summary
+
+Include:
+
+Overall score
+
+Top 10 strengths
+
+Top 10 weaknesses
+
+Top 20 improvements
+
+Risk assessment
+
+Production readiness (percentage)
+
+Maintainability score
+
+Architecture maturity level
+
+Estimated project maturity from 1 to 10.
+
+---
+
+# Output Format
+
+Generate the report as BOTH:
+
+1. A beautiful standalone HTML file.
+
+Requirements:
+
+* Modern responsive layout
+* Dark mode
+* Sticky sidebar with table of contents
+* Collapsible sections
+* Colored score cards
+* Progress bars
+* Severity badges
+* Syntax-highlighted code snippets (if any)
+* Professional typography
+* Print-friendly
+* No external CSS or JavaScript dependencies (everything embedded)
+
+2. A Markdown (.md) version with the same content.
+
+At the end, provide both files ready to save.
+Language Requirement
+Generate the entire report in Persian (Farsi).
+Requirements:
+Write all explanations, analyses, recommendations, strengths, weaknesses, and conclusions in fluent and professional Persian.
+Use technical terms commonly used by Persian-speaking .NET developers. When necessary, include the original English term in parentheses (for example: تزریق وابستگی (Dependency Injection)).
+Do not translate source code, class names, method names, namespaces, file names, or framework/library names.
+All tables, headings, scores, summaries, and roadmap sections must also be written in Persian.
+The generated HTML report must use RTL (right-to-left) layout with dir="rtl" and lang="fa".
+Use a modern Persian font stack (such as Vazirmatn, IRANSans, or system fallbacks) and ensure proper spacing and typography for Persian text.
+Numbers inside the report should be Persian digits unless they are part of source code or identifiers.
+The final deliverables must be:
+A standalone RTL HTML report.
+A Markdown (.md) report in Persian.

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -31,13 +31,15 @@ agent that made a change is not independent evidence about it.
 
 | Date | Overall | Production readiness | Methodology | Model | Files |
 |---|---|---|---|---|---|
-| 2026-07-08 | 4.6 / 10 | 30% | unversioned | Claude Opus 4.8 | [`AUDIT_2026-07.md`](AUDIT_2026-07.md) (summary), [`AUDIT_2026-07.html`](AUDIT_2026-07.html) (full, Persian) |
+| 2026-07-08 | 4.6 / 10 | 30% | [v1](METHODOLOGY_v1.md) | Claude Opus 4.8 | [`AUDIT_2026-07.md`](AUDIT_2026-07.md) (summary), [`AUDIT_2026-07.html`](AUDIT_2026-07.html) (full, Persian) |
 | 2026-08-26 | 6.6 / 10 | ~55% | unversioned | Claude Opus 5 | [`AUDIT_2026-08.md`](AUDIT_2026-08.md) |
 | 2026-08-29 | 7.8 / 10 | ~65% | v7.0 | GLM (Z.ai) / Cline | [`AUDIT_2026-08b.md`](AUDIT_2026-08b.md) |
 
 **Read this column-by-column, not row-by-row.** The three runs used different methods and
 different models — the product owner supplied the model attribution for the first two rows in
-August 2026, so the column is now known for every run. A score that rises between runs may
+August 2026, and the July prompt itself in `METHODOLOGY_v1.md`, so the column is now known
+for every run and readable for two of the three. (The prompt used on 2026-08-26 was not kept;
+that row's method is known only from what the audit itself describes.) A score that rises between runs may
 mean the code improved, or that a different reader weighted the same code differently. The
 comparison is only sound where the methodology and model columns match — which, so far, they
 never do. v7 requires both to be recorded, so the 2026-08-29 run is the first whose successor
@@ -63,6 +65,7 @@ a record of what this project learned about auditing itself:
 
 | Version | Answers |
 |---|---|
+| v1 | Nothing yet — the first pass. Fifty-odd review dimensions weighted equally, a score for each, and no rule about evidence, reproduction, scope, or what counts as a finding |
 | v7 | Findings inferred from the shape of the code without checking product intent; an audit that only read and never ran anything; a directory the method named but that did not exist |
 | v8 | Claims written during synthesis that no session had checked; a prior-audit status row carried forward for a problem already fixed; a verified sample stated as a verified universe; command output lost by the terminal and read as a negative result |
 

--- a/docs/process/INDEX.md
+++ b/docs/process/INDEX.md
@@ -47,6 +47,7 @@ docs/
 │   ├── README.md                  ← Archive index and score trend across all audits
 │   ├── METHODOLOGY_v8.md          ← How the next audit is run (current methodology)
 │   ├── METHODOLOGY_v7.md          ← Retired; kept because AUDIT_2026-08b.md was run under it
+│   ├── METHODOLOGY_v1.md          ← The original July prompt, archived for comparability
 │   ├── AUDIT_2026-07.md           ← July 2026 audit — English summary
 │   ├── AUDIT_2026-07.html         ← July 2026 audit — full report (Farsi)
 │   ├── AUDIT_2026-08.md           ← August 2026 re-audit


### PR DESCRIPTION
**Branch Name**: `feat/archive-july-audit-prompt`
**Linked Issue/Task**: replaces #162, which was withdrawn by #163

## Description

The trend table in `docs/audit/README.md` asks readers to weigh each score against the method
that produced it. Until now only v7 and v8 could actually be read. This archives the original
July prompt as `METHODOLOGY_v1.md` and links it from the table.

## Type of Change

- [x] Documentation (docs/comments only)

## Changes Made

- `docs/audit/METHODOLOGY_v1.md` — the July prompt, with an archival header
- `docs/audit/README.md` — the 2026-07-08 row's Methodology cell links it; the caveat says
  which of the three methods are readable; a v1 row added to the table of what each version
  answers
- `docs/process/INDEX.md` — tree updated

## What changed since #162

#162 published this file with the chat transcript's message boundaries intact — three lines of
the form `[<date> <time>] <name>:` carrying a contributor's name and the exact times they sent
the messages. That was withdrawn in #163.

Those three lines are now removed. They were delivery artifacts, not part of the method: one
of them fell in the middle of the Performance list, splitting `allocations` from
`LINQ inefficiencies`, which is now whole again. **The prompt text itself is unaltered** —
nothing corrected, reordered or tidied — and the header says exactly what was removed and why,
so the edit is on the record rather than silent.

The date the archive needs is 2026-07-08, which the audit it produced already carries. Nothing
in the file now identifies a person.

## Why it is worth keeping

v1 explains why the July audit's 4.6/10 is not comparable to anything after it:

- Fifty-odd review dimensions listed with equal weight — SOLID, KISS, YAGNI, naming, folder
  structure, code smells by name — and a score demanded for each
- No rule about evidence, no reproduction requirement, no scope exclusions, and no definition
  of what counts as a finding versus a preference
- "Generate the report as BOTH a standalone HTML file and a Markdown version", in Persian —
  which is why `AUDIT_2026-07.html` exists, and why every methodology since has said no HTML

Read next to v8, it is a compact record of what this project learned about auditing itself.

## Testing Completed

Documentation only.

- The staged diff was scanned for names, handles, emails, URLs, absolute user paths and chat
  timestamps: clean.
- All relative links across the 21 markdown files under `docs/` plus `AGENT.md` and
  `CLAUDE.md` resolve.

## Known issues not addressed

The 2026-08-26 prompt was not kept. Rather than guess at it, the README states plainly that
this row's method is known only from what the audit itself describes.

The pre-existing broken link in `docs/pull-requests/PR_TASK-003_QUARANTINE_STUBS.md` is still
there — unrelated, noted in #154.

## Deployment / Rollback

No runtime impact. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
