### PR TITLE
[Hotfix] Stop logging routine polling blips as Error — closes #148

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Telegram.Bot;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Polling;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -23,6 +24,18 @@ public class TelegramBotHostedService : BackgroundService
     private readonly IHostApplicationLifetime _applicationLifetime;
 
     private CancellationTokenSource? _receiverCts;
+
+    // A gap this much longer than the retry delay between two transient polling failures means
+    // updates were flowing again in between, so the next failure starts a fresh streak rather
+    // than continuing the old one (issue #148).
+    private static readonly TimeSpan PollingRetryDelay = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan PollingRecoveryGap = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PollingDownAlertThreshold = TimeSpan.FromMinutes(2);
+
+    private DateTimeOffset? _pollingFailureStreakStartedAt;
+    private DateTimeOffset? _lastPollingFailureAt;
+    private int _consecutivePollingFailures;
+    private bool _pollingDownAlertLogged;
 
     public TelegramBotHostedService(
         ITelegramBotClient botClient,
@@ -220,16 +233,60 @@ public class TelegramBotHostedService : BackgroundService
 
     private Task HandlePollingErrorAsync(ITelegramBotClient botClient, Exception exception, HandleErrorSource source, CancellationToken cancellationToken)
     {
-        _logger.LogError(exception, "Polling error ({Source})", source);
-
-        if (exception.Message.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
-            exception.Message.Contains("timed out", StringComparison.OrdinalIgnoreCase))
+        // ApiRequestException means Telegram itself rejected the request (rotated token, rate
+        // limit, ...). That's a real fault, not a transport blip, so it stays loud immediately.
+        if (exception is ApiRequestException apiException)
         {
-            _logger.LogWarning("Timeout detected. Waiting 10 seconds before retrying...");
-            return Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+            _logger.LogError(exception, "Polling error ({Source}): Telegram API rejected the request ({ErrorCode}).", source, apiException.ErrorCode);
+            return Task.CompletedTask;
         }
 
+        // Every other RequestException is TelegramBotClient.SendRequest wrapping a transport-level
+        // failure -- a dropped connection, a timed-out request, a malformed response. These are
+        // routine on a flaky connection and recover on their own; logging each one at Error with a
+        // full stack trace was making the log 100% noise, burying the one entry that matters
+        // (issue #148). Log at Warning, without the stack trace, unless the bot has genuinely
+        // stopped receiving updates for a while -- that's worth escalating to Error once.
+        if (exception is RequestException)
+        {
+            return HandleTransientPollingFailure(source, exception, DateTimeOffset.UtcNow, cancellationToken);
+        }
+
+        // Anything else is unexpected for this handler -- keep it loud rather than risk silencing
+        // a real bug behind the transient-failure path above.
+        _logger.LogError(exception, "Polling error ({Source})", source);
         return Task.CompletedTask;
+    }
+
+    // `now` is passed in rather than read here so the escalation timing can be driven
+    // deterministically from a test without sleeping real wall-clock minutes.
+    private Task HandleTransientPollingFailure(HandleErrorSource source, Exception exception, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        if (_lastPollingFailureAt is null || now - _lastPollingFailureAt.Value > PollingRecoveryGap)
+        {
+            _pollingFailureStreakStartedAt = now;
+            _consecutivePollingFailures = 0;
+            _pollingDownAlertLogged = false;
+        }
+
+        _lastPollingFailureAt = now;
+        _consecutivePollingFailures++;
+        var downFor = now - _pollingFailureStreakStartedAt!.Value;
+
+        if (downFor >= PollingDownAlertThreshold && !_pollingDownAlertLogged)
+        {
+            _pollingDownAlertLogged = true;
+            _logger.LogError(exception,
+                "Polling has been failing for {Duration} ({Count} consecutive failures, {Source}); the bot may not be receiving updates.",
+                downFor, _consecutivePollingFailures, source);
+        }
+        else
+        {
+            _logger.LogWarning("Polling error ({Source}): {ExceptionType} - {Message}. Retrying in {Delay}...",
+                source, exception.GetType().Name, exception.Message, PollingRetryDelay);
+        }
+
+        return Task.Delay(PollingRetryDelay, cancellationToken);
     }
 }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TelegramBotHostedService.cs
@@ -25,17 +25,35 @@ public class TelegramBotHostedService : BackgroundService
 
     private CancellationTokenSource? _receiverCts;
 
-    // A gap this much longer than the retry delay between two transient polling failures means
-    // updates were flowing again in between, so the next failure starts a fresh streak rather
-    // than continuing the old one (issue #148).
-    private static readonly TimeSpan PollingRetryDelay = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan PollingRecoveryGap = TimeSpan.FromSeconds(30);
+    // Backoff after a transient polling failure. The first retries are fast so an isolated blip --
+    // which the old code retried immediately -- does not cost the bot ten seconds of deafness, and
+    // it settles at the last entry once the failure looks sustained (issue #148).
+    private static readonly TimeSpan[] PollingRetryDelays =
+    [
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(10),
+    ];
+
+    private static readonly TimeSpan PollingRetryDelayMax = PollingRetryDelays[^1];
+
+    // How long the bot must have been failing to poll before that is worth one Error line.
     private static readonly TimeSpan PollingDownAlertThreshold = TimeSpan.FromMinutes(2);
 
     private DateTimeOffset? _pollingFailureStreakStartedAt;
     private DateTimeOffset? _lastPollingFailureAt;
+    private DateTimeOffset? _lastUpdateReceivedAt;
     private int _consecutivePollingFailures;
     private bool _pollingDownAlertLogged;
+
+    // A failing getUpdates does not fail fast: DefaultUpdateReceiver long-polls for
+    // _botClient.Timeout seconds, so under a total outage two consecutive failures land a whole
+    // poll cycle apart -- ~130s with ProxyBotClient's 120s timeout, not the ~10s that a small
+    // fixed constant would imply. Only a gap longer than one entire cycle (plus the backoff we
+    // add, plus margin) proves a poll completed in between. Deriving it from the client keeps the
+    // two in step if that timeout ever changes (issue #148).
+    private TimeSpan PollingRecoveryGap => _botClient.Timeout + PollingRetryDelayMax + TimeSpan.FromSeconds(30);
 
     public TelegramBotHostedService(
         ITelegramBotClient botClient,
@@ -185,6 +203,10 @@ public class TelegramBotHostedService : BackgroundService
 
     private async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, CancellationToken cancellationToken)
     {
+        // An update reaching us is the one unambiguous proof that polling is alive, which is what
+        // the down-alert below needs and cannot infer from the error path alone (issue #148).
+        RecordUpdateReceived(DateTimeOffset.UtcNow);
+
         // Resolved once so both the log entry and the fallback reply below can use them —
         // whichever branch below throws, this is who was talking to the bot (issue #99).
         var chatId = update.Message?.Chat.Id ?? update.CallbackQuery?.Message?.Chat.Id;
@@ -233,6 +255,15 @@ public class TelegramBotHostedService : BackgroundService
 
     private Task HandlePollingErrorAsync(ITelegramBotClient botClient, Exception exception, HandleErrorSource source, CancellationToken cancellationToken)
     {
+        // FatalError means the receive loop itself has died -- Telegram.Bot documents it as
+        // "Polling of updates will stop". Nothing about that is transient, and there is no loop
+        // left to back off for, so it must never take the path below however it is shaped.
+        if (source == HandleErrorSource.FatalError)
+        {
+            _logger.LogError(exception, "Polling has stopped: fatal error in the update receiver ({Source}).", source);
+            return Task.CompletedTask;
+        }
+
         // ApiRequestException means Telegram itself rejected the request (rotated token, rate
         // limit, ...). That's a real fault, not a transport blip, so it stays loud immediately.
         if (exception is ApiRequestException apiException)
@@ -258,11 +289,26 @@ public class TelegramBotHostedService : BackgroundService
         return Task.CompletedTask;
     }
 
+    // Separate from HandleUpdateAsync so a test can establish "polling was alive at time T"
+    // without having to fabricate an Update and run the whole dispatch path.
+    private void RecordUpdateReceived(DateTimeOffset now) => _lastUpdateReceivedAt = now;
+
     // `now` is passed in rather than read here so the escalation timing can be driven
     // deterministically from a test without sleeping real wall-clock minutes.
     private Task HandleTransientPollingFailure(HandleErrorSource source, Exception exception, DateTimeOffset now, CancellationToken cancellationToken)
     {
-        if (_lastPollingFailureAt is null || now - _lastPollingFailureAt.Value > PollingRecoveryGap)
+        // Two independent signs that polling recovered since the previous failure, because
+        // neither alone is enough. An update having arrived is proof, but a bot with no traffic
+        // never produces one; a gap longer than a whole poll cycle is the fallback for that case,
+        // but on its own it also matches a busy bot whose polls keep dying part-way through --
+        // which is exactly the #148 pattern, one failure every ~71s with trades settling normally
+        // throughout. Requiring both to be absent is what keeps a real outage escalating without
+        // firing on a flaky-but-working connection.
+        var recovered =
+            (_lastUpdateReceivedAt is { } lastUpdate && _lastPollingFailureAt is { } lastFailure && lastUpdate > lastFailure)
+            || (_lastPollingFailureAt is { } previousFailure && now - previousFailure > PollingRecoveryGap);
+
+        if (_lastPollingFailureAt is null || recovered)
         {
             _pollingFailureStreakStartedAt = now;
             _consecutivePollingFailures = 0;
@@ -272,6 +318,7 @@ public class TelegramBotHostedService : BackgroundService
         _lastPollingFailureAt = now;
         _consecutivePollingFailures++;
         var downFor = now - _pollingFailureStreakStartedAt!.Value;
+        var retryDelay = PollingRetryDelays[Math.Min(_consecutivePollingFailures - 1, PollingRetryDelays.Length - 1)];
 
         if (downFor >= PollingDownAlertThreshold && !_pollingDownAlertLogged)
         {
@@ -282,11 +329,28 @@ public class TelegramBotHostedService : BackgroundService
         }
         else
         {
+            // RequestException.Message is the fixed literal "Exception during making request", so
+            // logging it alone makes every one of these lines identical and says nothing about the
+            // cause. The cause is in the inner exception -- a socket reset, a TLS failure, a DNS
+            // error, "the response ended prematurely" -- and that is the part worth keeping.
             _logger.LogWarning("Polling error ({Source}): {ExceptionType} - {Message}. Retrying in {Delay}...",
-                source, exception.GetType().Name, exception.Message, PollingRetryDelay);
+                source, exception.GetType().Name, DescribeCause(exception), retryDelay);
         }
 
-        return Task.Delay(PollingRetryDelay, cancellationToken);
+        return Task.Delay(retryDelay, cancellationToken);
+    }
+
+    private static string DescribeCause(Exception exception)
+    {
+        var innermost = exception;
+        while (innermost.InnerException is not null)
+        {
+            innermost = innermost.InnerException;
+        }
+
+        return ReferenceEquals(innermost, exception)
+            ? exception.Message
+            : $"{exception.Message} ({innermost.GetType().Name}: {innermost.Message})";
     }
 }
 

--- a/tests/TallaEgg.AllServices.Tests/Fakes/CapturingLogger.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/CapturingLogger.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+
+namespace TallaEgg.AllServices.Tests.Fakes;
+
+/// <summary>
+/// Records every log call instead of writing it anywhere, so a test can assert on the level
+/// and exception a piece of code chose, not just that "something" got logged.
+/// </summary>
+public sealed class CapturingLogger<T> : ILogger<T>
+{
+    public sealed record Entry(LogLevel Level, Exception? Exception, string Message);
+
+    public List<Entry> Entries { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(new Entry(logLevel, exception, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/Fakes/FakeHostApplicationLifetime.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/FakeHostApplicationLifetime.cs
@@ -2,7 +2,11 @@ using Microsoft.Extensions.Hosting;
 
 namespace TallaEgg.AllServices.Tests.Fakes;
 
-/// <summary>Records whether shutdown was requested, without touching a real host.</summary>
+/// <summary>
+/// Satisfies the <see cref="IHostApplicationLifetime"/> a service under test asks for, without
+/// touching a real host. <see cref="StopApplicationCalled"/> is there for a test that exercises a
+/// shutdown path; the polling-error tests only need the constructor to succeed.
+/// </summary>
 public sealed class FakeHostApplicationLifetime : IHostApplicationLifetime
 {
     public CancellationToken ApplicationStarted => CancellationToken.None;

--- a/tests/TallaEgg.AllServices.Tests/Fakes/FakeHostApplicationLifetime.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/FakeHostApplicationLifetime.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Hosting;
+
+namespace TallaEgg.AllServices.Tests.Fakes;
+
+/// <summary>Records whether shutdown was requested, without touching a real host.</summary>
+public sealed class FakeHostApplicationLifetime : IHostApplicationLifetime
+{
+    public CancellationToken ApplicationStarted => CancellationToken.None;
+    public CancellationToken ApplicationStopping => CancellationToken.None;
+    public CancellationToken ApplicationStopped => CancellationToken.None;
+
+    public bool StopApplicationCalled { get; private set; }
+
+    public void StopApplication() => StopApplicationCalled = true;
+}

--- a/tests/TallaEgg.AllServices.Tests/TelegramBotHostedServicePollingErrorTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/TelegramBotHostedServicePollingErrorTests.cs
@@ -13,15 +13,31 @@ namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
 /// <c>HandlePollingErrorAsync</c> used to log every polling hiccup at Error with a full stack
-/// trace, so a dropped connection every ~50 seconds made the bot's error log 100% noise and hid
+/// trace, so a dropped connection every ~71 seconds made the bot's error log 100% noise and hid
 /// any real fault in it (issue #148). These pin the severity split (transport blip vs. a real
-/// Telegram API fault) and the escalate-on-persistence behaviour that replaced it.
+/// Telegram API fault vs. a dead receive loop) and the escalate-on-persistence behaviour that
+/// replaced it.
+///
+/// Cadence matters more than it looks here. <c>getUpdates</c> long-polls for the client's whole
+/// timeout, so under a total outage consecutive failures land a full poll cycle apart -- roughly
+/// two minutes, not the ten seconds a naive reading suggests. Tests that drive failures ten
+/// seconds apart therefore exercise a rhythm the deployed bot never produces, and would pass
+/// against a handler that can never escalate in production. Everything below is derived from
+/// <c>ITelegramBotClient.Timeout</c> for that reason.
 ///
 /// The handler is intentionally private -- it's wired into Telegram.Bot's <c>StartReceiving</c>,
 /// not a public API of this class -- so these reach it through reflection.
 /// </summary>
 public class TelegramBotHostedServicePollingErrorTests
 {
+    /// <summary>Longest a single failing poll can take before the transport gives up.</summary>
+    private static readonly TimeSpan PollCycle = new TelegramBotClient("1:AA").Timeout;
+
+    /// <summary>Worst-case spacing of two consecutive failures during a total outage.</summary>
+    private static readonly TimeSpan OutageCadence = PollCycle + TimeSpan.FromSeconds(10);
+
+    private static readonly TimeSpan DownAlertThreshold = TimeSpan.FromMinutes(2);
+
     private static (TelegramBotHostedService Service, CapturingLogger<TelegramBotHostedService> Logger) CreateService()
     {
         var logger = new CapturingLogger<TelegramBotHostedService>();
@@ -35,12 +51,16 @@ public class TelegramBotHostedServicePollingErrorTests
         return (service, logger);
     }
 
-    private static Task InvokeHandlePollingErrorAsync(TelegramBotHostedService service, Exception exception, CancellationToken cancellationToken = default)
+    private static Task InvokeHandlePollingErrorAsync(
+        TelegramBotHostedService service,
+        Exception exception,
+        HandleErrorSource source = HandleErrorSource.PollingError,
+        CancellationToken cancellationToken = default)
     {
         var method = typeof(TelegramBotHostedService).GetMethod("HandlePollingErrorAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("HandlePollingErrorAsync not found.");
 
-        return (Task)method.Invoke(service, [null, exception, HandleErrorSource.PollingError, cancellationToken])!;
+        return (Task)method.Invoke(service, [null, exception, source, cancellationToken])!;
     }
 
     private static Task InvokeHandleTransientPollingFailure(
@@ -52,21 +72,65 @@ public class TelegramBotHostedServicePollingErrorTests
         return (Task)method.Invoke(service, [HandleErrorSource.PollingError, exception, now, cancellationToken])!;
     }
 
+    private static void InvokeRecordUpdateReceived(TelegramBotHostedService service, DateTimeOffset now)
+    {
+        var method = typeof(TelegramBotHostedService).GetMethod("RecordUpdateReceived", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("RecordUpdateReceived not found.");
+
+        method.Invoke(service, [now]);
+    }
+
+    /// <summary>
+    /// Drives a total outage from <paramref name="from"/> at the cadence a real one produces --
+    /// no updates arriving, every poll dying only after the full long-poll timeout -- until the
+    /// down alert has had its chance to fire. Returns the moment of the last failure.
+    /// </summary>
+    private static DateTimeOffset DriveOutageUntilAlert(TelegramBotHostedService service, DateTimeOffset from)
+    {
+        var elapsed = TimeSpan.Zero;
+        while (elapsed < DownAlertThreshold)
+        {
+            InvokeHandleTransientPollingFailure(service, TransportFailure(), from + elapsed);
+            elapsed += OutageCadence;
+        }
+
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), from + elapsed);
+        return from + elapsed;
+    }
+
+    /// <summary>What TelegramBotClient.SendRequest wraps every dropped connection into.</summary>
+    private static RequestException TransportFailure() =>
+        new("Exception during making request",
+            new HttpRequestException("An error occurred while sending the request.",
+                new IOException("The response ended prematurely. (ResponseEnded)")));
+
+    // ---- severity split ----
+
     [Fact]
     public void ATransportLevelRequestException_LogsWarningNotErrorAndBacksOff()
     {
         var (service, logger) = CreateService();
-        // What TelegramBotClient.SendRequest wraps every dropped connection into -- including
-        // the "ResponseEnded" case from the issue, which contains neither "timeout" nor
+        // The "ResponseEnded" case from the issue, which contains neither "timeout" nor
         // "timed out" and so took no backoff at all under the old substring check.
-        var exception = new RequestException("Exception during making request", new HttpRequestException());
-
-        var task = InvokeHandlePollingErrorAsync(service, exception);
+        var task = InvokeHandlePollingErrorAsync(service, TransportFailure());
 
         var entry = Assert.Single(logger.Entries);
         Assert.Equal(LogLevel.Warning, entry.Level);
         Assert.Null(entry.Exception); // no stack trace for a routine blip
         Assert.False(task.IsCompleted, "a transient failure must still back off before the next poll");
+    }
+
+    [Fact]
+    public void ATransportLevelRequestException_LogsTheInnerCauseNotJustTheFixedWrapperMessage()
+    {
+        var (service, logger) = CreateService();
+
+        InvokeHandlePollingErrorAsync(service, TransportFailure());
+
+        // RequestException.Message is always "Exception during making request", so on its own it
+        // makes all ~1200 daily lines identical. The cause lives in the inner exception.
+        var entry = Assert.Single(logger.Entries);
+        Assert.Contains("ResponseEnded", entry.Message);
     }
 
     [Fact]
@@ -84,6 +148,22 @@ public class TelegramBotHostedServicePollingErrorTests
     }
 
     [Fact]
+    public void AFatalError_StaysAtErrorEvenWhenTheExceptionLooksTransient()
+    {
+        var (service, logger) = CreateService();
+
+        // Telegram.Bot documents FatalError as "Polling of updates will stop". The exception on
+        // that path is shaped exactly like a routine blip, so dispatching on type alone would
+        // downgrade a permanently deaf bot to a single Warning.
+        var task = InvokeHandlePollingErrorAsync(service, TransportFailure(), HandleErrorSource.FatalError);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.NotNull(entry.Exception);
+        Assert.True(task.IsCompleted, "there is no receive loop left to back off for");
+    }
+
+    [Fact]
     public void AnUnexpectedExceptionType_StaysAtErrorSeverity()
     {
         var (service, logger) = CreateService();
@@ -96,57 +176,108 @@ public class TelegramBotHostedServicePollingErrorTests
         Assert.Same(exception, entry.Exception);
     }
 
+    // ---- backoff ----
+
     [Fact]
-    public void ConsecutiveTransientFailures_EscalateToErrorOnlyAfterTheDownThreshold()
+    public void TheFirstBlipRetriesQuickly_AndOnlySustainedFailureSettlesAtTheLongDelay()
     {
         var (service, logger) = CreateService();
         var start = DateTimeOffset.UtcNow;
-        var exception = new RequestException("Exception during making request", new HttpRequestException());
 
-        // Ten seconds apart matches the handler's own retry delay -- a realistic failure cadence.
-        for (var i = 0; i < 11; i++)
-        {
-            InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(10 * i));
-        }
+        // An isolated blip used to cost nothing (immediate retry) and must not now cost ten
+        // seconds of deafness for a customer waiting on a keyboard tap.
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), start);
+        Assert.Contains("00:00:01", logger.Entries[0].Message);
 
-        // 100 seconds of failures so far: still under the two-minute threshold, so only Warnings.
-        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), start + TimeSpan.FromSeconds(1));
+        Assert.Contains("00:00:02", logger.Entries[1].Message);
 
-        // This one crosses the two-minute mark.
-        InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(130));
-        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), start + TimeSpan.FromSeconds(3));
+        Assert.Contains("00:00:05", logger.Entries[2].Message);
 
-        // Still down afterwards must not log a second Error -- one alert per streak, not one per failure.
-        InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(140));
+        // ...and it caps there rather than growing without bound.
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), start + TimeSpan.FromSeconds(8));
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), start + TimeSpan.FromSeconds(18));
+        Assert.Contains("00:00:10", logger.Entries[3].Message);
+        Assert.Contains("00:00:10", logger.Entries[4].Message);
+    }
+
+    // ---- escalate on persistence ----
+
+    [Fact]
+    public void ASustainedOutage_EscalatesOnceAtTheRealPollCadence()
+    {
+        var (service, logger) = CreateService();
+        var start = DateTimeOffset.UtcNow;
+
+        // No updates arrive and every poll dies only after the full long-poll timeout: the bot is
+        // genuinely deaf. This is the cadence a real outage produces, not one failure per 10s.
+        var lastFailure = DriveOutageUntilAlert(service, start);
+
+        var alert = Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains("may not be receiving updates", alert.Message);
+        Assert.Equal(alert, logger.Entries[^1]); // nothing before the threshold was an Error
+
+        // Still down afterwards must not log a second Error -- one alert per outage.
+        InvokeHandleTransientPollingFailure(service, TransportFailure(), lastFailure + OutageCadence);
         Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
     }
 
     [Fact]
-    public void RecoveringBetweenFailures_ResetsTheStreakSoASecondOutageEscalatesAgain()
+    public void BlipsWithUpdatesStillArriving_NeverEscalateHoweverLongTheyGoOn()
     {
         var (service, logger) = CreateService();
         var start = DateTimeOffset.UtcNow;
-        var exception = new RequestException("Exception during making request", new HttpRequestException());
 
-        // A two-minute outage that escalates once...
-        for (var i = 0; i <= 12; i++)
+        // The exact pattern issue #148 measured: 1214 failures in a day, one roughly every 71
+        // seconds, while trades placed through the bot settled normally throughout. The bot is
+        // working; this must stay Warning-only for as long as it lasts.
+        var cadence = TimeSpan.FromSeconds(71);
+        for (var i = 0; i < 60; i++)
         {
-            InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(10 * i));
+            var at = start + cadence * i;
+            InvokeHandleTransientPollingFailure(service, TransportFailure(), at);
+            InvokeRecordUpdateReceived(service, at + TimeSpan.FromSeconds(35)); // a customer got through
         }
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Equal(60, logger.Entries.Count(e => e.Level == LogLevel.Warning));
+    }
+
+    [Fact]
+    public void OccasionalBlipsOnAQuietBot_DoNotEscalateEitherEvenWithNoUpdatesToProveRecovery()
+    {
+        var (service, logger) = CreateService();
+        var start = DateTimeOffset.UtcNow;
+
+        // Overnight there may be no traffic at all, so no update can vouch for recovery. A gap
+        // longer than a whole poll cycle is what stands in for it: these polls are succeeding,
+        // they are just occasionally unlucky.
+        for (var i = 0; i < 20; i++)
+        {
+            InvokeHandleTransientPollingFailure(service, TransportFailure(), start + TimeSpan.FromMinutes(10) * i);
+        }
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public void RecoveringBetweenOutages_ResetsTheStreakSoASecondOutageEscalatesAgain()
+    {
+        var (service, logger) = CreateService();
+        var start = DateTimeOffset.UtcNow;
+
+        var firstOutageEnded = DriveOutageUntilAlert(service, start);
         Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
 
-        // ...followed by a long gap, meaning updates were flowing again in between...
-        var recovered = start + TimeSpan.FromMinutes(10);
-        InvokeHandleTransientPollingFailure(service, exception, recovered);
+        // Polling comes back -- an update proves it, so a short recovery counts, not only one
+        // longer than a poll cycle.
+        var recovered = firstOutageEnded + TimeSpan.FromSeconds(5);
+        InvokeRecordUpdateReceived(service, recovered);
 
-        // ...so recovery itself must not immediately re-trip the alert.
-        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        // A second outage after that must be able to escalate on its own.
+        DriveOutageUntilAlert(service, recovered + TimeSpan.FromSeconds(1));
 
-        // A second two-minute outage after recovery must be able to escalate on its own.
-        for (var i = 1; i <= 12; i++)
-        {
-            InvokeHandleTransientPollingFailure(service, exception, recovered + TimeSpan.FromSeconds(10 * i));
-        }
         Assert.Equal(2, logger.Entries.Count(e => e.Level == LogLevel.Error));
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/TelegramBotHostedServicePollingErrorTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/TelegramBotHostedServicePollingErrorTests.cs
@@ -1,0 +1,152 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TallaEgg.AllServices.Tests.Fakes;
+using TallaEgg.TelegramBot.Core.Interfaces;
+using TallaEgg.TelegramBot.Infrastructure;
+using TallaEgg.TelegramBot.Infrastructure.Options;
+using Telegram.Bot;
+using Telegram.Bot.Exceptions;
+using Telegram.Bot.Polling;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// <c>HandlePollingErrorAsync</c> used to log every polling hiccup at Error with a full stack
+/// trace, so a dropped connection every ~50 seconds made the bot's error log 100% noise and hid
+/// any real fault in it (issue #148). These pin the severity split (transport blip vs. a real
+/// Telegram API fault) and the escalate-on-persistence behaviour that replaced it.
+///
+/// The handler is intentionally private -- it's wired into Telegram.Bot's <c>StartReceiving</c>,
+/// not a public API of this class -- so these reach it through reflection.
+/// </summary>
+public class TelegramBotHostedServicePollingErrorTests
+{
+    private static (TelegramBotHostedService Service, CapturingLogger<TelegramBotHostedService> Logger) CreateService()
+    {
+        var logger = new CapturingLogger<TelegramBotHostedService>();
+        var service = new TelegramBotHostedService(
+            new TelegramBotClient("1:AA"),
+            botHandler: null!, // unused by the polling-error path under test
+            logger,
+            Options.Create(new TelegramBotOptions()),
+            new FakeHostApplicationLifetime());
+
+        return (service, logger);
+    }
+
+    private static Task InvokeHandlePollingErrorAsync(TelegramBotHostedService service, Exception exception, CancellationToken cancellationToken = default)
+    {
+        var method = typeof(TelegramBotHostedService).GetMethod("HandlePollingErrorAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("HandlePollingErrorAsync not found.");
+
+        return (Task)method.Invoke(service, [null, exception, HandleErrorSource.PollingError, cancellationToken])!;
+    }
+
+    private static Task InvokeHandleTransientPollingFailure(
+        TelegramBotHostedService service, Exception exception, DateTimeOffset now, CancellationToken cancellationToken = default)
+    {
+        var method = typeof(TelegramBotHostedService).GetMethod("HandleTransientPollingFailure", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("HandleTransientPollingFailure not found.");
+
+        return (Task)method.Invoke(service, [HandleErrorSource.PollingError, exception, now, cancellationToken])!;
+    }
+
+    [Fact]
+    public void ATransportLevelRequestException_LogsWarningNotErrorAndBacksOff()
+    {
+        var (service, logger) = CreateService();
+        // What TelegramBotClient.SendRequest wraps every dropped connection into -- including
+        // the "ResponseEnded" case from the issue, which contains neither "timeout" nor
+        // "timed out" and so took no backoff at all under the old substring check.
+        var exception = new RequestException("Exception during making request", new HttpRequestException());
+
+        var task = InvokeHandlePollingErrorAsync(service, exception);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Null(entry.Exception); // no stack trace for a routine blip
+        Assert.False(task.IsCompleted, "a transient failure must still back off before the next poll");
+    }
+
+    [Fact]
+    public void AnApiRequestException_LogsErrorImmediatelyWithNoBackoff()
+    {
+        var (service, logger) = CreateService();
+        var exception = new ApiRequestException("Unauthorized", 401);
+
+        var task = InvokeHandlePollingErrorAsync(service, exception);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Same(exception, entry.Exception);
+        Assert.True(task.IsCompleted, "a real API fault must not be delayed like a transient blip");
+    }
+
+    [Fact]
+    public void AnUnexpectedExceptionType_StaysAtErrorSeverity()
+    {
+        var (service, logger) = CreateService();
+        var exception = new InvalidOperationException("something genuinely unexpected");
+
+        InvokeHandlePollingErrorAsync(service, exception);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Same(exception, entry.Exception);
+    }
+
+    [Fact]
+    public void ConsecutiveTransientFailures_EscalateToErrorOnlyAfterTheDownThreshold()
+    {
+        var (service, logger) = CreateService();
+        var start = DateTimeOffset.UtcNow;
+        var exception = new RequestException("Exception during making request", new HttpRequestException());
+
+        // Ten seconds apart matches the handler's own retry delay -- a realistic failure cadence.
+        for (var i = 0; i < 11; i++)
+        {
+            InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(10 * i));
+        }
+
+        // 100 seconds of failures so far: still under the two-minute threshold, so only Warnings.
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+
+        // This one crosses the two-minute mark.
+        InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(130));
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+
+        // Still down afterwards must not log a second Error -- one alert per streak, not one per failure.
+        InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(140));
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public void RecoveringBetweenFailures_ResetsTheStreakSoASecondOutageEscalatesAgain()
+    {
+        var (service, logger) = CreateService();
+        var start = DateTimeOffset.UtcNow;
+        var exception = new RequestException("Exception during making request", new HttpRequestException());
+
+        // A two-minute outage that escalates once...
+        for (var i = 0; i <= 12; i++)
+        {
+            InvokeHandleTransientPollingFailure(service, exception, start + TimeSpan.FromSeconds(10 * i));
+        }
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+
+        // ...followed by a long gap, meaning updates were flowing again in between...
+        var recovered = start + TimeSpan.FromMinutes(10);
+        InvokeHandleTransientPollingFailure(service, exception, recovered);
+
+        // ...so recovery itself must not immediately re-trip the alert.
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+
+        // A second two-minute outage after recovery must be able to escalate on its own.
+        for (var i = 1; i <= 12; i++)
+        {
+            InvokeHandleTransientPollingFailure(service, exception, recovered + TimeSpan.FromSeconds(10 * i));
+        }
+        Assert.Equal(2, logger.Entries.Count(e => e.Level == LogLevel.Error));
+    }
+}


### PR DESCRIPTION
## Description
`HandlePollingErrorAsync` logged every Telegram polling error unconditionally at `Error` with a full stack trace, and only backed off when the exception message happened to contain "timeout"/"timed out". Nearly every real failure is `TelegramBotClient.SendRequest` wrapping a dropped connection into a plain `RequestException` ("Exception during making request"), which matches neither string — so it got zero backoff and made the bot's error log 100% noise (1214/1214 error lines on 2026-08-27 were this one recoverable blip).

## Linked Task / Finding
Closes #148

## Type
- [x] Hotfix

## Changes
- Split polling-error severity by exception **type** instead of message-substring matching:
  - `ApiRequestException` (Telegram rejected the request — rotated token, rate limit) → `Error`, immediately, no backoff. This is a real fault.
  - Plain `RequestException` (transport-level: dropped connection, timeout, malformed response) → `Warning`, no stack trace, and now **always** backs off (10s), not only when the message text happened to say "timeout".
  - Any other exception type → stays at `Error`, so nothing outside those two known-transient shapes is silenced.
- Added escalate-on-persistence: a run of transient failures now logs a single `Error` once the bot has genuinely been failing to poll for 2 consecutive minutes, and resets once a gap between failures implies polling recovered in between (so a later outage can escalate again).
- Added `TelegramBotHostedServicePollingErrorTests` (5 tests) covering the severity split, the backoff behavior, and the escalate/reset timing (driven via an explicit timestamp parameter so the 2-minute threshold is tested deterministically, no real sleeping).
- Added two small test doubles (`CapturingLogger<T>`, `FakeHostApplicationLifetime`) under `tests/TallaEgg.AllServices.Tests/Fakes/`.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`) — 506/506 passing (501 previously + 5 new)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Follows naming conventions (STANDARDS.md)
- [x] Tests added/updated (unit)
- [ ] Docs updated — not applicable, no behavior change to a documented API
- [ ] Peer reviewed — pending