### PR TITLE
docs(audit): archive methodology v2 through v6 and explain the numbering

### DIFF
--- a/docs/audit/METHODOLOGY_v2.md
+++ b/docs/audit/METHODOLOGY_v2.md
@@ -1,0 +1,360 @@
+# TallaEgg — Phased Independent Architecture, Security & Production Readiness Audit (v2)
+
+> **Historical — never used to run an audit.** This is one of the drafts between v1 and
+> v7; see [“Where these versions came from”](README.md#where-these-versions-came-from).
+> The current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+## HOW THIS PROMPT WORKS (READ FIRST)
+
+This audit is too large to complete in a single pass — no model can hold an entire
+ASP.NET Core solution in context at once. This version splits the work into **six
+phases**, run as **separate sessions** inside an agentic coding tool with real
+filesystem access to the repository (e.g. Claude Code operating directly on the repo,
+not a chat with pasted snippets).
+
+Each phase:
+- Reads the output files from all prior phases before starting.
+- Does its own work using real tools (`view`/`grep`/`git`/`dotnet` commands, not
+  memory or assumption).
+- Writes its findings to a dedicated file under `audit/` in the repo before ending.
+- Does NOT try to produce the final HTML/Markdown report itself (that's Phase 5 only).
+
+If a phase's output file already exists when you start, treat it as ground truth from
+a previous session — do not regenerate it from scratch, only extend it.
+
+Working files this audit produces (create the `audit/` folder if absent):
+
+```
+audit/00-inventory.md
+audit/01-architecture.md
+audit/02-findings-register.md      (append-only across phases 2A–2E)
+audit/03-cross-cutting.md
+audit/04-synthesis.md
+TallaEgg-Audit-Report.html         (Phase 5 output)
+TallaEgg-Audit-Report.md           (Phase 5 output)
+```
+
+**Redaction rule (applies to every phase, no exceptions):** never copy a real secret,
+API key, connection string, password, or token into any audit file. If evidence
+requires referencing one, describe its *shape and location* only — e.g. "hardcoded
+connection string with embedded credentials, `appsettings.json:14`" — never the value
+itself. A finding about a leaked secret is itself a document that must not leak the
+secret.
+
+**No fabrication rule (applies to every phase):** every fact that comes from the
+environment — git branch, commit hash, framework version, package versions,
+vulnerability data, line numbers — must come from an actual command you ran or file
+you viewed in this session. If a command fails or a tool is unavailable, write
+"unavailable in audit environment" for that field. Never guess or infer a plausible-
+sounding value.
+
+---
+
+# PHASE 0 — Repository Discovery & Inventory
+
+## Role
+Principal Software Architect performing initial repository reconnaissance.
+
+## Task
+Build a factual inventory of the repository. Do not draw architectural or quality
+conclusions yet — that's Phase 1 onward.
+
+Run real commands and record actual output:
+
+- `git rev-parse --abbrev-ref HEAD` → branch (or "unavailable")
+- `git rev-parse HEAD` → commit hash (or "unavailable")
+- `git log -1 --format=%cd` → last commit date (or "unavailable")
+- List all `.sln`, `.csproj` files and their target frameworks
+- List NuGet package references per project (`dotnet list package` if available)
+- Identify project types: API, Application, Domain, Infrastructure, Tests, Workers,
+  shared/common libraries
+- Identify Docker files, CI/CD config, migration folders, config files
+  (`appsettings*.json` — note their existence, never their contents if they contain
+  secrets)
+- Count approximate source files per project
+
+Do NOT open previous audit reports, TODOs, or prior AI-generated conclusions during
+this phase if they exist in the repo — this is an independent audit.
+
+## Output
+Write `audit/00-inventory.md` with: project list, references between projects,
+package list per project, framework versions, real git metadata, file/folder counts,
+and a short "scope of this audit" note (what was and wasn't reachable).
+
+---
+
+# PHASE 1 — Architecture Reconstruction & Dependency Graph
+
+## Precondition
+Read `audit/00-inventory.md` first.
+
+## Task
+Determine the *actual* architecture from evidence (project references, namespaces,
+DI registrations, controller/service/repository implementations) — not from folder
+names alone.
+
+Cover:
+- Intended vs. actual architecture (layered, clean, vertical slice, modular monolith,
+  etc. — whichever the evidence supports; do not force a label)
+- Dependency graph between projects/layers; flag violations of intended direction
+  (e.g. Domain → Infrastructure, API → DB direct access)
+- Circular dependencies, service locator usage, global/static state
+- SOLID violations with concrete file/class evidence (log candidates here; deep
+  SOLID/DRY analysis happens in Phase 2A)
+
+## Output
+Write `audit/01-architecture.md`.
+
+---
+
+# PHASE 2 — Domain-by-Domain Deep Audit
+
+Run as five sub-phases, each its own session. Each sub-phase reads
+`audit/00-inventory.md`, `audit/01-architecture.md`, and appends to
+`audit/02-findings-register.md` using the finding schema below — never overwrite
+earlier sub-phases' entries.
+
+### Finding schema (use for every entry across all of Phase 2)
+
+```
+### [ID]  e.g. SEC-003, FIN-007, DB-012
+
+- Severity: Critical / High / Medium / Low
+- Category: Architecture / Security / Database / Performance / Reliability /
+  Financial Integrity / Maintainability / ...
+- Location: Project / File path / Class / Method (line number ONLY if you directly
+  viewed it — omit rather than guess)
+- Evidence: what was actually observed, referencing the real implementation
+- Problem: what's wrong
+- Technical Risk: engineering consequence
+- Business Impact: product/business consequence
+- Recommendation: concrete, actionable — not "improve the architecture"
+- Effort: Low / Medium / High
+- Confidence: High / Medium / Low (High only when evidence is complete)
+- Production Decision: Must Fix Before Production / Should Fix Before Production /
+  Can Be Deferred / Optional Improvement
+```
+
+Classify every conclusion mentally as: confirmed defect, confirmed security issue,
+architectural weakness, maintainability concern, performance concern, best-practice
+deviation, design trade-off, or personal/style preference. Only the first six belong
+in the findings register as problems — a design trade-off is noted as context, not a
+defect.
+
+## Phase 2A — Code Quality & Design
+SOLID (concrete violations only, with evidence), DRY/KISS/YAGNI, naming and
+consistency across the codebase, folder/project structure, dead code, code smells
+(God Object, Long Method, Feature Envy, Primitive Obsession, Data Clumps, etc. — only
+where there's real evidence of maintainability impact).
+
+## Phase 2B — API, Validation, Error Handling, Logging
+Controllers/Minimal APIs, routing, status codes, request/response DTOs vs. leaked
+domain/DB models, versioning, pagination, idempotency. Validation: where it lives
+(syntactic vs. business vs. authorization vs. domain invariant), duplication. Error
+handling: swallowed exceptions, overly broad catches, centralized handling,
+ProblemDetails usage, sensitive-data leakage in error responses. Logging: structured
+logging, log levels, correlation IDs, whether a production incident in wallet/order
+flows could actually be diagnosed from what's logged.
+
+## Phase 2C — Database, EF Core, Async & Performance
+DbContext design, tracking behavior, N+1 queries, missing indexes, transaction
+boundaries, concurrency control (optimistic/pessimistic), migrations. Async
+correctness: `.Result`/`.Wait()`, async void, missing CancellationToken, fire-and-
+forget risks. Performance: only report issues with plausible evidence, not
+theoretical optimizations. Explicitly evaluate whether Repository/Unit of Work
+patterns are used, and if not, whether their absence causes a real problem — don't
+recommend them by default.
+
+## Phase 2D — Security Audit
+Authentication, authorization (including resource ownership / IDOR checks per
+endpoint), secrets handling (existence and location only — see redaction rule), CORS,
+CSRF, XSS, SQL injection, file upload handling, rate limiting, security headers,
+cookie/token handling, mass assignment. For dependency vulnerabilities: actually run
+`dotnet list package --vulnerable` (or equivalent) if available in the environment;
+if the tool isn't available, state that explicitly rather than asserting packages are
+safe or unsafe from memory. For every security finding, classify as: theoretical
+concern / probable vulnerability / confirmed vulnerability — do not claim a
+vulnerability without evidence.
+
+## Phase 2E — Financial / Wallet / Trading Domain Audit (dedicated deep pass)
+This is the highest-stakes section — give it the most rigor. For every operation that
+mutates wallet balances, order state, or asset holdings, trace it explicitly:
+
+```
+Input → Validation → Authorization → Business Rules → State Transition →
+Database Operations → External Operations → Commit → Failure Behavior →
+Retry Behavior → Recovery Behavior
+```
+
+For each such operation, check specifically:
+- Decimal/money precision and currency handling
+- Race conditions on concurrent requests to the same wallet/order
+- Double-spend potential
+- Atomicity — can the operation partially succeed and leave inconsistent state?
+- Idempotency / duplicate-request handling (replay protection)
+- Database constraints backing the invariants (unique constraints, check constraints)
+  — or their absence
+- Ledger/audit trail: can a balance be reconstructed independently of the live value?
+- Behavior when an external service call fails mid-operation
+
+Identify every operation that can leave the system in an inconsistent financial
+state, with concrete evidence.
+
+---
+
+# PHASE 3 — Cross-Cutting Quality
+
+## Precondition
+Read all prior `audit/` files, including the full findings register.
+
+## Task
+Testability (what's unit-testable vs. requires integration/E2E, and why), debug-
+ability (can a wallet/order/auth failure be diagnosed quickly in production from
+what's logged and how errors surface?), maintainability (class/method size,
+cyclomatic complexity, coupling/cohesion), extensibility (cost of adding a new asset,
+order type, payment method, or integration), modern C#/.NET practices (only where
+adoption would genuinely improve clarity/correctness/maintainability — not novelty
+for its own sake).
+
+Also produce **Positive Findings**: identify strong engineering decisions already in
+the codebase, explain why they're good, what risk they prevent, and whether they
+should become a project-wide standard. This audit is not criticism-only.
+
+## Output
+Write `audit/03-cross-cutting.md`.
+
+---
+
+# PHASE 4 — Synthesis & Scoring
+
+## Precondition
+Read every file under `audit/`, including the complete findings register.
+
+## Task
+- Score each category 0–10 (Architecture, Design Quality, Maintainability,
+  Scalability, Extensibility, Testability, Debuggability, Readability, Consistency,
+  Performance, Security, Reliability, Financial Domain Safety, SOLID, DI, Error
+  Handling, Logging, Validation, Configuration, API Design, Database/EF Core,
+  Concurrency, Observability). Each score must trace back to specific findings in the
+  register — state which findings drove the score. Avoid false precision (no "8.7"
+  without a stated reason).
+- Technical debt estimate by category (architectural, code, testing, security,
+  operational, documentation), each with impact/urgency/effort/expected benefit.
+- Production Readiness %, derived explicitly from the count and severity of open
+  Critical/High findings — never an invented number. Any unresolved Critical
+  financial or security finding caps this at a low percentage; state the cap
+  explicitly.
+- Refactoring roadmap: Phase 0 (production blockers) → Phase 1 (high priority) →
+  Phase 2 (structural) → Phase 3 (optimization) → Phase 4 (long-term), plus a
+  separate Quick Wins list.
+- Top 10 Strengths, Top 10 Weaknesses (ranked by risk), Top 20 Improvements (ranked
+  by Impact × Risk Reduction ÷ Effort — a serious security or financial-integrity fix
+  outranks a stylistic one regardless of effort).
+- Architecture maturity rating (1–10 scale, defined in the original methodology)
+  with justification.
+- Final risk assessment across Security / Financial / Data Integrity / Reliability /
+  Performance / Scalability / Maintainability / Architecture / Operations.
+
+## Output
+Write `audit/04-synthesis.md`.
+
+---
+
+# PHASE 5 — Final Report Generation
+
+## Precondition
+All of `audit/00…04` must exist and be internally consistent. Before generating
+anything, run the consistency check below and fix any gaps by returning to the
+relevant earlier phase rather than papering over them in the final report.
+
+## Consistency check (do this before writing the final files)
+- Every finding in the register has severity, confidence, and evidence
+- Scores in Phase 4 trace to findings, not vibes
+- Production readiness % reflects open Critical/High findings
+- No fabricated file paths, line numbers, branch names, or commit hashes anywhere
+- No secret values appear anywhere in any audit file
+- Markdown and HTML will contain the same substantive conclusions
+
+## Output requirements
+
+Generate two deliverables. **Because the full report is long, write it incrementally
+to disk section-by-section rather than composing it entirely in one response** — draft
+each major section as its own file write, so nothing is lost if generation is
+interrupted.
+
+1. **Markdown** (`TallaEgg-Audit-Report.md`) — full report in English, all sections
+   below, no artificial shortening.
+2. **Standalone HTML** (`TallaEgg-Audit-Report.html`) — single file, no external CSS/
+   JS dependencies, works offline. Dark mode, sticky sidebar/TOC, severity badges,
+   score cards, finding cards, roadmap visualization, print-friendly, responsive.
+   Same substantive content as the Markdown, not a summary of it.
+
+### Required sections (both formats)
+Executive Summary; Audit Metadata; Audit Methodology; Repository Overview;
+Architecture Reconstruction; Dependency Analysis; SOLID Analysis; Design Quality;
+Domain Model; Financial Domain Audit; Transaction Integrity; API Audit; Security
+Audit; Database/EF Core Audit; Async/Concurrency Audit; Performance Audit; Error
+Handling; Logging/Observability; Validation; Testability; Debuggability;
+Maintainability; Extensibility; Code Smells; Consistency; Modern C#/ASP.NET Core
+Practices; Positive Findings; Finding Register (master table, every finding);
+Technical Debt; Production Readiness; Refactoring Roadmap; Top 10 Strengths; Top 10
+Weaknesses; Top 20 Improvements; Final Scores; Final Risk Assessment; Architecture
+Maturity; Final Recommendation.
+
+### Audit Metadata table (populate with real values only)
+
+| Audit Metadata | Value |
+|---|---|
+| Audit Type | AI-Assisted Architecture & Code Audit |
+| Audit Date | *(actual date this phase ran)* |
+| AI Provider | *(actual provider available in this environment)* |
+| AI Model | *(actual model identity if available; otherwise: "Exact AI model identity was not available in the audit execution environment.")* |
+| Audit Methodology | Independent Evidence-Based Repository Audit (Phased) |
+| Repository | *(from Phase 0)* |
+| Branch | *(from Phase 0, real git output or "unavailable")* |
+| Commit | *(from Phase 0, real git output or "unavailable")* |
+| Framework | *(from Phase 0)* |
+| Audit Scope | *(what was actually covered — note any parts of the repo not reachable)* |
+| Human Review Status | Not yet reviewed by a human engineer |
+| Audit ID | TALLAEGG-AUDIT-[YYYYMMDD]-[SHORT-ID], real date |
+| Methodology Version | 2.0 (phased) |
+
+### Mandatory disclosure statement (include verbatim, both formats)
+
+> This audit was performed with the assistance of Artificial Intelligence and is
+> based on analysis of the source code, project structure, dependencies,
+> configuration, database-related artifacts, tests, and other repository artifacts
+> available within the defined audit scope. The findings represent an evidence-based
+> engineering assessment and should be validated by qualified human engineers before
+> making critical production, security, financial, or architectural decisions.
+
+### AI Limitations section (include)
+Note plainly that AI analysis may miss issues that depend on runtime-only behavior,
+production traffic patterns, infrastructure/environment configuration, undocumented
+business requirements, external service behavior, active-exploitation-only
+vulnerabilities, or production-only race conditions — and that this doesn't excuse
+shallow analysis in the areas that were reachable.
+
+### No false certification
+Never state the system is "completely secure," "guaranteed production-ready," or
+"perfect." Use evidence-based phrasing: "The reviewed code does not show evidence
+of...", "Within the audited scope, no implementation of X was identified,"
+"Additional runtime or penetration testing is recommended for confirmation."
+
+---
+
+# GLOBAL RULES (apply across every phase)
+
+- Language: English only, everywhere in every output file — including HTML UI text.
+  Do not translate identifiers, file paths, namespaces, or code snippets.
+- Start from zero: ignore any pre-existing audit docs, TODOs, or prior AI conclusions
+  in the repo unless explicitly doing the optional post-hoc comparison after the
+  independent audit is complete.
+- Don't recommend a pattern (Repository, CQRS, DDD, microservices, interfaces
+  everywhere) unless there's a concrete problem it solves in *this* codebase.
+  Absence of a pattern is not automatically a defect.
+- Don't claim a security or performance issue without evidence; don't fabricate line
+  numbers, branch names, commits, or vulnerability data.
+- Never include a real secret value in any audit file, at any severity.
+- A style preference is not an engineering defect — say so explicitly when a finding
+  is a trade-off rather than a problem.

--- a/docs/audit/METHODOLOGY_v3.md
+++ b/docs/audit/METHODOLOGY_v3.md
@@ -1,0 +1,327 @@
+# TallaEgg — Phased Architecture, Security & Production Readiness Audit (v3)
+
+> **Historical — never used to run an audit.** This is one of the drafts between v1 and
+> v7; see [“Where these versions came from”](README.md#where-these-versions-came-from).
+> The current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+## HOW THIS PROMPT WORKS (READ FIRST)
+
+This audit is too large to complete in a single pass — no model can hold an entire
+ASP.NET Core solution in context at once. This version splits the *work* into six
+phases, run as separate sessions inside an agentic coding tool with real filesystem
+access to the repository (e.g. Claude Code operating directly on the repo, not a chat
+with pasted snippets).
+
+**Two different things are kept deliberately separate:**
+
+- **Scratch work (Phases 0–4):** notes each phase needs to hand off to the next.
+  These live under `.audit-work/` and are disposable — add that folder to
+  `.gitignore`. Nobody archives these; they exist only to get you through a multi-
+  session run without re-reading the whole repo every time.
+- **The archive (Phase 5):** exactly **one** dated Markdown file, written to
+  `docs/audit/`, alongside your existing `AUDIT_FINDINGS.md` and
+  `RE_AUDIT_2026-08.md`. That's the only thing meant to be kept, linked, and diffed
+  over time.
+
+If `.audit-work/` files already exist when you start a phase, treat them as ground
+truth from a previous session — extend them, don't regenerate from scratch. If a
+prior archived audit already exists in `docs/audit/`, Phase 5 runs in **re-audit
+mode** (see below) instead of a fresh initial audit.
+
+**Redaction rule (every phase, no exceptions):** never copy a real secret, API key,
+connection string, password, or token into any file — scratch or archived. Describe
+its *shape and location* only, e.g. "hardcoded connection string with embedded
+credentials, `appsettings.json:14`." A finding about a leaked secret must not itself
+leak the secret.
+
+**No fabrication rule (every phase):** every environmental fact — git branch, commit
+hash, framework/package versions, vulnerability data, line numbers — must come from a
+command you actually ran or a file you actually viewed in this session. If a command
+fails or a tool is unavailable, write "unavailable in audit environment." Never guess.
+
+**Language: English only**, in every phase and in the final archived file — including
+code comments you quote and UI text if HTML is ever generated. Don't translate
+identifiers, file paths, namespaces, or code snippets.
+
+---
+
+# PHASE 0 — Repository Discovery (scratch)
+
+## Task
+Build a factual inventory. No conclusions yet.
+
+Run real commands and record actual output — never a plausible-sounding guess:
+- `git rev-parse --abbrev-ref HEAD` → branch (or "unavailable")
+- `git rev-parse HEAD` → commit hash (or "unavailable")
+- `git log -1 --format=%cd` → last commit date (or "unavailable")
+- `.sln`/`.csproj` files and target frameworks
+- Project references between projects; package references per project
+  (`dotnet list package` if available)
+- Project types: API, Application, Domain, Infrastructure, Tests, Workers, shared libs
+- Docker files, CI/CD config, migration folders, config file names (never contents if
+  they may hold secrets)
+- Approximate source file counts per project
+
+Do not open `docs/audit/*.md` or any prior findings during this phase — independence
+first, comparison later (Phase 5 handles that explicitly).
+
+## Output
+`.audit-work/00-inventory.md`.
+
+---
+
+# PHASE 1 — Architecture Reconstruction (scratch)
+
+Read Phase 0's output first.
+
+Determine the *actual* architecture from evidence (project references, namespaces, DI
+registrations) — not folder names. Cover: intended vs. actual architecture; the
+dependency graph and any violations (e.g. Domain → Infrastructure); circular
+dependencies, service locator usage, global/static state; SOLID violation candidates
+with concrete file/class evidence (deep pass happens in Phase 2A).
+
+## Output
+`.audit-work/01-architecture.md`.
+
+---
+
+# PHASE 2 — Domain-by-Domain Deep Audit (scratch)
+
+Five sub-phases, each its own session. Each reads Phases 0–1 and appends to
+`.audit-work/02-findings.md` — never overwrite an earlier sub-phase's entries.
+
+### Working note format (use for every finding, all of Phase 2)
+
+Write these as prose with a consistent anchor, the way a finding should read once it
+lands in the final report — not a mechanical 12-field form. At minimum, every entry
+needs an **ID**, a **severity**, **where it lives** (project/file/class/method — real
+line number only if you actually viewed it), what you **observed**, why it **matters**
+(technical + business consequence), and a **concrete recommendation**. Classify each
+one mentally as: confirmed defect, confirmed security issue, architectural weakness,
+maintainability concern, performance concern, best-practice deviation, or design
+trade-off — only report the first six as problems; note a trade-off as context, not a
+defect.
+
+ID prefixes: `C-` critical, `H-` high, `M-` medium, `L-` low — numbered sequentially
+within category as you find them (e.g. C-1, C-2, H-1...).
+
+## Phase 2A — Code Quality & Design
+SOLID (concrete violations, with evidence), DRY/KISS/YAGNI, naming/consistency,
+folder/project structure, dead code, code smells — only where there's real
+maintainability evidence.
+
+## Phase 2B — API, Validation, Error Handling, Logging
+Controllers/Minimal APIs, status codes, DTO leakage, versioning, idempotency.
+Validation: where it lives (syntactic/business/authorization/domain invariant),
+duplication. Error handling: swallowed exceptions, broad catches, centralized
+handling, sensitive-data leakage. Logging: structured logging, correlation IDs,
+whether a production wallet/order failure could actually be diagnosed from what's
+logged.
+
+## Phase 2C — Database, EF Core, Async & Performance
+Tracking behavior, N+1s, missing indexes, transaction boundaries, concurrency control,
+migrations. Async correctness: `.Result`/`.Wait()`, async void, missing
+CancellationToken. Performance: only with plausible evidence. Evaluate whether
+Repository/Unit of Work is needed here specifically, not by default.
+
+## Phase 2D — Security Audit
+AuthN/AuthZ (including per-endpoint resource ownership), secrets handling (location
+only), CORS, CSRF, XSS, SQL injection, file uploads, rate limiting, headers, cookies/
+tokens, mass assignment. For dependency vulnerabilities: actually run
+`dotnet list package --vulnerable` (or equivalent) if available; if not available,
+say so rather than asserting packages are safe from memory. Classify each: theoretical
+concern / probable vulnerability / confirmed vulnerability.
+
+## Phase 2E — Financial / Wallet / Trading Domain Audit
+Highest-stakes section. For every operation that mutates wallet balances, order
+state, or asset holdings, trace explicitly:
+
+```
+Input → Validation → Authorization → Business Rules → State Transition →
+Database Operations → External Operations → Commit → Failure Behavior →
+Retry Behavior → Recovery Behavior
+```
+
+Check specifically: decimal/money precision; race conditions on concurrent requests
+to the same wallet/order; double-spend potential; atomicity (can it partially
+succeed?); idempotency/replay protection; database constraints backing the invariants
+(or their absence); whether a balance can be reconstructed independently of the live
+value; behavior when an external call fails mid-operation.
+
+**Before flagging something as a defect, check whether it might be intentional
+product behavior** (e.g. a commented-out guard that exists because it conflicts with
+a deliberate feature like credit trading). A finding built on inferred intent rather
+than confirmed intent belongs at Medium confidence at most, with the uncertainty
+stated plainly — not asserted as fact.
+
+Identify every operation that can leave the system in an inconsistent financial
+state, with concrete evidence.
+
+---
+
+# PHASE 3 — Cross-Cutting Quality (scratch)
+
+Read all prior `.audit-work/` files. Cover: testability (what's unit-testable vs.
+needs integration/E2E, and why); debuggability (can a wallet/order/auth failure be
+diagnosed quickly from what's logged?); maintainability (size, complexity, coupling);
+extensibility (cost of adding a new asset/order type/integration); modern C#/.NET
+practices, only where adoption genuinely helps.
+
+Also capture **Positive Findings** — strong decisions already in the codebase, why
+they're good, and whether they should become a project-wide standard. This is not a
+criticism-only exercise.
+
+## Output
+`.audit-work/03-cross-cutting.md`.
+
+---
+
+# PHASE 4 — Synthesis (scratch)
+
+Read every `.audit-work/` file, including the full findings list.
+
+- Score each category 0–10 (Architecture, Design Quality, Maintainability,
+  Scalability, Extensibility, Testability, Debuggability, Readability, Consistency,
+  Performance, Security, Reliability, Financial Domain Safety, SOLID, DI, Error
+  Handling, Logging, Validation, Configuration, API Design, Database/EF Core,
+  Concurrency, Observability) — each traceable to specific findings, no false
+  precision.
+- Technical debt by category, with impact/urgency/effort/benefit.
+- Production Readiness %, derived from the count and severity of open Critical/High
+  findings — never invented. An unresolved Critical financial or security finding
+  caps this low; say so explicitly.
+- Refactoring roadmap: Phase 0 (blockers) → Phase 1 (high priority) → Phase 2
+  (structural) → Phase 3 (optimization), plus a separate Quick Wins list.
+- Top strengths, top weaknesses (by risk), top improvements (by Impact × Risk
+  Reduction ÷ Effort — a real security/financial fix outranks a stylistic one
+  regardless of effort).
+- Architecture maturity (1–10) with justification.
+- Overall risk across Security / Financial / Data Integrity / Reliability /
+  Performance / Scalability / Maintainability / Architecture / Operations.
+
+## Output
+`.audit-work/04-synthesis.md`.
+
+---
+
+# PHASE 5 — Archive: Write the Final Report (single file)
+
+## Precondition
+All `.audit-work/00…04` files exist and are internally consistent. Before writing
+anything, check: every finding has severity + evidence; scores trace to findings;
+readiness % reflects open Critical/High items; no fabricated paths/hashes/line
+numbers anywhere; no secret values anywhere.
+
+## Step 1 — detect audit mode
+Look in `docs/audit/` for **any** prior audit file, not just ones matching the
+`AUDIT_YYYY-MM.md` pattern — older files may use different names (e.g.
+`AUDIT_FINDINGS.md`, `RE_AUDIT_2026-08.md`) and are still valid history. If a
+`docs/audit/README.md` index exists, use it to find the most recent one; otherwise
+open each candidate file and use the `**Audit Date**` line inside it to determine
+recency — never assume from filename alone. If no prior audit file exists at all,
+this is an **initial audit**. Otherwise this is a **re-audit**, and the rest of this
+phase changes shape accordingly. After writing the new archived file, also add a row
+for it to `docs/audit/README.md` (create that index if it doesn't exist yet) so the
+next run's detection stays reliable.
+
+## Step 2 (re-audit only) — verify against the code, not the tracker
+Read the most recent prior archived file. For every open finding in it, check the
+*current code*, not issue/PR status — a task board can say "done" while the code
+says otherwise, or vice versa. Also run real verification where possible, e.g.
+`dotnet build <solution>` and `dotnet test <solution>`, and record actual output. If
+a build was incremental rather than clean, say so rather than reporting "no warnings"
+from a build that didn't actually recompile anything — verify with a clean build if
+the distinction matters to what you're reporting.
+
+For each prior finding, classify its current state as one of: **Resolved**,
+**Partial** (say exactly what portion isn't), **Contained** (mitigated at the call
+site or behind a flag, not fixed at the source — say what would undo the
+containment), or **Open**.
+
+**If a prior finding turns out to have been wrong** (inferred from code shape rather
+than confirmed intent, and it turns out intentional) — don't quietly drop it. Mark it
+**Corrected**, dated, with the real explanation, and keep it in the file. This is the
+single most valuable thing your last re-audit did: it kept its own track record
+honest instead of erasing the mistake.
+
+Continue the ID sequence from the prior file for genuinely new findings (`N-1`,
+`N-2`, ...) rather than restarting numbering.
+
+## Step 3 — write `docs/audit/AUDIT_YYYY-MM.md`
+
+One file. Match the header conventions your team has already proven work — adapt as
+needed, but keep this shape:
+
+```markdown
+# Audit — <Month YYYY>
+
+**Audit Date**:
+**Overall Score**: X/10 (was Y/10 on <prior date>, if re-audit)
+**Production Readiness**: XX% (was YY%, if re-audit)
+**Scope**: <what was actually covered — name anything excluded and why>
+
+> This is a stable reference of what this audit found — not a status tracker.
+> Remediation status lives in issues/PRs and the task board, never here. Each
+> finding maps to a task; check that task's branch/PR for current status. Do not
+> edit this file to mark work "done" — write a new dated audit instead.
+
+**Verification performed**: <real commands run and their real output>
+```
+
+Then, in whatever order best serves a reader of *this specific audit* (an initial
+audit and a re-audit will naturally read differently — don't force a rigid section
+list onto both):
+
+- **If re-audit:** a table of prior findings and their current state (Resolved /
+  Partial / Contained / Open / Corrected), then prose detail for anything not simply
+  Resolved — the interesting cases deserve explanation, closed-with-no-nuance ones
+  don't need more than the table row.
+- All findings from this audit (from `.audit-work/02-findings.md`), in prose with the
+  ID/severity/location/evidence/recommendation content from Phase 2 — condense
+  mechanical repetition, keep every piece of evidence.
+- Strengths (carry forward prior strengths that still hold; add new ones).
+- Score table (compare to prior audit if re-audit; explain what moved and why).
+- Roadmap for what's next, prioritized by risk.
+- **A note on this audit's own reliability** — if any findings were corrected in
+  Step 2, or if you're materially uncertain about anything you're reporting as fact,
+  say so here in one short section rather than burying the caveat inline. This
+  doesn't need to be a template; if nothing was corrected, a one-line "no corrections
+  this round" suffices.
+
+Keep the required governance information, but light — a few lines, not a heavy table:
+AI provider and model used (never fabricated — if unavailable, say so explicitly),
+audit date, methodology version, and this line, included once near the top:
+
+> This audit was performed with the assistance of Artificial Intelligence, based on
+> analysis of the source code, configuration, and other repository artifacts within
+> the stated scope. It should be validated by qualified human engineers before
+> critical production, security, financial, or architectural decisions are made.
+
+## No standalone HTML by default
+Don't generate an HTML report as part of this workflow. If a polished, shareable
+version is needed for a specific audience later, generate it on request from the
+archived Markdown at that point — a one-off render, not a second file maintained in
+parallel on every audit run.
+
+## No false certification
+Never state the system is "completely secure," "guaranteed production-ready," or
+"perfect." Use evidence-based phrasing: "The reviewed code does not show evidence
+of...", "no implementation of X was identified within the audited scope,"
+"additional runtime or penetration testing is recommended for confirmation."
+
+---
+
+# GLOBAL RULES (every phase)
+
+- Start independent: don't let a prior archived audit bias Phase 0–4 — those phases
+  build their own picture from the code. Phase 5 is where comparison happens,
+  explicitly and only there.
+- Don't recommend a pattern (Repository, CQRS, DDD, microservices, interfaces
+  everywhere) unless there's a concrete problem it solves in *this* codebase.
+  Absence of a pattern isn't automatically a defect.
+- Don't claim a security or performance issue without evidence; don't fabricate line
+  numbers, branch names, commits, or vulnerability data.
+- Never include a real secret value in any file, scratch or archived, at any
+  severity.
+- A style preference is not an engineering defect — say so explicitly when a finding
+  is a trade-off rather than a problem.

--- a/docs/audit/METHODOLOGY_v4.md
+++ b/docs/audit/METHODOLOGY_v4.md
@@ -1,0 +1,423 @@
+# TallaEgg — Phased Architecture, Security & Production Readiness Audit (v4)
+
+> **Historical — never used to run an audit.** This is one of the drafts between v1 and
+> v7; see [“Where these versions came from”](README.md#where-these-versions-came-from).
+> The current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+## HOW THIS PROMPT WORKS (READ FIRST)
+
+This audit is too large to complete in a single pass — no model can hold an entire
+ASP.NET Core solution in context at once. This version splits the *work* into six
+phases, run as separate sessions inside an agentic coding tool with real filesystem
+access to the repository (e.g. Claude Code operating directly on the repo, not a chat
+with pasted snippets).
+
+**Two different things are kept deliberately separate:**
+
+- **Scratch work (Phases 0–4):** notes each phase needs to hand off to the next.
+  These live under `.audit-work/` and are disposable — add that folder to
+  `.gitignore`. Nobody archives these; they exist only to get you through a multi-
+  session run without re-reading the whole repo every time.
+- **The archive (Phase 5):** exactly **one** dated Markdown file, written to
+  `docs/audit/`. That's the only thing meant to be kept, linked, and diffed over
+  time.
+
+If `.audit-work/` files already exist when you start a phase, treat them as ground
+truth from a previous session — extend them, don't regenerate from scratch. If a
+prior archived audit already exists in `docs/audit/`, Phase 5 runs in **re-audit
+mode** (see below) instead of a fresh initial audit.
+
+**The goal is not the longest possible report.** The goal is an accurate,
+evidence-based Engineering & Production Risk Audit. A shorter report with ten
+well-evidenced findings is worth more than a long one padded with restated style
+preferences. Do not manufacture findings to make a section look thorough.
+
+**Redaction rule (every phase, no exceptions):** never copy a real secret, API key,
+connection string, password, or token into any file — scratch or archived. Describe
+its *shape and location* only, e.g. "hardcoded connection string with embedded
+credentials, `appsettings.json:14`." A finding about a leaked secret must not itself
+leak the secret.
+
+**No fabrication rule (every phase):** every environmental fact — git branch, commit
+hash, framework/package versions, vulnerability data, line numbers — must come from a
+command you actually ran or a file you actually viewed in this session. If a command
+fails or a tool is unavailable, write "unavailable in audit environment." Never guess.
+
+**Language: English only**, in every phase and in the final archived file — including
+code comments you quote and UI text if HTML is ever generated. Don't translate
+identifiers, file paths, namespaces, or code snippets.
+
+---
+
+## INDEPENDENCE — applies to Phases 0 through 4 without exception
+
+Phases 0–4 are where you actually look at the code and form conclusions. During
+these phases:
+
+- Do not open any file under `docs/audit/` (previous audits, findings, scores, TODOs,
+  or prior AI-generated recommendations of any kind).
+- Do not assume a previously reported issue is still present, and do not assume a
+  previously reported issue has been fixed. Every claim in Phases 0–4 comes from code
+  you looked at *this session*, not from memory of a prior report.
+- Do not preserve, anchor to, or discount against a previous score. Score what you
+  find, not what would be a plausible-looking delta from last time.
+
+Comparison against history is real and useful — it happens in **Phase 5 only**, after
+the independent analysis is already locked in. If Phase 5 finds a contradiction
+between what Phases 0–4 concluded and what a prior archived audit said (e.g. a
+finding the prior audit called "open" that current code shows is fixed, or vice
+versa), **current code evidence always wins**. Do not soften or discard your
+independent finding to match the old one. Instead, report the contradiction itself as
+part of the re-audit narrative (see Phase 5) — that contradiction is often the most
+useful thing a re-audit surfaces.
+
+---
+
+# PHASE 0 — Repository Discovery (scratch)
+
+## Task
+Build a factual inventory. No conclusions yet.
+
+Run real commands and record actual output — never a plausible-sounding guess:
+- `git rev-parse --abbrev-ref HEAD` → branch (or "unavailable")
+- `git rev-parse HEAD` → commit hash (or "unavailable")
+- `git log -1 --format=%cd` → last commit date (or "unavailable")
+- `.sln`/`.csproj` files and target frameworks
+- Project references between projects; package references per project
+  (`dotnet list package` if available)
+- Project types: API, Application, Domain, Infrastructure, Tests, Workers, shared libs
+- Docker files, CI/CD config, migration folders, config file names (never contents if
+  they may hold secrets)
+- Approximate source file counts per project
+
+Also flag, without judgment, anything that's a candidate for exclusion from deep
+review: generated code (EF migrations unless specifically inspected, `obj/`, `bin/`,
+scaffolded files), vendored third-party code, and any area a product owner has
+already asked to be out of scope. This list feeds the **Audit Coverage** section in
+Phase 5 — it's not a decision yet, just a flag.
+
+Do not open `docs/audit/*.md` or any prior findings during this phase — see
+INDEPENDENCE above.
+
+## Output
+`.audit-work/00-inventory.md`.
+
+---
+
+# PHASE 1 — Architecture Reconstruction (scratch)
+
+Read Phase 0's output first.
+
+Determine the *actual* architecture from evidence (project references, namespaces, DI
+registrations) — not folder names. Cover: intended vs. actual architecture; the
+dependency graph and any violations (e.g. Domain → Infrastructure); circular
+dependencies, service locator usage, global/static state; SOLID violation candidates
+with concrete file/class evidence (deep pass happens in Phase 2A).
+
+## Output
+`.audit-work/01-architecture.md`.
+
+---
+
+# PHASE 2 — Domain-by-Domain Deep Audit (scratch)
+
+Five sub-phases, each its own session. Each reads Phases 0–1 and appends to
+`.audit-work/02-findings.md` — never overwrite an earlier sub-phase's entries.
+
+### Finding format — mandatory for every significant finding
+
+Every significant finding must follow this exact evidentiary chain, in this order.
+Never make a claim without concrete repository evidence — if you can't fill
+"Evidence" with something you actually viewed, it isn't a finding yet.
+
+```
+Evidence           → what was actually observed in the repo: file, class, method,
+                      real line number only if you directly viewed it, and what the
+                      code actually does (not a paraphrase of what it should do)
+Technical Analysis  → what this means technically — why it's a defect, weakness, or
+                      risk, reasoned from the evidence above
+Risk                → the engineering consequence if left unaddressed
+Business Impact     → the product/financial/user consequence if left unaddressed
+Recommendation      → concrete and actionable — not "improve the architecture"
+Severity            → Critical / High / Medium / Low
+Confidence          → High / Medium / Low — High only when the evidence is complete
+                      and the intent behind the code (see False Positive Control
+                      below) isn't in question
+```
+
+Prefix each finding's ID by severity: `C-` critical, `H-` high, `M-` medium, `L-` low
+— numbered sequentially as found (C-1, C-2, H-1...).
+
+Classify each one mentally as: confirmed defect, confirmed security issue,
+architectural weakness, maintainability concern, performance concern, best-practice
+deviation, or design trade-off — only the first six go in as problems; note a
+trade-off as context, not a defect.
+
+### False Positive Control (read before flagging anything architectural)
+
+The absence of a pattern is not evidence of a problem. Do **not** report the absence
+of Repository, Unit of Work, CQRS, MediatR, DDD tactical patterns, extensive
+interface layers, Minimal APIs, microservices, or any other named pattern as a
+finding **unless** you have concrete evidence, from this codebase, that its absence
+is actually causing a real engineering problem — a test that can't be written, a
+change that requires touching N unrelated files, a bug traceable to the missing
+abstraction. "This is a common pattern and it's missing" is not evidence. "Method X
+can't be unit tested because Y is instantiated directly instead of injected, and
+here's the test I tried to write" is evidence.
+
+## Phase 2A — Code Quality & Design
+SOLID (concrete violations, with evidence), DRY/KISS/YAGNI, naming/consistency,
+folder/project structure, dead code, code smells — only where there's real
+maintainability evidence.
+
+## Phase 2B — API, Validation, Error Handling, Logging
+Controllers/Minimal APIs, status codes, DTO leakage, versioning, idempotency.
+Validation: where it lives (syntactic/business/authorization/domain invariant),
+duplication. Error handling: swallowed exceptions, broad catches, centralized
+handling, sensitive-data leakage. Logging: structured logging, correlation IDs,
+whether a production wallet/order failure could actually be diagnosed from what's
+logged.
+
+## Phase 2C — Database, EF Core, Async & Performance
+Tracking behavior, N+1s, missing indexes, transaction boundaries, concurrency control,
+migrations. Async correctness: `.Result`/`.Wait()`, async void, missing
+CancellationToken. Performance: only with plausible evidence. Evaluate whether
+Repository/Unit of Work is needed here specifically, not by default (False Positive
+Control applies).
+
+## Phase 2D — Security Audit
+AuthN/AuthZ (including per-endpoint resource ownership), secrets handling (location
+only), CORS, CSRF, XSS, SQL injection, file uploads, rate limiting, headers, cookies/
+tokens, mass assignment. For dependency vulnerabilities: actually run
+`dotnet list package --vulnerable` (or equivalent) if available; if not available,
+say so rather than asserting packages are safe from memory. Classify each: theoretical
+concern / probable vulnerability / confirmed vulnerability.
+
+## Phase 2E — Financial / Wallet / Trading Domain Audit
+Highest-stakes section. This is the domain where risk should dominate every other
+consideration in this audit — see the risk-weighting rule in Phase 4. For every
+operation that mutates wallet balances, order state, or asset holdings, trace
+explicitly:
+
+```
+Input → Validation → Authorization → Business Rules → State Transition →
+Database Operations → External Operations → Commit → Failure Behavior →
+Retry Behavior → Recovery Behavior
+```
+
+Check specifically: decimal/money precision; race conditions on concurrent requests
+to the same wallet/order; double-spend potential; atomicity (can it partially
+succeed?); idempotency/replay protection; database constraints backing the invariants
+(or their absence); whether a balance can be reconstructed independently of the live
+value; behavior when an external call fails mid-operation.
+
+**Before flagging something as a defect, check whether it might be intentional
+product behavior** (e.g. a commented-out guard that exists because it conflicts with
+a deliberate feature like credit trading) — this is the False Positive Control rule
+applied to the financial domain specifically, where a wrong finding is most costly. A
+finding built on inferred intent rather than confirmed intent belongs at Medium
+confidence at most, with the uncertainty stated plainly — not asserted as fact.
+
+Identify every operation that can leave the system in an inconsistent financial
+state, with concrete evidence.
+
+---
+
+# PHASE 3 — Cross-Cutting Quality (scratch)
+
+Read all prior `.audit-work/` files. Cover: testability (what's unit-testable vs.
+needs integration/E2E, and why); debuggability (can a wallet/order/auth failure be
+diagnosed quickly from what's logged?); maintainability (size, complexity, coupling);
+extensibility (cost of adding a new asset/order type/integration); modern C#/.NET
+practices, only where adoption genuinely helps.
+
+Also capture **Positive Findings** — strong decisions already in the codebase, why
+they're good, and whether they should become a project-wide standard. This is not a
+criticism-only exercise.
+
+## Output
+`.audit-work/03-cross-cutting.md`.
+
+---
+
+# PHASE 4 — Synthesis (scratch)
+
+Read every `.audit-work/` file, including the full findings list.
+
+### Risk-weighted scoring — apply before assigning any score
+
+TallaEgg is a financial platform; weight accordingly. When scoring categories and
+computing Production Readiness, **Financial Integrity, wallet/balance operations,
+transaction atomicity, concurrency correctness, security/authorization, data
+consistency, and reliability weigh significantly more than naming, formatting, or
+other purely stylistic findings.** A codebase with clean naming and inconsistent
+money-handling is in worse shape than the reverse, and the scores must reflect that
+— don't let a high count of minor style findings pull down a category that's
+otherwise financially sound, and don't let clean style prop up a category that has
+real financial or security risk in it.
+
+**Score calibration (hard constraint):** a category score must not exceed **3/10** if
+it contains any unresolved Critical finding, and must not exceed **5/10** if it
+contains more than one unresolved High-severity finding — regardless of other
+strengths counted in that category. State explicitly, next to each such score, which
+finding(s) triggered the cap.
+
+- Score each category 0–10 (Architecture, Design Quality, Maintainability,
+  Scalability, Extensibility, Testability, Debuggability, Readability, Consistency,
+  Performance, Security, Reliability, Financial Domain Safety, SOLID, DI, Error
+  Handling, Logging, Validation, Configuration, API Design, Database/EF Core,
+  Concurrency, Observability) — each traceable to specific findings, no false
+  precision.
+- Technical debt by category, with impact/urgency/effort/benefit.
+- Production Readiness %, derived from the count and severity of open Critical/High
+  findings — never invented. An unresolved Critical financial or security finding
+  caps this low; say so explicitly.
+- Refactoring roadmap: Phase 0 (blockers) → Phase 1 (high priority) → Phase 2
+  (structural) → Phase 3 (optimization), plus a separate Quick Wins list.
+- Top strengths, top weaknesses (by risk), top improvements (by Impact × Risk
+  Reduction ÷ Effort — a real security/financial fix outranks a stylistic one
+  regardless of effort).
+- Architecture maturity (1–10) with justification.
+- Overall risk across Security / Financial / Data Integrity / Reliability /
+  Performance / Scalability / Maintainability / Architecture / Operations.
+
+## Output
+`.audit-work/04-synthesis.md`.
+
+---
+
+# PHASE 5 — Archive: Write the Final Report (single file)
+
+## Precondition
+All `.audit-work/00…04` files exist and are internally consistent. Before writing
+anything, check: every finding follows the Evidence → Technical Analysis → Risk →
+Business Impact → Recommendation → Severity → Confidence chain; score caps are
+applied and their triggering findings named; readiness % reflects open Critical/High
+items; no fabricated paths/hashes/line numbers anywhere; no secret values anywhere.
+
+## Step 1 — detect audit mode
+Look in `docs/audit/` for **any** prior audit file, not just ones matching the
+`AUDIT_YYYY-MM.md` pattern — older files may use different names and are still valid
+history. If a `docs/audit/README.md` index exists, use it to find the most recent
+one; otherwise open each candidate file and use the `**Audit Date**` line inside it
+to determine recency — never assume from filename alone. If no prior audit file
+exists at all, this is an **initial audit**. Otherwise this is a **re-audit**, and
+the rest of this phase changes shape accordingly. After writing the new archived
+file, also add a row for it to `docs/audit/README.md` (create that index if it
+doesn't exist yet) so the next run's detection stays reliable.
+
+## Step 2 (re-audit only) — verify against the code, not the tracker
+Read the most recent prior archived file. For every open finding in it, check the
+*current code*, not issue/PR status — a task board can say "done" while the code
+says otherwise, or vice versa. Also run real verification where possible, e.g.
+`dotnet build <solution>` and `dotnet test <solution>`, and record actual output. If
+a build was incremental rather than clean, say so rather than reporting "no warnings"
+from a build that didn't actually recompile anything — verify with a clean build if
+the distinction matters to what you're reporting.
+
+For each prior finding, classify its current state as one of: **Resolved**,
+**Partial** (say exactly what portion isn't), **Contained** (mitigated at the call
+site or behind a flag, not fixed at the source — say what would undo the
+containment), or **Open**. Per INDEPENDENCE above, this classification is made by
+comparing your Phase 0–4 findings (already concluded independently) against the
+prior file — never the reverse.
+
+**If a prior finding turns out to have been wrong** (inferred from code shape rather
+than confirmed intent, and it turns out intentional) — don't quietly drop it. Mark it
+**Corrected**, dated, with the real explanation, and keep it in the file.
+
+Continue the ID sequence from the prior file for genuinely new findings (`N-1`,
+`N-2`, ...) rather than restarting numbering.
+
+## Step 3 — write `docs/audit/AUDIT_YYYY-MM.md`
+
+One file. Match the header conventions your team has already proven work — adapt as
+needed, but keep this shape:
+
+```markdown
+# Audit — <Month YYYY>
+
+**Audit Date**:
+**Overall Score**: X/10 (was Y/10 on <prior date>, if re-audit)
+**Production Readiness**: XX% (was YY%, if re-audit)
+**Scope**: <what was actually covered — name anything excluded and why>
+
+> This is a stable reference of what this audit found — not a status tracker.
+> Remediation status lives in issues/PRs and the task board, never here. Each
+> finding maps to a task; check that task's branch/PR for current status. Do not
+> edit this file to mark work "done" — write a new dated audit instead.
+
+**Verification performed**: <real commands run and their real output>
+```
+
+Then, in whatever order best serves a reader of *this specific audit* (an initial
+audit and a re-audit will naturally read differently — don't force a rigid section
+list onto both):
+
+- **Audit Coverage** — what was actually deeply reviewed (name the projects/files/
+  areas), what was only inventoried at a structural level, and what was explicitly
+  excluded and why (generated code, vendored dependencies, product-owner-excluded
+  areas from Phase 0's flags). Be specific enough that a reader knows what this audit
+  does *not* claim to have checked.
+- **If re-audit:** a table of prior findings and their current state (Resolved /
+  Partial / Contained / Open / Corrected), then prose detail for anything not simply
+  Resolved — the interesting cases deserve explanation, closed-with-no-nuance ones
+  don't need more than the table row.
+- All findings from this audit (from `.audit-work/02-findings.md`), condensing the
+  Evidence → Technical Analysis → Risk → Business Impact → Recommendation →
+  Severity → Confidence chain into readable prose — condense mechanical repetition,
+  keep every piece of evidence and the severity/confidence tags.
+- Strengths (carry forward prior strengths that still hold; add new ones).
+- Score table (compare to prior audit if re-audit; explain what moved and why, and
+  name the finding(s) behind any capped score).
+- Roadmap for what's next, prioritized by risk — financial/security/concurrency
+  findings first, regardless of effort, per the risk-weighting rule in Phase 4.
+- **A note on this audit's own reliability** — if any findings were corrected in
+  Step 2, or if you're materially uncertain about anything you're reporting as fact,
+  say so here in one short section rather than burying the caveat inline. If nothing
+  was corrected, a one-line "no corrections this round" suffices.
+
+Keep the required governance information, but light — a few lines, not a heavy table:
+AI provider and model used (never fabricated — if unavailable, say so explicitly),
+audit date, methodology version, and this line, included once near the top:
+
+> This audit was performed with the assistance of Artificial Intelligence, based on
+> analysis of the source code, configuration, and other repository artifacts within
+> the stated scope. It should be validated by qualified human engineers before
+> critical production, security, financial, or architectural decisions are made.
+
+## No standalone HTML by default
+Don't generate an HTML report as part of this workflow. If a polished, shareable
+version is needed for a specific audience later, generate it on request from the
+archived Markdown at that point — a one-off render, not a second file maintained in
+parallel on every audit run.
+
+## No false certification
+Never state the system is "completely secure," "guaranteed production-ready," or
+"perfect." Use evidence-based phrasing: "The reviewed code does not show evidence
+of...", "no implementation of X was identified within the audited scope,"
+"additional runtime or penetration testing is recommended for confirmation."
+
+---
+
+# GLOBAL RULES (every phase)
+
+- Independence is non-negotiable — see INDEPENDENCE above. It applies to Phases 0–4
+  without exception; Phase 5 is the only place comparison against history happens,
+  and current evidence always wins over a prior report when they disagree.
+- False Positive Control — see Phase 2. The absence of a pattern (Repository, CQRS,
+  MediatR, DDD, interfaces, Minimal APIs, microservices, or any other) is never
+  itself a finding; only concrete evidence of a real problem caused by its absence
+  is.
+- Every significant finding follows Evidence → Technical Analysis → Risk → Business
+  Impact → Recommendation → Severity → Confidence. Never claim without concrete
+  repository evidence.
+- Risk outweighs style — see the scoring rule in Phase 4. Financial integrity,
+  concurrency, security, and reliability findings dominate naming/formatting
+  findings in every score and every ranking.
+- Don't claim a security or performance issue without evidence; don't fabricate line
+  numbers, branch names, commits, or vulnerability data.
+- Never include a real secret value in any file, scratch or archived, at any
+  severity.
+- Don't pad the report. A shorter, accurate audit beats a long one with manufactured
+  findings.

--- a/docs/audit/METHODOLOGY_v5.md
+++ b/docs/audit/METHODOLOGY_v5.md
@@ -1,0 +1,220 @@
+# TallaEgg — MVP Audit (v5, one-day version)
+
+> **Historical — never used to run an audit.** This is one of the drafts between v1 and
+> v7; see [“Where these versions came from”](README.md#where-these-versions-came-from).
+> The current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+## WHY THIS VERSION EXISTS
+
+v4 was built for a mature codebase and spreads the work across 10 sessions over
+several days — accurate, but too heavy for an MVP-stage project. This version keeps
+everything that actually protects you from a bad finding (evidence discipline,
+false-positive control, risk-weighted scoring, redaction, independence) and cuts
+everything that was there for scale and long-term process discipline, not accuracy.
+Four sessions, runnable in one working day.
+
+**What's compressed and why it's still safe:**
+- Discovery + architecture merge into one session — for an MVP-sized solution, this
+  is genuinely one sitting of work, not two.
+- Code quality + API/validation/logging + database/performance merge into one
+  session — these are the lower-stakes categories; breadth in one pass beats three
+  separate deep passes at MVP scale.
+- Security + Financial stay their own session, on the stronger model, unmerged with
+  anything else — this is the one place compression would actually be dangerous.
+- Cross-cutting quality, scoring, and the final report merge into one closing
+  session — an MVP doesn't need a separate testability/extensibility deep-dive; a
+  short pass folded into synthesis is enough.
+- The category list to score is cut from 23 down to 6 that actually matter for a
+  pre-launch financial MVP.
+
+If the project outgrows MVP scope later, go back to v4 for a deeper pass — this
+version is deliberately not trying to be the permanent audit process.
+
+---
+
+## RULES THAT DON'T GET LIGHTER (apply to every session)
+
+- **Evidence chain, mandatory for every significant finding:**
+  `Evidence → Technical Analysis → Risk → Business Impact → Recommendation →
+  Severity → Confidence`. No claim without something you actually viewed in the
+  repo this session.
+- **False Positive Control:** the absence of a pattern (Repository, CQRS, DDD,
+  interfaces, microservices, etc.) is never itself a finding — only concrete
+  evidence that its absence causes a real problem is.
+- **Independence:** don't open `docs/audit/` during the working sessions (1–3).
+  Comparison against a prior audit happens only in the final session, and current
+  code evidence always wins if it conflicts with what an old report said.
+- **No fabrication:** git branch/commit, package versions, vulnerability data, line
+  numbers — only from a command you actually ran or a file you actually viewed.
+  Unavailable tool → say "unavailable," never guess.
+- **Redaction:** never copy a real secret/key/connection string/token into any file.
+  Describe its shape and location only.
+- **Risk over style:** Financial Integrity, concurrency, and security findings
+  dominate every score and every ranking. Naming/formatting findings never outrank
+  them regardless of count.
+- **Don't pad.** A short, accurate report beats a long one with manufactured
+  findings — this matters more, not less, for a one-day audit.
+- **Language: English only**, everywhere.
+
+Working notes live in `.audit-work/` (gitignored, disposable). The one thing that
+gets archived is `docs/audit/AUDIT_YYYY-MM.md`.
+
+---
+
+# SESSION 1 — Discovery & Architecture
+
+Run real commands, record actual output, never guess:
+- `git rev-parse --abbrev-ref HEAD`, `git rev-parse HEAD`, `git log -1 --format=%cd`
+  (or "unavailable")
+- `.sln`/`.csproj` files, target frameworks, project references, package references
+  (`dotnet list package` if available)
+- Project types (API/Application/Domain/Infrastructure/Tests/Workers), Docker/CI
+  config, migration folders
+
+Then, from that evidence (not folder names): what architecture is actually
+implemented, the real dependency graph, any direction violations (e.g. Domain →
+Infrastructure), circular dependencies, global/static state.
+
+Flag anything to exclude from deep review (generated code, vendored dependencies,
+anything already out of scope by product decision) — one line each, no elaboration
+needed at MVP scale.
+
+## Output
+`.audit-work/01-discovery-architecture.md`.
+
+---
+
+# SESSION 2 — Code Quality, API & Data Layer
+
+Read Session 1's output first. Cover, in one pass:
+
+- **Code quality:** concrete SOLID violations with evidence, real duplication, dead
+  code, naming inconsistency — only where it has real maintainability impact.
+- **API & validation:** leaked domain/DB models in responses, missing/duplicated
+  validation, swallowed exceptions, sensitive-data leakage in error responses,
+  whether a production failure could actually be diagnosed from what's logged.
+- **Database & performance:** tracking behavior, obvious N+1s, transaction
+  boundaries, missing concurrency control, blocking async calls (`.Result`,
+  `.Wait()`, `async void`) — only report with plausible evidence, not theoretical
+  optimization.
+
+Every finding uses the evidence chain from the rules above. ID prefixes: `C-`
+critical, `H-` high, `M-` medium, `L-` low, numbered as found.
+
+## Output
+`.audit-work/02-code-api-data.md`.
+
+---
+
+# SESSION 3 — Security & Financial Risk
+
+**Switch to the strongest available model for this session — do not compress this
+one further.** This is where a missed or wrong finding costs the most.
+
+## Security
+AuthN/AuthZ (including per-endpoint resource ownership), secrets handling (location
+only), CORS, CSRF, XSS, SQL injection, rate limiting, cookie/token handling. Run
+`dotnet list package --vulnerable` if available; if not, say so rather than
+asserting packages are safe from memory. Classify each finding: theoretical concern
+/ probable vulnerability / confirmed vulnerability.
+
+## Financial / Wallet / Trading
+For every operation that mutates balances, order state, or asset holdings, trace:
+
+```
+Input → Validation → Authorization → Business Rules → State Transition →
+Database Operations → External Operations → Commit → Failure Behavior →
+Retry Behavior → Recovery Behavior
+```
+
+Check: decimal/money precision; race conditions on concurrent requests to the same
+wallet/order; double-spend potential; atomicity of multi-step operations;
+idempotency/replay protection; database constraints backing the invariants (or their
+absence); whether a balance can be reconstructed independently of the live value.
+
+**Before flagging something as a defect, check whether it might be intentional
+product behavior.** A finding built on inferred rather than confirmed intent is
+Medium confidence at most, and say so plainly.
+
+## Output
+`.audit-work/03-security-financial.md`.
+
+---
+
+# SESSION 4 — Cross-Cutting Pass, Synthesis & Report
+
+Read all three prior `.audit-work/` files.
+
+## Quick cross-cutting pass (folded in, not a separate deep dive)
+One short pass: anything that's clearly untestable due to tight coupling, anything
+that would make a production incident hard to diagnose, and genuine strengths worth
+naming — 3–5 bullets each is enough at MVP scale, not an exhaustive category-by-
+category review.
+
+## Scoring (6 categories, not 23)
+Score 0–10, each traceable to specific findings:
+- **Financial Integrity**
+- **Security**
+- **Reliability & Concurrency**
+- **Architecture & Code Quality** (merged — MVP doesn't need these split)
+- **Data Layer & Performance**
+- **Overall**
+
+**Score cap, hard rule:** a category caps at **3/10** with any unresolved Critical
+finding in it, and at **5/10** with more than one unresolved High finding — name the
+finding(s) that triggered the cap next to the score.
+
+**Production Readiness %**, derived from open Critical/High counts, never invented.
+An unresolved Critical financial or security finding caps this low — say so
+explicitly.
+
+**Fix-before-launch list** — the small number of things that must be fixed before
+real money moves through this system, ranked by risk, not effort. This is the
+single most important output of an MVP audit; everything else is secondary.
+
+## Archive: write the single file
+
+Look in `docs/audit/` for a prior audit (any filename, e.g. `AUDIT_FINDINGS.md`,
+`RE_AUDIT_2026-08.md`, or `AUDIT_YYYY-MM.md`) — use `docs/audit/README.md` if it
+exists, otherwise check each file's `**Audit Date**` line. No prior file → initial
+audit. Prior file exists → re-audit: check each of its open findings against
+*current code*, not tracker/issue status, and classify Resolved / Partial /
+Contained / Open. If a prior finding turns out to have been wrong, mark it
+**Corrected** with the real explanation — don't silently drop it. Continue the ID
+sequence for genuinely new findings rather than restarting.
+
+Write `docs/audit/AUDIT_YYYY-MM.md`:
+
+```markdown
+# Audit — <Month YYYY> (MVP scope)
+
+**Audit Date**:
+**Overall Score**: X/10 (was Y/10 on <date>, if re-audit)
+**Production Readiness**: XX% (was YY%, if re-audit)
+**Scope**: <what was covered — name anything excluded>
+
+> This is a stable reference of what this audit found — not a status tracker.
+> Remediation status lives in issues/PRs, never here. Do not edit this file to
+> mark work "done" — write a new dated audit instead.
+
+**Verification performed**: <real commands run and their real output, if any>
+```
+
+Followed by: fix-before-launch list, findings (condensed evidence-chain prose, IDs
+kept), strengths, score table with caps named, and — if re-audit — the prior-findings
+status table plus a one-line note on this audit's own reliability (or "no
+corrections this round").
+
+Add a row to `docs/audit/README.md` (create it if it doesn't exist) so the next run
+can find this one.
+
+No HTML report by default — generate one later, on request, from this file if
+you ever need something polished to hand to someone outside the team.
+
+## No false certification
+Never say the system is "completely secure" or "guaranteed production-ready." Use
+evidence-based phrasing: "no evidence of X was found within the audited scope,"
+"further testing is recommended before relying on this."
+
+## Output
+`docs/audit/AUDIT_YYYY-MM.md` + updated `docs/audit/README.md`.

--- a/docs/audit/METHODOLOGY_v6.md
+++ b/docs/audit/METHODOLOGY_v6.md
@@ -1,0 +1,240 @@
+# TallaEgg — MVP Risk Audit (v6, one-day, single-file)
+
+> **Historical — never used to run an audit.** This is one of the drafts between v1 and
+> v7; see [“Where these versions came from”](README.md#where-these-versions-came-from).
+> The current methodology is [`METHODOLOGY_v8.md`](METHODOLOGY_v8.md).
+
+## WHAT THIS IS
+
+One working day, one archived deliverable: `docs/audit/AUDIT_YYYY-MM.md`. Nothing
+else gets generated — no HTML, no second format. This file is the only thing meant
+to be kept, linked, diffed, and compared across future audits.
+
+**Success criterion:** can we identify the most important risks in this MVP within
+one working day and hand the team a clear, evidence-based list of what must be
+fixed before the next release? Optimize for signal-to-noise, not report length.
+
+---
+
+## PRIORITY ORDER — deeply inspect in this order
+
+1. **Critical security vulnerabilities** — including authentication/authorization
+   bypass on financial resources (IDOR, missing ownership checks on wallet/order
+   endpoints). On a financial platform this is usually the single most damaging bug
+   class, so it isn't split out separately — it's folded into #1, not ranked below
+   business-logic concerns.
+2. Financial / wallet / balance integrity
+3. Transaction atomicity and concurrency
+4. Data integrity and EF Core/database issues
+5. Critical business-logic bugs
+6. Reliability and error handling
+7. Major architectural problems that will make near-term development difficult
+8. Critical testability gaps
+9. Obvious performance problems
+
+## DEPRIORITIZE — skip unless there is concrete evidence of real risk
+
+Minor naming issues, formatting, theoretical SOLID violations, exhaustive code
+smells, stylistic preferences, unnecessary design-pattern recommendations,
+hypothetical scalability concerns, enterprise-level architecture improvements,
+exhaustive line-by-line review, low-impact refactoring. The absence of a popular
+pattern (Repository, CQRS, DDD, microservices, extensive interfaces, etc.) is never
+itself a finding — only concrete evidence that its absence causes a real problem is.
+
+## RISK-BASED SAMPLING — apply in every session
+
+Do not inspect every file with equal depth. Deeply inspect the critical execution
+paths: **Wallet, Order, Transaction, Authentication/Authorization, API boundaries,
+persistence, and any other financially sensitive workflow.** Inspect supporting code
+only as far as needed to understand those paths — a utility class three calls away
+from a wallet mutation gets read to understand the path, not audited line-by-line in
+its own right.
+
+---
+
+## RULES THAT APPLY TO EVERY SESSION
+
+- **Independence:** start from zero. Don't open `docs/audit/` during the working
+  sessions. Don't assume a previously reported issue is still present or already
+  fixed. Don't inherit a previous score. Comparison against history happens only in
+  the final session, and current code evidence always wins if it conflicts with an
+  old report.
+- **Evidence-based, every significant finding:** `Evidence → Analysis → Risk →
+  Recommendation`. No claim without something actually viewed in the repo this
+  session.
+- **No fabrication:** git branch/commit, package versions, vulnerability data, line
+  numbers — only from a command actually run or a file actually viewed. Tool
+  unavailable → say so, never guess.
+- **Redaction:** never copy a real secret/key/connection string/token into any file
+  — describe its shape and location only.
+- **Don't pad.** Fewer, real findings beat a long list padded to look thorough.
+- **Language: English only**, everywhere in the archived file.
+
+Working notes live in `.audit-work/` (gitignored, disposable, never archived).
+
+---
+
+# SESSION 1 — Discovery & Architecture (~30–45 min)
+
+Real commands only, record actual output:
+- `git rev-parse --abbrev-ref HEAD`, `git rev-parse HEAD`, `git log -1 --format=%cd`
+  (or "unavailable")
+- `.sln`/`.csproj` files, target frameworks, project references, package references
+- Project types, Docker/CI config, migration folders
+
+Then map the actual architecture from evidence and flag, in one line each, anything
+out of scope for deep review (generated code, vendored dependencies, anything
+already excluded by product decision).
+
+## Output
+`.audit-work/01-discovery-architecture.md`.
+
+---
+
+# SESSION 2 — Priorities 4–9: Data, Reliability, Architecture, Testability, Performance (~45–60 min)
+
+Read Session 1's output. Apply risk-based sampling: full depth on the financially
+sensitive paths, lighter pass everywhere else.
+
+Cover: EF Core tracking/transactions/missing concurrency control, obvious N+1s;
+critical business-logic bugs found while tracing the critical paths; error handling
+around wallet/order/auth flows (swallowed exceptions, sensitive-data leakage,
+whether a production failure could actually be diagnosed from logs); architectural
+issues that will slow near-term feature work specifically (not enterprise-maturity
+gaps); testability gaps in the critical paths; performance problems only with
+plausible, observed evidence.
+
+Every finding: `Evidence → Analysis → Risk → Recommendation`, plus ID/Severity/
+Location/Confidence/Estimated Effort (see schema below). ID prefixes: `C-`
+critical, `H-` high, `M-` medium, `L-` low, numbered as found.
+
+## Output
+`.audit-work/02-priorities-4-9.md`.
+
+---
+
+# SESSION 3 — Priorities 1–3: Security, Financial Integrity, Concurrency (~45–60 min)
+
+**Switch to the strongest available model — this session doesn't get compressed.**
+
+## Security (Priority 1)
+AuthN/AuthZ with explicit resource-ownership checks on every wallet/order endpoint,
+secrets handling (location only), CORS, CSRF, XSS, SQL injection, rate limiting.
+Run `dotnet list package --vulnerable` if available; if not, say so rather than
+asserting packages are safe from memory. Classify: theoretical concern / probable
+vulnerability / confirmed vulnerability.
+
+## Financial / Wallet / Transaction Integrity (Priorities 2–3)
+For every operation that mutates balances, order state, or asset holdings, trace:
+
+```
+Input → Validation → Authorization → Business Rules → State Transition →
+Database Operations → External Operations → Commit → Failure Behavior →
+Retry Behavior → Recovery Behavior
+```
+
+Check: decimal/money precision; race conditions on concurrent requests to the same
+wallet/order; double-spend potential; atomicity of multi-step operations;
+idempotency/replay protection; database constraints backing the invariants (or their
+absence); whether a balance can be reconstructed independently of the live value.
+
+**Before flagging something as a defect, check whether it might be intentional
+product behavior.** A finding built on inferred rather than confirmed intent is
+Medium confidence at most, stated plainly as uncertain.
+
+## Output
+`.audit-work/03-priorities-1-3.md`.
+
+---
+
+# SESSION 4 — Synthesis & Archive (~30–45 min)
+
+Read all three prior files.
+
+## Finding limits — targets, not a hard ceiling
+Critical: report all identified, no cap. High: aim for the ~10 that matter most —
+if risk-based sampling on the priority paths genuinely surfaces more real, distinct
+High findings, report all of them; never omit a real one or quietly downgrade its
+severity just to fit a number. Medium: same logic, aim for ~10. Low: include only if
+genuinely useful — skip entirely rather than pad.
+
+## Finding schema (every finding in the final report)
+```
+ID           — C-/H-/M-/L- + sequential number
+Severity     — Critical / High / Medium / Low
+Location     — project / file / class / method (real line number only if directly viewed)
+Evidence     — what was actually observed in the code
+Analysis     — why it matters, reasoned from the evidence (fold into the prose)
+Risk         — engineering + business consequence if unaddressed
+Recommendation — concrete and actionable
+Confidence   — High / Medium / Low
+Estimated Effort — Low / Medium / High
+```
+
+## Detect audit mode & compare
+Look in `docs/audit/` for any prior audit file (any name) — use
+`docs/audit/README.md` if it exists, otherwise each file's `**Audit Date**` line.
+No prior file → initial audit. Prior file exists → re-audit: check every open prior
+finding against *current code*, not tracker/issue status; classify Resolved /
+Partial / Contained / Open. If a prior finding turns out to have been wrong, mark it
+**Corrected** with the real explanation rather than silently dropping it. Continue
+the ID sequence for genuinely new findings.
+
+## Write `docs/audit/AUDIT_YYYY-MM.md` — the only deliverable
+
+Required sections, in this order:
+
+1. **Audit Metadata & Disclosure** — who/what performed this audit, stated plainly
+   and near the top, not buried:
+   ```
+   Performed By: <name/role of the person who ran this audit session>
+   AI Provider: <actual provider available in this environment>
+   AI Model: <exact model if available; otherwise "not available in this
+              execution environment" — never fabricated>
+   Audit Date: <real date>
+   Commit / Branch: <real git output, or "unavailable">
+   Audit ID: TALLAEGG-AUDIT-<YYYYMMDD>-<short id>
+   Methodology Version: 6.0 (one-day, single-file)
+   ```
+   Plus, once:
+   > This audit was performed with the assistance of Artificial Intelligence,
+   > based on analysis of the source code, configuration, and other repository
+   > artifacts within the stated scope. It should be validated by qualified human
+   > engineers before critical production, security, financial, or architectural
+   > decisions are made.
+2. **Executive Summary**
+3. **Audit Scope & Coverage** — what was deeply reviewed (the priority paths, by
+   name), what was sampled lightly, what was explicitly excluded and why.
+4. **Progress vs. Previous Audits** — if re-audit: a compact trend table pulling
+   from every archived audit found via `docs/audit/README.md` (date, overall score,
+   production readiness %), so improvement is visible across more than just the
+   immediately previous run; then the prior-findings status table
+   (Resolved/Partial/Contained/Open/Corrected). If initial audit: state plainly
+   "Initial audit — no prior baseline."
+5. **Critical Findings**
+6. **High-Priority Findings**
+7. **Key Positive Findings** — genuine strengths, not a courtesy section; skip if
+   there's nothing real to say.
+8. **Security Assessment**
+9. **Financial & Data Integrity Assessment**
+10. **Architecture Assessment**
+11. **Production/MVP Readiness** — the % and, above it, the actual **fix-before-
+    release list** — this is the section the team will act on first.
+12. **Prioritized Fix Roadmap** — ordered by risk, following the priority order
+    above, not by effort.
+13. **Final Score** — overall + the handful of categories that matter (Security,
+    Financial Integrity, Reliability/Concurrency, Architecture, Data Layer). Any
+    category containing an unresolved Critical caps at 3/10; more than one
+    unresolved High caps it at 5/10 — name the finding that triggered the cap.
+
+## No false certification
+Never say the system is "completely secure" or "guaranteed production-ready." Use
+evidence-based phrasing: "no evidence of X was found within the audited scope,"
+"further testing is recommended before relying on this."
+
+Update `docs/audit/README.md` with a row for this run (create it if it doesn't
+exist) — this is what makes the next audit's trend table and mode-detection work.
+
+## Output
+`docs/audit/AUDIT_YYYY-MM.md` (the only archived deliverable) +
+updated `docs/audit/README.md`.

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -64,6 +64,24 @@ asks for.
 Scope has also varied: the August pass excluded the **Affiliate** service at the product
 owner's request, and v7 keeps that exclusion.
 
+## Where these versions came from
+
+The numbered prompts in this directory are the working history of how this project learned to
+audit itself. They are archived so that a score can be read next to the method that produced
+it.
+
+- **[v1](METHODOLOGY_v1.md)** produced the 2026-07-08 audit.
+- **[v2](METHODOLOGY_v2.md)–[v6](METHODOLOGY_v6.md)** were drafted with the help of several
+  models — GPT-5.3, Claude Sonnet 5, Claude Fable 5 and Claude Opus 5 — each reviewing and
+  revising the version before it across several rounds. **None of them was ever used to run an
+  audit.** They are the iteration, not the instrument, and each carries a banner saying so.
+- **[v7](METHODOLOGY_v7.md)** is where that process settled, and the version the team decided
+  to audit with. It produced the 2026-08-29 audit.
+- **[v8](METHODOLOGY_v8.md)** is current, written from what that audit got wrong.
+
+So the jump from v1 to v7 in the trend table is not missing history: two versions have ever
+produced an audit, and the 2026-08-26 run used none at all.
+
 ## Why the methodology keeps changing
 
 Each version answers failures found in the run before it, so the version column above is also

--- a/docs/process/INDEX.md
+++ b/docs/process/INDEX.md
@@ -48,6 +48,7 @@ docs/
 │   ├── METHODOLOGY_v8.md          ← How the next audit is run (current methodology)
 │   ├── METHODOLOGY_v7.md          ← Retired; kept because AUDIT_2026-08b.md was run under it
 │   ├── METHODOLOGY_v1.md          ← The original July prompt, archived for comparability
+│   ├── METHODOLOGY_v2–6.md         ← Drafts between v1 and v7; none was ever run
 │   ├── AUDIT_2026-07.md           ← July 2026 audit — English summary
 │   ├── AUDIT_2026-07.html         ← July 2026 audit — full report (Farsi)
 │   ├── AUDIT_2026-08.md           ← August 2026 re-audit


### PR DESCRIPTION
**Branch Name**: `feat/archive-methodology-v2-to-v6`
**Linked Issue/Task**: follows #164, #165, #166

## Description

The trend table jumped from v1 to v7 with nothing in between, which read as missing history.
It was not. v2–v6 are drafts that were argued over and never run; they are now archived, with
a section in `docs/audit/README.md` recording where they came from.

## Type of Change

- [x] Documentation (docs/comments only)

## Changes Made

- `docs/audit/METHODOLOGY_v2.md` … `METHODOLOGY_v6.md` — the five drafts, supplied by the
  product owner, unaltered apart from the banner below
- `docs/audit/README.md` — a "Where these versions came from" section
- `docs/process/INDEX.md` — tree updated

Each of v2–v6 gets a three-line banner marking it historical and pointing at v8. Without it
they read as live instructions: nothing inside `METHODOLOGY_v4.md` tells a reader not to run
it, and running the wrong one would be an easy and expensive mistake.

## Where they came from

Written with the help of **GPT-5.3, Claude Sonnet 5, Claude Fable 5 and Claude Opus 5**, each
reviewing and revising the version before it across several rounds, until the process settled
at v7 — the version the team decided to audit with.

So two versions have ever produced an audit: v1 and v7. The 2026-08-26 run used none (#165).

## The lineage is legible in the files

Worth reading in order, because it is a compact record of what this project learned:

- **v2–v4** — six phases across ten sessions, 23 scored categories, HTML *and* Markdown
  deliverables. Built for a mature codebase. v4 adds the score caps and False Positive Control
  that survive into v8 today.
- **v5** — compresses to four sessions for MVP scale, cuts the category list from 23 to 6,
  and states plainly what was compressed and why each compression is still safe.
- **v6** — drops the second deliverable and settles on one archived Markdown file.
- **v7** — reviewed and rewritten from v6 in #154, and actually run.

## Testing Completed

Documentation only.

- All five files were read in full before committing. They are English throughout, contain no
  names, handles, URLs, absolute user paths, chat timestamps or credential values; the matches
  for "secret" and "token" are their own redaction rules.
- The staged diff was scanned for the same patterns: clean.
- All relative links across the 26 markdown files under `docs/` plus `AGENT.md` and
  `CLAUDE.md` resolve.

## Known issues not addressed

The pre-existing broken link in `docs/pull-requests/PR_TASK-003_QUARANTINE_STUBS.md` is still
there — unrelated, noted in #154.

## Deployment / Rollback

No runtime impact. Rollback is `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
