### PR TITLE
docs(audit): link the v7.0 cell in the trend table to its methodology

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -33,7 +33,7 @@ agent that made a change is not independent evidence about it.
 |---|---|---|---|---|---|
 | 2026-07-08 | 4.6 / 10 | 30% | [v1](METHODOLOGY_v1.md) | Claude Opus 4.8 | [`AUDIT_2026-07.md`](AUDIT_2026-07.md) (summary), [`AUDIT_2026-07.html`](AUDIT_2026-07.html) (full, Persian) |
 | 2026-08-26 | 6.6 / 10 | ~55% | none — ad hoc | Claude Opus 5 | [`AUDIT_2026-08.md`](AUDIT_2026-08.md) |
-| 2026-08-29 | 7.8 / 10 | ~65% | v7.0 | GLM (Z.ai) / Cline | [`AUDIT_2026-08b.md`](AUDIT_2026-08b.md) |
+| 2026-08-29 | 7.8 / 10 | ~65% | [v7.0](METHODOLOGY_v7.md) | GLM (Z.ai) / Cline | [`AUDIT_2026-08b.md`](AUDIT_2026-08b.md) |
 
 **Read this column-by-column, not row-by-row.** The three runs used different methods and
 different models — the product owner supplied the model attribution for the first two rows in


### PR DESCRIPTION
**Branch Name**: `docs/link-v7-in-trend-table`
**Linked Issue/Task**: follows #165

## Description

In the trend table in `docs/audit/README.md`, the v1 cell linked to `METHODOLOGY_v1.md` but
v7.0 was plain text. Both now link to the file that produced that row.

That column exists so a reader weighing a score can reach the method behind it; a cell that
names a version without linking it only half does the job.

## Type of Change

- [x] Documentation (docs/comments only)

## Changes Made

- `docs/audit/README.md` — one cell: `v7.0` → `[v7.0](METHODOLOGY_v7.md)`

The 2026-08-26 cell stays unlinked, because there is nothing to link to — see #165.

## Testing Completed

Documentation only. All relative links across the 21 markdown files under `docs/` plus
`AGENT.md` and `CLAUDE.md` resolve.

## Deployment / Rollback

No runtime impact. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
