### PR TITLE
[Chore] Fix five housekeeping items from the August 29 audit — Issue #161

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
   

--- a/src/Affiliate/Affiliate.Api/Affiliate.Api.csproj
+++ b/src/Affiliate/Affiliate.Api/Affiliate.Api.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
 </Project> 

--- a/src/Order/Orders.Api/Orders.Api.csproj
+++ b/src/Order/Orders.Api/Orders.Api.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -297,10 +297,10 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             
             while (matchCount < maxMatches && !cancellationToken.IsCancellationRequested)
             {
-                // Get locked orders for this asset
-                // Fetch this asset's orders under a database lock.
-                var buyOrders = await matchingRepository.GetBuyOrdersWithLockAsync(asset);
-                var sellOrders = await matchingRepository.GetSellOrdersWithLockAsync(asset);
+                // Get this asset's orders for matching
+                // Fetch this asset's buy and sell orders.
+                var buyOrders = await matchingRepository.GetBuyOrdersAsync(asset);
+                var sellOrders = await matchingRepository.GetSellOrdersAsync(asset);
 
                 if (!buyOrders.Any() || !sellOrders.Any())
                 {
@@ -395,7 +395,7 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             if (incomingOrder.Side == OrderSide.Buy)
             {
                 // For buy orders, find sell orders with price <= buy price
-                var sellOrders = await matchingRepository.GetSellOrdersWithLockAsync(incomingOrder.Asset);
+                var sellOrders = await matchingRepository.GetSellOrdersAsync(incomingOrder.Asset);
                 return sellOrders
                     .Where(s => s.Price <= incomingOrder.Price && s.RemainingAmount > 0)
                     .Where(s => IsAllowedCounterparty(incomingOrder, s))
@@ -404,7 +404,7 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             else
             {
                 // For sell orders, find buy orders with price >= sell price
-                var buyOrders = await matchingRepository.GetBuyOrdersWithLockAsync(incomingOrder.Asset);
+                var buyOrders = await matchingRepository.GetBuyOrdersAsync(incomingOrder.Asset);
                 return buyOrders
                     .Where(b => b.Price >= incomingOrder.Price && b.RemainingAmount > 0)
                     .Where(b => IsAllowedCounterparty(incomingOrder, b))

--- a/src/Order/Orders.Infrastructure/Configurations/QuoteConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/QuoteConfiguration.cs
@@ -13,10 +13,14 @@ public class QuoteConfiguration : IEntityTypeConfiguration<Quote>
 
         builder.Property(q => q.Symbol).IsRequired().HasMaxLength(20);
 
-        // Price precision must match the Orders.Price column exactly: decimal(18,2).
+        // Kept at decimal(18,2). #146 widened the Orders.Price column itself to decimal(28,8), so
+        // this no longer needs to match the column exactly — Orders.Price can hold more precision
+        // than a quote produces. It stays narrower here because nothing that creates a quote emits
+        // more than 2 decimal places today.
         //
-        // A quote price becomes an order price directly. If the quote carried more precision, it
-        // would recreate the discrepancy behind issue #52: the lock computed from one price and
+        // A quote price becomes an order price directly, so if this property carried more
+        // precision than Orders.Price could hold, storing it would silently round on the way in —
+        // the discrepancy behind issue #52, where the lock was computed from one price and
         // settlement from a differently-rounded one.
         builder.Property(q => q.BuyPrice).IsRequired().HasPrecision(18, 2);
         builder.Property(q => q.SellPrice).IsRequired().HasPrecision(18, 2);

--- a/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
+++ b/src/Order/Orders.Infrastructure/OrderMatchingRepository.cs
@@ -10,8 +10,9 @@ using TallaEgg.Core.Enums.Order;
 namespace Orders.Infrastructure;
 
 /// <summary>
-/// Repository with Database Locking for Thread-Safe Order Matching
-/// Repository that uses database locking to match orders safely.
+/// Repository for order matching. Thread safety comes from the optimistic concurrency token
+/// on <see cref="Order.RemainingAmount"/>, checked in <see cref="ExecuteAtomicMatchAsync"/> —
+/// not from any database lock taken here.
 /// </summary>
 public class OrderMatchingRepository
 {
@@ -25,10 +26,11 @@ public class OrderMatchingRepository
     }
 
     /// <summary>
-    /// Get buy orders with pessimistic lock for atomic matching
-    /// Fetches buy orders under a mutual lock, for atomic matching.
+    /// Fetches confirmed buy orders for matching, ordered by price-time priority.
+    /// No lock is taken here — the actual concurrency guard is the optimistic concurrency
+    /// token on <see cref="Order.RemainingAmount"/>, applied in <see cref="ExecuteAtomicMatchAsync"/>.
     /// </summary>
-    public async Task<List<Order>> GetBuyOrdersWithLockAsync(string asset)
+    public async Task<List<Order>> GetBuyOrdersAsync(string asset)
     {
         try
         {
@@ -54,10 +56,11 @@ public class OrderMatchingRepository
     }
 
     /// <summary>
-    /// Get sell orders with pessimistic lock for atomic matching
-    /// Fetches sell orders under a mutual lock, for atomic matching.
+    /// Fetches confirmed sell orders for matching, ordered by price-time priority.
+    /// No lock is taken here — the actual concurrency guard is the optimistic concurrency
+    /// token on <see cref="Order.RemainingAmount"/>, applied in <see cref="ExecuteAtomicMatchAsync"/>.
     /// </summary>
-    public async Task<List<Order>> GetSellOrdersWithLockAsync(string asset)
+    public async Task<List<Order>> GetSellOrdersAsync(string asset)
     {
         try
         {

--- a/src/TallaEgg/TallaEgg.Api/TallaEgg.Api.csproj
+++ b/src/TallaEgg/TallaEgg.Api/TallaEgg.Api.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
 </Project>

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -284,7 +284,9 @@ namespace TallaEgg.Core
         }
 
         /// <summary>
-        /// The storage precision of an order price. The Orders.Price column is decimal(18,2).
+        /// The storage precision of an order price. Independent of the Orders.Price column
+        /// itself, which #146 widened to decimal(28,8); this is an application-level cap, not a
+        /// mirror of the column.
         /// </summary>
         public const int OrderPriceDecimalPlaces = 2;
 

--- a/src/User/Users.Api/Users.Api.csproj
+++ b/src/User/Users.Api/Users.Api.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
 </Project> 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -10,7 +10,6 @@ using TallaEgg.Core.Cors;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
-using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Requests.Trade;
 using TallaEgg.Core.Requests.Wallet;
@@ -326,14 +325,3 @@ static string ResolveSharedConfigPath(Microsoft.Extensions.Hosting.IHostEnvironm
 
 
 app.Run();
-
-// Request models
-public record WithdrawRequest(Guid UserId, string Asset, decimal Amount, string? ReferenceId = null);
-public record ChargeRequest(Guid UserId, string Asset, decimal Amount, string? PaymentMethod = null);
-public record TransferRequest(Guid FromUserId, Guid ToUserId, string Asset, decimal Amount);
-public record CreditRequest(Guid UserId, string Asset, decimal Amount);
-public record DebitRequest(Guid UserId, string Asset, decimal Amount);
-
-// Market order balance request models
-public record ValidateBalanceRequest(Guid UserId, string Asset, decimal Amount, OrderSide orderSide); // 0 = Buy, 1 = Sell
-public record UpdateBalanceRequest(Guid UserId, string Asset, decimal Amount, OrderSide orderSide, Guid OrderId); // 0 = Buy, 1 = Sell

--- a/src/Wallet/Wallet.Api/Wallet.Api.csproj
+++ b/src/Wallet/Wallet.Api/Wallet.Api.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="C:\Users\shahi\Documents\GitHub\TallaEgg\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
+    <Content Update="..\..\..\config\appsettings.global.json" Link="Properties\appsettings.global.json" />
   </ItemGroup>
 
 </Project> 

--- a/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
@@ -156,7 +156,7 @@ public class DealerModeSkipsBackgroundMatchingTests : IDisposable
     ///
     /// <para>
     /// <b>Why:</b> the order-book query cannot run under SQLite —
-    /// <c>GetSellOrdersWithLockAsync</c> orders by <c>Price</c>, and SQLite raises
+    /// <c>GetSellOrdersAsync</c> orders by <c>Price</c>, and SQLite raises
     /// <c>NotSupportedException: SQLite does not support expressions of type 'decimal' in ORDER
     /// BY clauses</c>. Verified directly, not assumed. Production uses SQL Server, where it is
     /// fine. So "a trade appears" is not reachable here, but "the engine reached the order

--- a/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
@@ -53,7 +53,7 @@ public class PendingOrderNotMatchableTests : IDisposable
         return order;
     }
 
-    // A note on coverage: GetBuyOrdersWithLockAsync and GetSellOrdersWithLockAsync are not tested
+    // A note on coverage: GetBuyOrdersAsync and GetSellOrdersAsync are not tested
     // directly here, because they sort with OrderBy(o => o.Price) and SQLite does not support
     // ordering on decimal, which is fine on SQL Server. Both use the same shared Matchable
     // expression that the GetActiveAssetsAsync test below covers. This is a limitation of the test


### PR DESCRIPTION
## Description
Fixes five unrelated, low-severity items collected in `docs/audit/AUDIT_2026-08b.md` §10. None affects correctness; done in one pass per the issue's own framing.

## Issue/Task Reference
Closes #161

## Changes Made
- **Absolute paths**: the six `.csproj` files (`Affiliate.Api`, `Orders.Api`, `TallaEgg.Api`, `Users.Api`, `Wallet.Api`, `TallaEgg.TelegramBot.Infrastructure`) hardcoded `C:\Users\shahi\...` in a `<Content Update>` path for `appsettings.global.json`. Made relative to each project's own location instead.
- **Stale precision comments**: `QuoteConfiguration.cs` and `CurrenciesConstant.cs` both still described the `Orders.Price` column as `decimal(18,2)`; #146 widened it to `(28,8)`. Corrected both comments to state the current column precision and explain why `Quote.BuyPrice/SellPrice` and `OrderPriceDecimalPlaces` intentionally stay at 2dp (an application-level choice, not a mirror of the column) rather than changing any actual precision value.
- **Misleading lock names**: `GetBuyOrdersWithLockAsync`/`GetSellOrdersWithLockAsync` take no lock — the real concurrency guard is the optimistic concurrency token checked in `ExecuteAtomicMatchAsync`. Renamed to `GetBuyOrdersAsync`/`GetSellOrdersAsync`, updated their doc comments and the class-level summary (which made the same claim), and updated all call sites in `MatchingEngineService.cs` and references in two test files.
- **Dead code**: removed the unused request records (`WithdrawRequest`, `ChargeRequest`, `TransferRequest`, `CreditRequest`, `DebitRequest`, `ValidateBalanceRequest`, `UpdateBalanceRequest`) at the bottom of `Wallet.Api/Program.cs` — confirmed via repo-wide grep that none is referenced anywhere — along with the now-unused `using TallaEgg.Core.Enums.Order;`. Also deleted `src/Wallet/Wallet.Tests`, which contained only `bin/`/`obj/` and nothing git-tracked.
- **AsNoTracking (item 5)**: assessed, not applied. The only read queries this PR touches are `GetBuyOrdersAsync`/`GetSellOrdersAsync`, whose returned entities are later passed into `ExecuteAtomicMatchAsync`, which relies on them being tracked by the same `DbContext` to reload/re-check them before a trade. Marking them `AsNoTracking` would change that coupling in financial matching code — out of scope for a no-behavior-change pass. Per the issue: no sweep, only where safely applicable, and this wasn't.

## Testing
- [x] `dotnet build TallaEgg.sln` — 0 warnings, 0 errors
- [x] `dotnet test tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj` — 501/501 passing (unchanged; this is a no-behavior-change cleanup pass, so no new tests were added)
- [ ] No secrets/tokens in diff

## Security Checklist
- [x] No hardcoded credentials
- [x] No SQL injection vulnerabilities
- [x] Input validation present (unchanged)

## Deployment Notes
No migrations, no config changes, no behavior changes. Safe to deploy with no special steps.