### PR TITLE
docs(audit): record that the 2026-08-26 audit had no methodology

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -32,18 +32,24 @@ agent that made a change is not independent evidence about it.
 | Date | Overall | Production readiness | Methodology | Model | Files |
 |---|---|---|---|---|---|
 | 2026-07-08 | 4.6 / 10 | 30% | [v1](METHODOLOGY_v1.md) | Claude Opus 4.8 | [`AUDIT_2026-07.md`](AUDIT_2026-07.md) (summary), [`AUDIT_2026-07.html`](AUDIT_2026-07.html) (full, Persian) |
-| 2026-08-26 | 6.6 / 10 | ~55% | unversioned | Claude Opus 5 | [`AUDIT_2026-08.md`](AUDIT_2026-08.md) |
+| 2026-08-26 | 6.6 / 10 | ~55% | none — ad hoc | Claude Opus 5 | [`AUDIT_2026-08.md`](AUDIT_2026-08.md) |
 | 2026-08-29 | 7.8 / 10 | ~65% | v7.0 | GLM (Z.ai) / Cline | [`AUDIT_2026-08b.md`](AUDIT_2026-08b.md) |
 
 **Read this column-by-column, not row-by-row.** The three runs used different methods and
 different models — the product owner supplied the model attribution for the first two rows in
 August 2026, and the July prompt itself in `METHODOLOGY_v1.md`, so the column is now known
-for every run and readable for two of the three. (The prompt used on 2026-08-26 was not kept;
-that row's method is known only from what the audit itself describes.) A score that rises between runs may
-mean the code improved, or that a different reader weighted the same code differently. The
-comparison is only sound where the methodology and model columns match — which, so far, they
-never do. v7 requires both to be recorded, so the 2026-08-29 run is the first whose successor
-can be genuinely comparable to it.
+for every run, and the method is readable for two of the three. A score that rises between
+runs may mean the code improved, or that a different reader weighted the same code
+differently. The comparison is only sound where the methodology and model columns match —
+which, so far, they never do. v7 requires both to be recorded, so the 2026-08-29 run is the
+first whose successor can be genuinely comparable to it.
+
+**The 2026-08-26 run had no methodology.** It was commissioned by two sentences inside a
+message about something else — audit the code, every service except Affiliate — and
+delivered twelve minutes later. It was also run by the same session that had been editing
+this repository that day, so it was not independent of the code it measured in even the
+weakest sense. Both facts belong next to its 6.6, and neither is visible in the audit
+itself.
 
 One independence fact, checked 2026-08-30 and worth weighting the rows by: all 31 commits
 merged between the 2026-08-26 audit and the 2026-08-29 one (`git log --since=2026-08-26


### PR DESCRIPTION
**Branch Name**: `docs/record-second-audit-had-no-method`
**Linked Issue/Task**: follows #164

## Description

`docs/audit/README.md` described the 2026-08-26 run's method as "unversioned", and said it was
known only from what the audit itself describes. Both statements were wrong, and the correction
is more interesting than the error.

## Type of Change

- [x] Documentation (docs/comments only)

## What the search found

The prompt for that audit was looked for in the stored session history. There was none to
find. The audit was commissioned by two sentences inside a message about closing the OKR
cycle — audit the code, every service except Affiliate — and the result was reported twelve
minutes later.

Two consequences, both of which belong beside that row's 6.6 and neither of which is visible
in the audit file:

1. **There was no methodology**, so "unversioned" overstated it. The column now reads
   `none — ad hoc`.
2. **It was not independent.** The audit was run by the same session that had been editing
   this repository that day. The README already carries a caveat about models being the same
   across rows; this is stronger, because it is the same *session*, holding everything it had
   just changed.

For scale: that run took twelve minutes, the 2026-08-29 run took sixty-seven, and v8 budgets
four to five and a half hours.

## Changes Made

- `docs/audit/README.md` — the 2026-08-26 Methodology cell; the stale parenthetical removed;
  a paragraph recording both facts.

## Why no METHODOLOGY_v2.md

Building a methodology document out of two sentences would give that run a standing it never
had, and would make the version column look continuous when it is not. The honest record is
that the entry is empty and why.

## Testing Completed

Documentation only. The staged diff was scanned for names, handles, emails, URLs, absolute
user paths and chat timestamps: clean. No text from the session history is quoted; the
instruction is described rather than reproduced.

## Deployment / Rollback

No runtime impact. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
