### PR TITLE
[Chore] Add run-tallaegg agent skill

### DIFF
--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: run-tallaegg
+description: Build, run, and drive the TallaEgg backend (Users/Wallet/Orders APIs plus the Telegram bot's own handlers) end to end without a live Telegram connection. Use when asked to start TallaEgg, run the services, smoke-test the bot, generate sample trading data, or verify a change actually works against the running app rather than just its unit tests.
+---
+
+TallaEgg is a Telegram bot (Persian-language gold trading) backed by three ASP.NET Core
+microservices (Users.Api, Wallet.Api, Orders.Api) and SQL Server, one database per service.
+There is no GUI to screenshot and no live Telegram connection available outside a real bot
+token — the agent path here is `.claude/skills/run-tallaegg/driver.ps1`, a thin wrapper that
+builds the solution, launches the three APIs, and drives them through
+**`TelegramBot.TallaEgg.TelegramBot.Simulator`** — a project the repo already ships, which
+replays real bot conversations (registration, admin approval, quote publishing, quote-fill
+trades, menu navigation) through the real `IBotHandler` and the real APIs/database, faking
+only the Telegram transport itself. That is the interaction surface: not a browser, not a
+window, a conversation replayed through the actual handler code.
+
+All paths below are relative to the repo root (`TallaEgg.sln`'s directory), not to this skill
+directory. The driver is Windows PowerShell (`powershell.exe`, not `pwsh`) — this project's
+native dev environment is Windows with a local SQL Server Express instance, per `AGENT.md`.
+
+## Prerequisites
+
+- .NET 9 SDK (`dotnet --version` -> `9.x`)
+- A reachable SQL Server instance. On a normal dev box this is SQL Server Express
+  (`Server=localhost\SQLEXPRESS`, Windows integrated auth) — confirm it's running:
+
+  ```powershell
+  Get-Service | Where-Object { $_.Name -like '*SQL*' } | Select-Object Name, Status
+  # -> MSSQL$SQLEXPRESS  Running
+  ```
+
+  Any reachable SQL Server works; only the connection strings in the config below need to match.
+
+## Setup
+
+`config/appsettings.global.json` is git-ignored (it holds live credentials — never commit it)
+and every service reads its own section from it. If it doesn't exist yet, create it from the
+template and point the four connection strings at your SQL Server:
+
+```powershell
+Copy-Item config/appsettings.global.example.json config/appsettings.global.json
+# then edit ConnectionStrings:{UsersDb,WalletDb,OrdersDb,AffiliateDb} to a real server
+```
+
+Each API runs its own EF Core migrations at startup (`context.Database.MigrateAsync()`), so
+there is no separate migrate step — an empty/nonexistent database is created and schema'd the
+first time `driver.ps1 start` launches it.
+
+The Simulator's config section (`Services:TallaEgg.TelegramBot.Infrastructure`) needs a
+syntactically-present `TelegramBotToken`, but it is never dialed for this path — the Simulator
+only constructs a `TelegramBotClient` and never calls `StartReceiving`/`GetMe`. The example
+file's placeholder (`REPLACE_WITH_TEST_BOT_TOKEN_FROM_BOTFATHER`) is fine as-is; verified by
+running the smoke test with exactly that value in place.
+
+## Build
+
+```powershell
+dotnet build TallaEgg.sln --configuration Release
+# -> Build succeeded. 0 Warning(s) 0 Error(s)
+```
+
+(`driver.ps1 start`, below, does this for you — this is only if you want the build on its own.)
+
+## Run (agent path)
+
+Everything goes through `driver.ps1`:
+
+```powershell
+& .claude/skills/run-tallaegg/driver.ps1 start    # build + launch Users/Wallet/Orders, wait for health
+& .claude/skills/run-tallaegg/driver.ps1 status    # confirm what's listening
+& .claude/skills/run-tallaegg/driver.ps1 smoke     # the actual interaction — see below
+& .claude/skills/run-tallaegg/driver.ps1 stop      # stop whatever is listening on the 3 ports
+```
+
+`start` builds in Release, launches the three APIs as background processes (stdout/stderr
+redirected to `run-logs/<service>.{out,err}.log`), and polls each service's Swagger page
+(`/api-docs/index.html`) until all three answer 200 or 60 seconds pass. On timeout it prints
+the last 40 lines of each service's stderr log and throws.
+
+`smoke` is the real interaction. With no arguments it runs a small simulation
+(`--users 5 --quotes 5 --trades 10 --seed 1`): registers 5 fake Telegram users through the real
+`/start` + contact-share flow, promotes one to admin, has admin approve/reject the rest, funds
+wallets, publishes quotes through the real `18500000-18550000`-style text command, fills trades
+by quote acceptance, and clicks through the help/history/balance menu buttons — end to end,
+through the real handler and API code, against the real database. Pass your own args through
+after `smoke`:
+
+```powershell
+& .claude/skills/run-tallaegg/driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
+```
+
+A clean run ends with a line like:
+
+```
+=== Done in 00:00:10.26. Registered 5 (4 approved), trades attempted 10, errors 0 ===
+```
+
+`errors 0` is the thing to check. Every simulated user has `TelegramId < 0`, and each run's
+first phase (`DataReset`) wipes only rows with `TelegramId < 0` before it starts, so re-running
+`smoke` repeatedly against the same database is safe and self-cleaning — it can never touch a
+real (positive-id) user's data.
+
+Verified end-to-end on this machine, twice (bash-launched and PowerShell-launched), against a
+real local SQL Server Express instance — both runs finished with `errors 0` and left queryable
+data behind, confirmed via:
+
+```powershell
+Invoke-RestMethod http://localhost:5140/api/orders/MAUA/IRT/best-prices
+# -> {"Success":true,"Message":"...","Data":{"Symbol":"MAUA/IRT","BestBidPrice":...,"BestAskPrice":...}}
+```
+
+## Direct invocation (no bot layer)
+
+Most PRs in this repo touch one service's API or business logic, not the bot conversation. For
+that, skip the Simulator and hit the running API directly — the three Swagger UIs
+(`http://localhost:5136/api-docs`, `:60933/api-docs`, `:5140/api-docs`) list every route. Example:
+
+```powershell
+Invoke-RestMethod http://localhost:5140/api/symbols/active
+# -> {"Success":true,"Message":null,"Data":["MAUA/IRT","SEKE_BAHAR/IRT","BTC/IRT"]}
+```
+
+## Run (human path)
+
+`dotnet run --project src/User/Users.Api/Users.Api.csproj` (etc., one per terminal) — the same
+thing `driver.ps1 start` does, but blocking and in the foreground. See `AGENT.md` for the full
+per-service list, including the bot itself (`TelegramBot/TallaEgg.TelegramBot.Infrastructure`),
+which `driver.ps1` deliberately does not launch — it needs a real, valid Telegram bot token and
+outbound access to `api.telegram.org`, neither of which this driver path requires.
+
+## Test
+
+```powershell
+dotnet test tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj --no-build
+# -> Passed! Failed: 0, Passed: 501, Skipped: 0, Total: 501
+```
+
+Unit tests are a sanity check; `smoke` above is what actually proves the running system works.
+
+---
+
+## Gotchas
+
+- **`pwsh` doesn't exist here — use `powershell.exe`/`& driver.ps1`.** This box only has Windows
+  PowerShell 5.1, not PowerShell Core. `pwsh -File driver.ps1 ...` fails with "term not
+  recognized"; invoke the script directly (`& .claude/skills/run-tallaegg/driver.ps1 start`).
+- **`dotnet test` alone can run against a stale `bin`.** It only builds the test project's own
+  dependency graph — per `AGENT.md`, always `dotnet build TallaEgg.sln` (which `driver.ps1
+  start` does) before relying on `--no-build` anywhere.
+- **The "User not found" 400 warnings during `smoke`'s registration phase are expected, not
+  errors.** `UsersApiClient` logs a warning every time it looks up a Telegram id that doesn't
+  exist yet — which is every new simulated user, by construction, right before it's created.
+  The simulation's own error counter (`errors 0` in the final summary line) is what indicates
+  real failure; the interleaved warnings are noise from a normal existence check.
+- **`Start-Process dotnet -ArgumentList 'run',...` outlives the parent shell if you don't track
+  it.** `driver.ps1 stop` doesn't rely on remembered PIDs for this reason — it resolves the
+  *current* `OwningProcess` for each of the three ports via `Get-NetTCPConnection` and kills
+  that, so it works even if the shell that ran `start` already exited.
+- **Orders.Api calling Wallet/Users before they're listening just logs noisy (harmless)
+  connection-refused warnings, not a failure** — `driver.ps1 start` gives Users a 3-second head
+  start before launching Orders for exactly this reason, but a slow machine can still race it;
+  the readiness poll at the end catches that regardless.
+
+## Troubleshooting
+
+- **`config/appsettings.global.json is missing`** (thrown by `driver.ps1 start`): copy
+  `config/appsettings.global.example.json` to that path first — see Setup above. It's
+  git-ignored on purpose (`CLAUDE.md`: never commit it, it holds live credentials).
+- **`Timed out waiting for Users/Wallet/Orders APIs to report healthy.`**: `driver.ps1` prints
+  the last 40 lines of each `run-logs/*.err.log` when this happens. In practice this has meant
+  either SQL Server isn't reachable (check the `Get-Service` command under Prerequisites) or a
+  connection string in `config/appsettings.global.json` points at the wrong server/database.
+- **A previous `smoke` run's data is still there and you want a clean slate without running a
+  new simulation**: there's no standalone reset command — `smoke`'s Phase 0 always resets
+  first, so running `smoke --users 1 --quotes 1 --trades 1` is the cheapest way to wipe
+  previously-simulated (`TelegramId < 0`) rows on demand.

--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -38,7 +38,9 @@ and every service reads its own section from it. If it doesn't exist yet, create
 template and point the four connection strings at your SQL Server:
 
 ```powershell
-Copy-Item config/appsettings.global.example.json config/appsettings.global.json
+# -NoClobber matters: the file is untracked (issue #33), so overwriting a real one destroys
+# live connection strings, bot token and OwnerTelegramIds with no git copy to recover from.
+Copy-Item config/appsettings.global.example.json config/appsettings.global.json -NoClobber
 # then edit ConnectionStrings:{UsersDb,WalletDb,OrdersDb,AffiliateDb} to a real server
 ```
 
@@ -72,22 +74,32 @@ Everything goes through `driver.ps1`:
 & .claude/skills/run-tallaegg/driver.ps1 stop      # stop whatever is listening on the 3 ports
 ```
 
-`start` builds in Release, launches the three APIs as background processes (stdout/stderr
-redirected to `run-logs/<service>.{out,err}.log`), and polls each service's Swagger page
-(`/api-docs/index.html`) until all three answer 200 or 60 seconds pass. On timeout it prints
-the last 40 lines of each service's stderr log and throws.
+`start` refuses to run if any of the three ports is already listening (tell it `stop` first —
+otherwise the new processes die on "address already in use" while the health poll answers 200
+from the old ones), builds in Release and **throws if the build fails**, launches the three
+APIs as background processes (stdout/stderr redirected to `run-logs/<service>.{out,err}.log`),
+and polls each service's Swagger page (`/api-docs/index.html`) until all three answer 200 or 60
+seconds pass. On timeout it prints the last 40 lines of *both* logs per service and throws.
 
 `smoke` is the real interaction. With no arguments it runs a small simulation
 (`--users 5 --quotes 5 --trades 10 --seed 1`): registers 5 fake Telegram users through the real
 `/start` + contact-share flow, promotes one to admin, has admin approve/reject the rest, funds
 wallets, publishes quotes through the real `18500000-18550000`-style text command, fills trades
 by quote acceptance, and clicks through the help/history/balance menu buttons — end to end,
-through the real handler and API code, against the real database. Pass your own args through
-after `smoke`:
+through the real handler and API code, against the real database. Override any subset of the
+knobs after `smoke` — the ones you don't name keep the small defaults above (the driver merges
+them; passing them straight through would drop to the Simulator's own compiled defaults of 100
+users / 120 quotes / **1000 trades**, so `smoke --seed 7` alone would be a hundred-fold bigger
+run than it looks):
 
 ```powershell
 & .claude/skills/run-tallaegg/driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
+& .claude/skills/run-tallaegg/driver.ps1 smoke --trades 50    # 5 users, 5 quotes, 50 trades, seed 1
 ```
+
+`--users` must be at least 2: user #0 is promoted to admin and is the counterparty to every
+fill, so it can never trade with itself, and a 1-user run ends `errors 1` with "No approved
+users to trade with."
 
 A clean run ends with a line like:
 
@@ -95,14 +107,33 @@ A clean run ends with a line like:
 === Done in 00:00:10.26. Registered 5 (4 approved), trades attempted 10, errors 0 ===
 ```
 
-`errors 0` is the thing to check. Every simulated user has `TelegramId < 0`, and each run's
-first phase (`DataReset`) wipes only rows with `TelegramId < 0` before it starts, so re-running
-`smoke` repeatedly against the same database is safe and self-cleaning — it can never touch a
-real (positive-id) user's data.
+`errors 0` is the thing to check, and the driver checks it for you — the Simulator itself always
+exits 0 no matter how much failed, so `driver.ps1 smoke` parses that summary line and throws if
+the count isn't zero or the line never appeared.
 
-Verified end-to-end on this machine, twice (bash-launched and PowerShell-launched), against a
-real local SQL Server Express instance — both runs finished with `errors 0` and left queryable
-data behind, confirmed via:
+### What a run changes on the database
+
+- **Rows with `TelegramId < 0`.** Every simulated user is in that range, and each run's first
+  phase (`DataReset`) wipes only that range before starting, so repeated runs are self-cleaning
+  and a real (positive-id) user's data is never touched.
+- **The auto-quote flag for `MAUA/IRT`.** The Simulator turns it off in Phase 2 — a background
+  publisher replacing the run's quotes breaks quote-fill trades — and never turns it back on.
+  That is per-symbol Orders-DB state, not `TelegramId`-scoped, so `DataReset` does not restore
+  it. **`driver.ps1 smoke` reads the flag before the run and puts it back afterwards**, including
+  when the run fails part-way. If the restore itself fails the driver says so; turn it back on
+  from the bot with the admin command `اتومات روشن`, or:
+
+  ```powershell
+  Invoke-RestMethod -Method Post -ContentType 'application/json' `
+    -Uri http://localhost:5140/api/autoquote-settings/MAUA/IRT/enabled `
+    -Body '{"IsEnabled":true,"UpdatedByUserId":"00000000-0000-0000-0000-000000000000"}'
+  ```
+
+  Running the Simulator directly (not through `driver.ps1`) leaves auto-quote off.
+
+Verified end-to-end on this machine against a real local SQL Server Express instance — the run
+finished with `errors 0`, left queryable data behind, and left the auto-quote flag as it found
+it. Confirmed via:
 
 ```powershell
 Invoke-RestMethod http://localhost:5140/api/orders/MAUA/IRT/best-prices
@@ -153,9 +184,21 @@ Unit tests are a sanity check; `smoke` above is what actually proves the running
   The simulation's own error counter (`errors 0` in the final summary line) is what indicates
   real failure; the interleaved warnings are noise from a normal existence check.
 - **`Start-Process dotnet -ArgumentList 'run',...` outlives the parent shell if you don't track
-  it.** `driver.ps1 stop` doesn't rely on remembered PIDs for this reason — it resolves the
-  *current* `OwningProcess` for each of the three ports via `Get-NetTCPConnection` and kills
-  that, so it works even if the shell that ran `start` already exited.
+  it.** `driver.ps1 stop` therefore kills on two grounds: the *current* `OwningProcess` of each
+  of the three ports via `Get-NetTCPConnection` (so it works even if the shell that ran `start`
+  already exited), plus anything still alive from `run-logs/launcher.pids`. The second is what
+  catches a service that died before Kestrel bound — unreachable SQL Server, say — which owns no
+  port but is still running and still holding a lock on `bin/`. It reports only kills that
+  actually succeeded, and warns about the ones it couldn't make.
+- **All three APIs log to stdout, not stderr.** They configure Serilog `.WriteTo.Console()` with
+  no `standardErrorFromLevel`, so `run-logs/<service>.err.log` is usually empty and the real
+  error is in `<service>.out.log`. `driver.ps1 start` tails both on timeout for this reason.
+- **The `/api-docs` health probe only exists in Development.** All three APIs map Swagger inside
+  `if (app.Environment.IsDevelopment())`. `dotnet run` picks up `ASPNETCORE_ENVIRONMENT=Development`
+  from each project's `launchSettings.json`, so this works by default — but on a box where the
+  environment variable is set to Production (as `scripts/windows-services/install-services.ps1`
+  does for installed services), the services come up fine and `start` still times out. The
+  timeout message says so.
 - **Orders.Api calling Wallet/Users before they're listening just logs noisy (harmless)
   connection-refused warnings, not a failure** — `driver.ps1 start` gives Users a 3-second head
   start before launching Orders for exactly this reason, but a slow machine can still race it;
@@ -167,10 +210,22 @@ Unit tests are a sanity check; `smoke` above is what actually proves the running
   `config/appsettings.global.example.json` to that path first — see Setup above. It's
   git-ignored on purpose (`CLAUDE.md`: never commit it, it holds live credentials).
 - **`Timed out waiting for Users/Wallet/Orders APIs to report healthy.`**: `driver.ps1` prints
-  the last 40 lines of each `run-logs/*.err.log` when this happens. In practice this has meant
-  either SQL Server isn't reachable (check the `Get-Service` command under Prerequisites) or a
-  connection string in `config/appsettings.global.json` points at the wrong server/database.
+  the last 40 lines of every `run-logs/*.log` when this happens — check the `.out.log` files
+  first, that's where Serilog puts errors. In practice this has meant either SQL Server isn't
+  reachable (check the `Get-Service` command under Prerequisites), a connection string in
+  `config/appsettings.global.json` points at the wrong server/database, or
+  `ASPNETCORE_ENVIRONMENT` isn't Development (see Gotchas). The launched processes are left
+  running so their logs stay readable; `driver.ps1 stop` cleans them up.
+- **`Already listening: ...`** (thrown by `driver.ps1 start`): a previous stack is still up.
+  `driver.ps1 status` shows what owns the ports, `driver.ps1 stop` clears them. `start` refuses
+  rather than launching processes that would die on "address already in use" while the health
+  poll answered from the old ones.
+- **`Build failed (exit N)`**: fix the build. `start` stops here on purpose — it launches with
+  `--no-build`, so continuing would serve the *previous* build and quietly invalidate whatever
+  you were trying to verify.
 - **A previous `smoke` run's data is still there and you want a clean slate without running a
   new simulation**: there's no standalone reset command — `smoke`'s Phase 0 always resets
-  first, so running `smoke --users 1 --quotes 1 --trades 1` is the cheapest way to wipe
-  previously-simulated (`TelegramId < 0`) rows on demand.
+  first, so `smoke --users 5 --quotes 1 --trades 1` is the cheapest way to wipe
+  previously-simulated (`TelegramId < 0`) rows on demand. Keep `--users` at 5 rather than the
+  bare minimum of 2: each non-admin registration is only approved with probability 0.9, so a
+  2-user run can land on the one rejection and end `errors 1` with nobody left to trade.

--- a/.claude/skills/run-tallaegg/driver.ps1
+++ b/.claude/skills/run-tallaegg/driver.ps1
@@ -6,17 +6,28 @@
 .DESCRIPTION
   See SKILL.md in this same directory for the full explanation. Short version:
 
-    pwsh driver.ps1 start                                  # build (Release) + launch the 3 APIs, wait for health
-    pwsh driver.ps1 status                                 # show whether the 3 ports are listening
-    pwsh driver.ps1 smoke                                  # drive the whole stack via the bot Simulator (small run)
-    pwsh driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7   # bigger/custom run
-    pwsh driver.ps1 stop                                   # stop whatever is listening on the 3 ports
+    & driver.ps1 start                                  # build (Release) + launch the 3 APIs, wait for health
+    & driver.ps1 status                                 # show whether the 3 ports are listening
+    & driver.ps1 smoke                                  # drive the whole stack via the bot Simulator (small run)
+    & driver.ps1 smoke --users 20 --trades 50           # same, overriding only the knobs you name
+    & driver.ps1 stop                                   # stop whatever is listening on the 3 ports
+
+  This box has Windows PowerShell 5.1 and no PowerShell Core, so invoke the script directly
+  with `&` — `pwsh -File driver.ps1 ...` fails with "term not recognized".
 
   "smoke" is the actual interaction: it runs TallaEgg.TelegramBot.Simulator, which replays
   real bot conversations (registration, admin approval, quote publishing, quote-fill trades,
   menu navigation) through the real IBotHandler and the real Users/Wallet/Orders APIs and
-  database — everything except the live Telegram connection, which it fakes. It only ever
-  touches rows with TelegramId < 0, so it is safe to run against a real local dev database.
+  database — everything except the live Telegram connection, which it fakes.
+
+  Two things it changes on the database it runs against:
+    * Rows with TelegramId < 0 — created, then wiped by the next run's DataReset phase. A
+      real (positive-id) user's data is never touched.
+    * The auto-quote enabled flag for MAUA/IRT — the Simulator turns it off in its Phase 2 and
+      never turns it back on, because a background publisher replacing the run's quotes breaks
+      quote-fill trades. That is per-symbol Orders-DB state, not TelegramId-scoped, so
+      DataReset does not restore it. This script reads the flag before the run and puts it
+      back afterwards; see Restore-AutoQuote below.
 #>
 param(
     [Parameter(Mandatory = $true, Position = 0)]
@@ -29,7 +40,6 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
-Set-Location $repoRoot
 
 $ports = [ordered]@{ users = 5136; wallet = 60933; orders = 5140 }
 $projects = @{
@@ -38,6 +48,10 @@ $projects = @{
     orders = 'src/Order/Orders.Api/Orders.Api.csproj'
 }
 $logDir = Join-Path $repoRoot 'run-logs'
+$pidFile = Join-Path $logDir 'launcher.pids'
+
+# The symbol the Simulator trades, and whose auto-quote flag it turns off (Simulation.cs).
+$smokeSymbol = 'MAUA/IRT'
 
 function Test-ServicesUp {
     foreach ($name in $ports.Keys) {
@@ -49,6 +63,47 @@ function Test-ServicesUp {
     return $true
 }
 
+function Get-ListeningPorts {
+    $busy = @()
+    foreach ($name in $ports.Keys) {
+        if (Get-NetTCPConnection -LocalPort $ports[$name] -State Listen -ErrorAction SilentlyContinue) {
+            $busy += "$name ($($ports[$name]))"
+        }
+    }
+    return $busy
+}
+
+function Get-AutoQuoteEnabled {
+    # Returns $true/$false, or $null if the setting could not be read (caller then skips restore
+    # rather than guessing — writing the wrong value back is worse than leaving it alone).
+    try {
+        $r = Invoke-RestMethod -TimeoutSec 10 -Uri "http://localhost:$($ports['orders'])/api/autoquote-settings/$smokeSymbol"
+        return [bool]$r.Data.IsEnabled
+    } catch {
+        Write-Warning "Could not read auto-quote setting for ${smokeSymbol}: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Restore-AutoQuote {
+    param([bool]$Enabled)
+
+    try {
+        # Guid.Empty as the updater: this is a dev-tooling restore, not an admin action, and
+        # AutoQuoteSettings.CreateDefault already uses Guid.Empty as its no-real-user sentinel.
+        $body = @{ IsEnabled = $Enabled; UpdatedByUserId = [guid]::Empty.ToString() } | ConvertTo-Json
+        Invoke-RestMethod -Method Post -TimeoutSec 10 -ContentType 'application/json' -Body $body `
+            -Uri "http://localhost:$($ports['orders'])/api/autoquote-settings/$smokeSymbol/enabled" | Out-Null
+        Write-Host "Restored auto-quote for $smokeSymbol to IsEnabled=$Enabled."
+    } catch {
+        Write-Warning "Failed to restore auto-quote for ${smokeSymbol} to IsEnabled=${Enabled}: $($_.Exception.Message)"
+        Write-Warning "Turn it back on from the bot with the admin command 'اتومات روشن' if it was on before."
+    }
+}
+
+Push-Location $repoRoot
+try {
+
 switch ($Command) {
     'start' {
         $configPath = Join-Path $repoRoot 'config/appsettings.global.json'
@@ -56,10 +111,24 @@ switch ($Command) {
             throw "config/appsettings.global.json is missing. Copy config/appsettings.global.example.json to that path and point ConnectionStrings at a local SQL Server (see SKILL.md Prerequisites)."
         }
 
+        # Without this, a second 'start' launches three processes that each die on "address
+        # already in use" while Test-ServicesUp answers 200 from the processes already running
+        # — reporting success for a stack that is not running the build we just made.
+        $busy = Get-ListeningPorts
+        if ($busy.Count -gt 0) {
+            throw "Already listening: $($busy -join ', '). Run 'driver.ps1 stop' first, or 'driver.ps1 status' to see what owns them."
+        }
+
         New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 
         Write-Host "Building (Release)..."
         dotnet build TallaEgg.sln --configuration Release | Out-Host
+        # A native command's nonzero exit does not throw in Windows PowerShell 5.1, not even
+        # under $ErrorActionPreference = 'Stop'. Unchecked, a failed build falls straight
+        # through to 'dotnet run --no-build' and silently serves the previous build.
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build failed (exit $LASTEXITCODE). Fix the build before starting the services."
+        }
 
         $procIds = @()
         foreach ($name in @('users', 'wallet', 'orders')) {
@@ -75,7 +144,7 @@ switch ($Command) {
                 Start-Sleep -Seconds 3
             }
         }
-        $procIds | Set-Content (Join-Path $logDir 'launcher.pids')
+        $procIds | Set-Content $pidFile
 
         Write-Host "Waiting for services to come up..."
         for ($i = 0; $i -lt 30; $i++) {
@@ -86,12 +155,18 @@ switch ($Command) {
             Start-Sleep -Seconds 2
         }
 
-        Write-Host "Services did not come up in time. Recent stderr:"
-        Get-ChildItem $logDir -Filter '*.err.log' | ForEach-Object {
-            Write-Host "--- $($_.Name) ---"
-            Get-Content $_.FullName -Tail 40
-        }
-        throw "Timed out waiting for Users/Wallet/Orders APIs to report healthy."
+        # Both streams: all three APIs configure Serilog .WriteTo.Console() with no
+        # standardErrorFromLevel, so errors land in *.out.log, not *.err.log.
+        Write-Host "Services did not come up in time. Recent output:"
+        Get-ChildItem $logDir -Filter '*.log' |
+            Where-Object { $_.Name -ne 'smoke.log' } |
+            Sort-Object Name |
+            ForEach-Object {
+                Write-Host "--- $($_.Name) ---"
+                Get-Content $_.FullName -Tail 40
+            }
+        Write-Host "The services launched above are still running; 'driver.ps1 stop' cleans them up."
+        throw "Timed out waiting for Users/Wallet/Orders APIs to report healthy. If all three are in fact serving, check that ASPNETCORE_ENVIRONMENT is Development — the /api-docs probe only exists there."
     }
 
     'status' {
@@ -111,20 +186,105 @@ switch ($Command) {
         if (-not (Test-ServicesUp)) {
             throw "Users/Wallet/Orders are not all up. Run 'driver.ps1 start' first."
         }
-        $simArgs = if ($Rest -and $Rest.Count -gt 0) { $Rest } else { @('--users', '5', '--quotes', '5', '--trades', '10', '--seed', '1') }
+
+        # Merge over the defaults rather than replacing them: passing $Rest straight through
+        # would drop every knob the caller did not name, and SimulationOptions.FromArgs then
+        # falls back to its own compiled defaults (100 users / 120 quotes / 1000 trades) —
+        # so 'smoke --seed 7' would quietly become a hundred-fold bigger run.
+        $simOptions = [ordered]@{ '--users' = '5'; '--quotes' = '5'; '--trades' = '10'; '--seed' = '1' }
+        for ($i = 0; $i -lt $Rest.Count; $i++) {
+            $key = $Rest[$i]
+            if (-not $simOptions.Contains($key)) {
+                throw "Unknown simulator argument '$key'. Supported: $($simOptions.Keys -join ', ')."
+            }
+            if ($i + 1 -ge $Rest.Count) {
+                throw "Simulator argument '$key' has no value."
+            }
+            $simOptions[$key] = $Rest[++$i]
+        }
+        if ([int]$simOptions['--users'] -lt 2) {
+            # User #0 is promoted to admin and is the counterparty to every fill, so it can
+            # never trade with itself; with fewer than two users the trade phase has nobody
+            # left and records "No approved users to trade with."
+            throw "--users must be at least 2 (user #0 becomes the admin/market maker and cannot be its own counterparty)."
+        }
+
+        $simArgs = @()
+        foreach ($k in $simOptions.Keys) { $simArgs += $k; $simArgs += $simOptions[$k] }
+
+        New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+        $smokeLog = Join-Path $logDir 'smoke.log'
+
+        $autoQuoteWas = Get-AutoQuoteEnabled
         Write-Host "Running simulator with args: $simArgs"
-        dotnet run --no-build --configuration Release `
-            --project TelegramBot/TallaEgg.TelegramBot.Simulator/TallaEgg.TelegramBot.Simulator.csproj -- @simArgs
+        try {
+            dotnet run --no-build --configuration Release `
+                --project TelegramBot/TallaEgg.TelegramBot.Simulator/TallaEgg.TelegramBot.Simulator.csproj -- @simArgs |
+                Tee-Object -FilePath $smokeLog
+            $simExit = $LASTEXITCODE
+        }
+        finally {
+            # The Simulator disables auto-quote for the symbol and never re-enables it; put the
+            # flag back however we found it, including when the run threw part-way through.
+            if ($null -ne $autoQuoteWas -and $autoQuoteWas) {
+                Restore-AutoQuote -Enabled $true
+            }
+        }
+
+        if ($simExit -ne 0) {
+            throw "Simulator exited with code $simExit. Full output: $smokeLog"
+        }
+
+        # The Simulator returns 0 whatever happens — it only *logs* its error count — so the
+        # summary line is the real result and has to be parsed for it.
+        $summary = Select-String -Path $smokeLog -Pattern 'trades attempted \d+, errors (\d+)' | Select-Object -Last 1
+        if (-not $summary) {
+            throw "Simulator produced no summary line; it did not finish. Full output: $smokeLog"
+        }
+        $errorCount = [int]$summary.Matches[0].Groups[1].Value
+        if ($errorCount -ne 0) {
+            throw "Simulation finished with $errorCount error(s). Full output: $smokeLog"
+        }
+        Write-Host "Simulation completed with errors 0."
     }
 
     'stop' {
+        # Port owners first, then anything still alive from launcher.pids: a service that died
+        # before Kestrel bound (unreachable SQL Server, say) owns no port but is still running,
+        # and that is exactly the case 'start' throws on.
+        $targets = @()
+        $targets += Get-NetTCPConnection -LocalPort ([int[]]$ports.Values) -State Listen -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty OwningProcess
+        if (Test-Path $pidFile) {
+            $targets += Get-Content $pidFile | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }
+        }
+
         $stopped = 0
-        Get-NetTCPConnection -LocalPort ([int[]]$ports.Values) -State Listen -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty OwningProcess -Unique |
-            ForEach-Object {
-                Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue
+        $failed = @()
+        foreach ($target in ($targets | Select-Object -Unique)) {
+            $proc = Get-Process -Id $target -ErrorAction SilentlyContinue
+            if (-not $proc) { continue }
+            try {
+                Stop-Process -Id $target -Force -ErrorAction Stop
                 $stopped++
+            } catch {
+                # Counting a kill that did not happen is how 'stop' comes to report a stack
+                # down while it is still listening, which the next 'start' then trips over.
+                $failed += "$target ($($proc.ProcessName)): $($_.Exception.Message)"
             }
+        }
+
+        if (Test-Path $pidFile) { Remove-Item $pidFile -Force }
+
         "Stopped $stopped process(es)."
+        if ($failed.Count -gt 0) {
+            Write-Warning "Could not stop $($failed.Count) process(es):"
+            $failed | ForEach-Object { Write-Warning "  $_" }
+        }
     }
+}
+
+}
+finally {
+    Pop-Location
 }

--- a/.claude/skills/run-tallaegg/driver.ps1
+++ b/.claude/skills/run-tallaegg/driver.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+  Build, launch, and drive the TallaEgg backend (Users/Wallet/Orders APIs) end-to-end,
+  without a live Telegram connection.
+
+.DESCRIPTION
+  See SKILL.md in this same directory for the full explanation. Short version:
+
+    pwsh driver.ps1 start                                  # build (Release) + launch the 3 APIs, wait for health
+    pwsh driver.ps1 status                                 # show whether the 3 ports are listening
+    pwsh driver.ps1 smoke                                  # drive the whole stack via the bot Simulator (small run)
+    pwsh driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7   # bigger/custom run
+    pwsh driver.ps1 stop                                   # stop whatever is listening on the 3 ports
+
+  "smoke" is the actual interaction: it runs TallaEgg.TelegramBot.Simulator, which replays
+  real bot conversations (registration, admin approval, quote publishing, quote-fill trades,
+  menu navigation) through the real IBotHandler and the real Users/Wallet/Orders APIs and
+  database — everything except the live Telegram connection, which it fakes. It only ever
+  touches rows with TelegramId < 0, so it is safe to run against a real local dev database.
+#>
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('start', 'status', 'smoke', 'stop')]
+    [string]$Command,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Rest
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+Set-Location $repoRoot
+
+$ports = [ordered]@{ users = 5136; wallet = 60933; orders = 5140 }
+$projects = @{
+    users  = 'src/User/Users.Api/Users.Api.csproj'
+    wallet = 'src/Wallet/Wallet.Api/Wallet.Api.csproj'
+    orders = 'src/Order/Orders.Api/Orders.Api.csproj'
+}
+$logDir = Join-Path $repoRoot 'run-logs'
+
+function Test-ServicesUp {
+    foreach ($name in $ports.Keys) {
+        try {
+            $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 2 -Uri "http://localhost:$($ports[$name])/api-docs/index.html"
+            if ($r.StatusCode -ne 200) { return $false }
+        } catch { return $false }
+    }
+    return $true
+}
+
+switch ($Command) {
+    'start' {
+        $configPath = Join-Path $repoRoot 'config/appsettings.global.json'
+        if (-not (Test-Path $configPath)) {
+            throw "config/appsettings.global.json is missing. Copy config/appsettings.global.example.json to that path and point ConnectionStrings at a local SQL Server (see SKILL.md Prerequisites)."
+        }
+
+        New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+        Write-Host "Building (Release)..."
+        dotnet build TallaEgg.sln --configuration Release | Out-Host
+
+        $procIds = @()
+        foreach ($name in @('users', 'wallet', 'orders')) {
+            Write-Host "Starting $name ($($projects[$name]))..."
+            $p = Start-Process dotnet -ArgumentList @('run', '--no-build', '--configuration', 'Release', '--project', $projects[$name]) `
+                -RedirectStandardOutput (Join-Path $logDir "$name.out.log") `
+                -RedirectStandardError (Join-Path $logDir "$name.err.log") `
+                -PassThru -WindowStyle Hidden
+            $procIds += $p.Id
+            if ($name -eq 'users') {
+                # Orders.Api's own startup calls Wallet/Users; giving Users a head start avoids
+                # a burst of connection-refused warnings in its log (harmless, but noisy).
+                Start-Sleep -Seconds 3
+            }
+        }
+        $procIds | Set-Content (Join-Path $logDir 'launcher.pids')
+
+        Write-Host "Waiting for services to come up..."
+        for ($i = 0; $i -lt 30; $i++) {
+            if (Test-ServicesUp) {
+                Write-Host "All services up after $($i * 2)s."
+                return
+            }
+            Start-Sleep -Seconds 2
+        }
+
+        Write-Host "Services did not come up in time. Recent stderr:"
+        Get-ChildItem $logDir -Filter '*.err.log' | ForEach-Object {
+            Write-Host "--- $($_.Name) ---"
+            Get-Content $_.FullName -Tail 40
+        }
+        throw "Timed out waiting for Users/Wallet/Orders APIs to report healthy."
+    }
+
+    'status' {
+        foreach ($name in $ports.Keys) {
+            $conn = Get-NetTCPConnection -LocalPort $ports[$name] -State Listen -ErrorAction SilentlyContinue
+            if ($conn) {
+                $ownerPid = ($conn | Select-Object -First 1 -ExpandProperty OwningProcess)
+                "{0,-8} port {1,-6} LISTENING (pid $ownerPid)" -f $name, $ports[$name]
+            }
+            else {
+                "{0,-8} port {1,-6} down" -f $name, $ports[$name]
+            }
+        }
+    }
+
+    'smoke' {
+        if (-not (Test-ServicesUp)) {
+            throw "Users/Wallet/Orders are not all up. Run 'driver.ps1 start' first."
+        }
+        $simArgs = if ($Rest -and $Rest.Count -gt 0) { $Rest } else { @('--users', '5', '--quotes', '5', '--trades', '10', '--seed', '1') }
+        Write-Host "Running simulator with args: $simArgs"
+        dotnet run --no-build --configuration Release `
+            --project TelegramBot/TallaEgg.TelegramBot.Simulator/TallaEgg.TelegramBot.Simulator.csproj -- @simArgs
+    }
+
+    'stop' {
+        $stopped = 0
+        Get-NetTCPConnection -LocalPort ([int[]]$ports.Values) -State Listen -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty OwningProcess -Unique |
+            ForEach-Object {
+                Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue
+                $stopped++
+            }
+        "Stopped $stopped process(es)."
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,7 @@ appsettings.*.json
 
 # Logs
 logs/
+run-logs/
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Description
Adds `.claude/skills/run-tallaegg/`: an agent-facing skill that documents and scripts how to build, launch, and actually drive the TallaEgg backend end to end — not just run its unit tests — without needing a live Telegram bot token or network access to `api.telegram.org`.

## Changes Made
- `.claude/skills/run-tallaegg/driver.ps1` — a PowerShell driver with four subcommands (`start`, `status`, `smoke`, `stop`) that builds the solution in Release, launches Users/Wallet/Orders as background processes, polls their Swagger pages for health, and stops them by resolving current port ownership plus any survivor from `launcher.pids`.
- `.claude/skills/run-tallaegg/SKILL.md` — points future agents at the driver, documents Prerequisites/Setup/Build/Run/Test, and records Gotchas and Troubleshooting hit while building this.
- `.gitignore`: added `run-logs/` for the driver's redirected stdout/stderr (the individual `.log` files were already covered by the existing `*.log` rule; the directory itself and `launcher.pids` were not).

## Why this shape
The repo already ships `TelegramBot/TallaEgg.TelegramBot.Simulator`, a project that replays real bot conversations (registration, admin approval, quote publishing, quote-fill trades, menu navigation) through the real `IBotHandler` and the real Users/Wallet/Orders APIs and database — faking only the Telegram transport. That's the interaction surface this skill points at via `driver.ps1 smoke`, rather than writing a new harness from scratch.

## What a `smoke` run changes on the database
- **Rows with `TelegramId < 0`** — every simulated user. Each run's `DataReset` phase wipes only that range before starting, so runs are self-cleaning and a real (positive-id) user's data is never touched.
- **The auto-quote flag for `MAUA/IRT`** — the Simulator turns it off in Phase 2 (a background publisher replacing the run's quotes breaks quote-fill trades) and never turns it back on. This is per-symbol Orders-DB state, not `TelegramId`-scoped, so `DataReset` does not restore it. `driver.ps1 smoke` reads the flag before the run and puts it back afterwards, including when the run fails part-way.

> An earlier revision of this PR claimed a run "only ever touches rows with `TelegramId < 0`" and so "can never touch a real user's data". The second half is true; the first half was not, and the auto-quote flag was the counterexample. Fixed in review — see below.

## Review fixes (2026-08-30)
Review found the driver reporting success in several cases where it had not done the work:
- **A failed build was never detected.** In Windows PowerShell 5.1 a native command's nonzero exit does not throw, even under `$ErrorActionPreference = 'Stop'`, so `start` fell through to `dotnet run --no-build`, served the *previous* build and printed "All services up" — the exact outcome this skill exists to prevent. Now checks `$LASTEXITCODE` and throws.
- **`smoke` could not fail.** The Simulator returns 0 whatever happens and only logs its error count; the driver now parses the summary line and throws on a nonzero count or a missing line.
- **Partial argument overrides escalated the run ~100x.** `smoke --seed 7` passed only `--seed`, so `SimulationOptions` fell back to its own compiled defaults (100 users / 120 quotes / 1000 trades). Arguments are now merged over the documented defaults; unknown ones are rejected, and `--users` below 2 is refused (user #0 is the admin/market maker and cannot be its own counterparty, so a 1-user run always ends `errors 1`).
- **`start` now refuses when the ports are already listening**, instead of launching processes that die on "address already in use" while the health poll answers 200 from the old ones.
- **Timeout diagnostics tailed the wrong stream.** All three APIs use Serilog `.WriteTo.Console()` with no `standardErrorFromLevel`, so errors land in `*.out.log` and the `*.err.log` files the driver printed were empty. Both are tailed now.
- **`stop` now also kills `launcher.pids` survivors**, so a service that died before Kestrel bound (unreachable SQL Server) is cleaned up, and counts only kills that actually succeeded.
- **The Setup recipe now uses `Copy-Item -NoClobber`.** `config/appsettings.global.json` is untracked (#33), so an agent following the doc verbatim on a configured box would have destroyed live credentials with no way to recover them.
- **The script's own usage block said `pwsh`**, which the skill's Gotchas already documented as unavailable here.

## Testing
Verified on this machine against a real local SQL Server Express instance:
- [x] `dotnet build TallaEgg.sln --configuration Release` — 0 warnings, 0 errors
- [x] `driver.ps1 start` → `status` → `smoke` → `stop` — ended `errors 0`
- [x] Auto-quote for MAUA/IRT set enabled before a `smoke` run and observed restored to enabled afterwards
- [x] A deliberately broken build made `start` throw `Build failed (exit 1)` instead of launching stale binaries
- [x] `smoke --users 1`, `smoke --bogus 3`, and `start` with the ports already bound each refused with a specific message
- [x] `smoke --seed 7` confirmed to keep 5/5/10 rather than falling back to 100/120/1000
- [x] Follow-up `Invoke-RestMethod http://localhost:5140/api/orders/MAUA/IRT/best-prices` confirmed the simulated data is queryable afterward
- [x] `dotnet test tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj` — 501/501 passing (unchanged)
- [x] No secrets/tokens in diff (confirmed — no config values were copied into these files; `config/appsettings.global.json` was never touched)

## Deployment Notes
Docs/tooling only — no service code changed, no migrations, no config changes.

## Known follow-ups (not in this PR)
- The launch + health-poll logic overlaps `.github/workflows/manual-test-run.yml`, which already encodes the same project paths, probe, and retry budget. Extracting one script under `scripts/` that both call would remove the divergence.
- `AGENT.md` still says "There is no working script" for starting the stack. That stays accurate for the human path (this driver is agent-facing and deliberately does not launch the bot), but is worth revisiting alongside the deduplication above.
