### PR TITLE
[Hotfix][Critical] Plausibility band for auto-published quotes — issue #158

### DIFF
--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -49,6 +50,37 @@ public class AutoQuotePublisherService : BackgroundService
     /// </para>
     /// </summary>
     private const decimal MaxDeviationPercent = 5m;
+
+    /// <summary>
+    /// How many consecutive band rejections mean the feed, and not the market, is what changed.
+    ///
+    /// <para>
+    /// One rejection is a glitch and holding the previous quote is the whole point. Three in a
+    /// row — six minutes of a source insisting on the same implausible level — is not transient,
+    /// and the system cannot tell a real repricing from a persistently broken feed: the provider
+    /// chain returns the first source that answers and never compares two against each other.
+    /// </para>
+    ///
+    /// <para>
+    /// So it stops rather than guesses (product owner, issue #158). Continuing to hold the quote
+    /// would be the worse of the two: during a genuine fast move a stale price is exactly what a
+    /// customer arbitrages, and only in the direction that costs the shop. An outage an admin can
+    /// end in seconds is recoverable; a run of trades at a price nobody meant to offer is not.
+    /// </para>
+    /// </summary>
+    private const int MaxConsecutiveRejections = 3;
+
+    /// <summary>
+    /// Consecutive band rejections per symbol, reset by any tick that publishes.
+    ///
+    /// <para>
+    /// Deliberately in memory rather than on <see cref="AutoQuoteSettings"/>: a restart clearing
+    /// it only costs three more held ticks before the same stop happens, which does not justify a
+    /// column and a migration. The stop itself is persisted, so what a restart must not lose —
+    /// that the shop decided to stop quoting this symbol — is not held here.
+    /// </para>
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _consecutiveRejections = new();
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<AutoQuotePublisherService> _logger;
@@ -124,7 +156,15 @@ public class AutoQuotePublisherService : BackgroundService
         var quoteRepo = scope.ServiceProvider.GetRequiredService<IQuoteRepository>();
 
         if (!IsPlausible(symbol, referencePrice.Value, await quoteRepo.GetActiveAsync(symbol)))
+        {
+            await StopQuotingIfRejectionsPersistAsync(symbol, quoteRepo, settingsRepo, settings);
             return;
+        }
+
+        // Any published tick clears the streak, so only *consecutive* rejections count towards
+        // stopping. A single outlier between good ticks is the transient case the band already
+        // handles by holding the previous quote.
+        _consecutiveRejections.TryRemove(symbol, out _);
 
         // referencePrice is already Toman per traded base unit (a gram of gold, a whole coin, a
         // whole Bitcoin) — each provider does its own unit conversion, so nothing here is
@@ -202,12 +242,61 @@ public class AutoQuotePublisherService : BackgroundService
         // like a quiet market, and the point of the band is that somebody finds out. The rejected
         // value and the band it violated are both in the message so the log alone says what
         // happened, without needing the price source to be queried again.
+        //
+        // Four decimal places rather than two: a marginal breach rounded to two prints "is 5.00%
+        // away ... outside the plausibility band of ±5%", which reads as a contradiction to
+        // whoever is on call.
         _logger.LogWarning(
             "Auto-quote for {Symbol} rejected: reference price {Reference} is {Deviation}% away from the last published mid {LastMid}, " +
             "outside the plausibility band of ±{Band}%. Keeping the previous quote (buy {LastBuy}, sell {LastSell}).",
-            symbol, referencePrice, decimal.Round(deviationPercent, 2), lastMid, MaxDeviationPercent,
+            symbol, referencePrice, decimal.Round(deviationPercent, 4), lastMid, MaxDeviationPercent,
             lastQuote.BuyPrice, lastQuote.SellPrice);
 
         return false;
+    }
+
+    /// <summary>
+    /// Counts one band rejection for a symbol and, once they stop looking transient, takes the
+    /// symbol out of service: the active quote is deactivated so nothing stale stays tradeable,
+    /// and auto-quoting is switched off so the next tick cannot publish an unanchored price
+    /// through the cold-start path.
+    ///
+    /// <para>
+    /// Switching off reuses <see cref="AutoQuoteSettings.IsEnabled"/>, which exists for exactly
+    /// this — its own documentation calls it the switch to reach for when a reading or a provider
+    /// misbehaves. An admin turns it back on from the bot after publishing a price by hand, so
+    /// recovery needs no deploy and no database access.
+    /// </para>
+    /// </summary>
+    private async Task StopQuotingIfRejectionsPersistAsync(
+        string symbol,
+        IQuoteRepository quoteRepo,
+        IAutoQuoteSettingsRepository settingsRepo,
+        AutoQuoteSettings settings)
+    {
+        var rejections = _consecutiveRejections.AddOrUpdate(symbol, 1, (_, count) => count + 1);
+
+        if (rejections < MaxConsecutiveRejections) return;
+
+        // Deactivate before disabling. If the process dies between the two, the half that has
+        // happened is the one that stops customers trading a price the shop no longer believes.
+        var deactivated = await quoteRepo.DeactivateActiveAsync(symbol);
+
+        // Guid.Empty rather than the admin who last configured auto-quote: nobody turned this
+        // off, the service did, and recording a person here would send whoever investigates to
+        // ask them why.
+        settings.SetEnabled(false, Guid.Empty);
+        await settingsRepo.SaveAsync(settings);
+
+        // The streak is spent. If an admin re-enables auto-quote while the feed is still wrong,
+        // it gets a full three ticks again rather than stopping on the first one.
+        _consecutiveRejections.TryRemove(symbol, out _);
+
+        _logger.LogError(
+            "Auto-quote for {Symbol} stopped after {Rejections} consecutive prices outside the ±{Band}% band. " +
+            "{Deactivated} quote(s) deactivated and auto-quoting disabled: the price source and the last published " +
+            "quote have disagreed for {Minutes} minutes, which is a broken feed or a real repricing, and this service " +
+            "cannot tell them apart. Publish a quote by hand and re-enable auto-quote once the source is trusted.",
+            symbol, rejections, MaxDeviationPercent, deactivated, MaxConsecutiveRejections * PollInterval.TotalMinutes);
     }
 }

--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 using TallaEgg.Core;
+using TallaEgg.Core.ErrorHandling;
 
 namespace Orders.Application.Services;
 
@@ -28,6 +29,26 @@ namespace Orders.Application.Services;
 public class AutoQuotePublisherService : BackgroundService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// How far the reference price may sit from the last published quote before the tick is
+    /// refused, as a percentage of that quote's mid price.
+    ///
+    /// <para>
+    /// This is a business number rather than an engineering one, set by the product owner
+    /// (issue #158). Gold does not move 5% in the two minutes between ticks, so a source that
+    /// says it did is reporting a broken feed, not a market. The value is deliberately far wider
+    /// than any real move and still far narrower than the failures it exists to catch: a
+    /// per-mithqal figure read as per-gram is roughly 4.33x, a misplaced decimal is 10x.
+    /// </para>
+    ///
+    /// <para>
+    /// One band covers every symbol. If the coin or Bitcoin ever needs its own, it belongs
+    /// alongside the spread in <see cref="AutoQuoteSettings"/> so an admin can set it per symbol,
+    /// which is a larger change than this one.
+    /// </para>
+    /// </summary>
+    private const decimal MaxDeviationPercent = 5m;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<AutoQuotePublisherService> _logger;
@@ -100,14 +121,17 @@ public class AutoQuotePublisherService : BackgroundService
             return;
         }
 
+        var quoteRepo = scope.ServiceProvider.GetRequiredService<IQuoteRepository>();
+
+        if (!IsPlausible(symbol, referencePrice.Value, await quoteRepo.GetActiveAsync(symbol)))
+            return;
+
         // referencePrice is already Toman per traded base unit (a gram of gold, a whole coin, a
         // whole Bitcoin) — each provider does its own unit conversion, so nothing here is
         // specific to any one symbol.
         var halfSpread = settings.SpreadPercent / 100m / 2m;
         var buyPrice = decimal.Round(referencePrice.Value * (1 - halfSpread), 2);
         var sellPrice = decimal.Round(referencePrice.Value * (1 + halfSpread), 2);
-
-        var quoteRepo = scope.ServiceProvider.GetRequiredService<IQuoteRepository>();
 
         try
         {
@@ -118,12 +142,72 @@ public class AutoQuotePublisherService : BackgroundService
                 "Auto-published quote for {Symbol}: buy {BuyPrice}, sell {SellPrice} (reference {Reference}, spread {Spread}%).",
                 symbol, buyPrice, sellPrice, referencePrice, settings.SpreadPercent);
         }
-        catch (ArgumentException ex)
+        catch (BusinessRuleException ex)
         {
             // Quote.Publish's own validation (e.g. a zero/negative price from a source
             // returning garbage) rejects the quote. Logged and skipped, not thrown further —
             // the previous quote stays active until the next tick gets a sane price.
+            //
+            // This used to catch ArgumentException, which Quote.Publish has never thrown: all
+            // five of its validation paths raise BusinessRuleException, which derives straight
+            // from Exception. The handler could not run, so a rejected price was reported by the
+            // loop's generic catch at Error — reading as a service fault rather than the normal
+            // rejection it is — and this warning was never written (issue #158, same shape
+            // as #143).
             _logger.LogWarning(ex, "Auto-quote for {Symbol} rejected by Quote.Publish; keeping the previous quote.", symbol);
         }
+    }
+
+    /// <summary>
+    /// Whether a reference price is close enough to the last published quote to be believable.
+    ///
+    /// <para>
+    /// The comparison is against that quote's mid price, which for an auto-published quote is
+    /// exactly the reference price it was built from — the spread is applied symmetrically either
+    /// side. A manually published quote need not be symmetric, but its mid is still the best
+    /// statement available of what the shop last considered this symbol to be worth.
+    /// </para>
+    ///
+    /// <para>
+    /// Rejecting rather than clamping is deliberate. Clamping would publish a price no source
+    /// ever reported, which the shop is then bound to honour, and a feed stuck on a bad number
+    /// would walk the quote towards it one tick at a time until it arrived. Holding the previous
+    /// quote leaves the shop on the last price a source actually agreed with.
+    /// </para>
+    /// </summary>
+    /// <param name="symbol">The symbol being quoted, for the log message.</param>
+    /// <param name="referencePrice">The price the provider chain returned this tick.</param>
+    /// <param name="lastQuote">The symbol's active quote, or null if it has never had one.</param>
+    private bool IsPlausible(string symbol, decimal referencePrice, Quote? lastQuote)
+    {
+        if (lastQuote is null)
+        {
+            // Cold start: nothing has ever been published for this symbol, so there is nothing
+            // for the price to be implausible relative to. Accepting it is what lets auto-quote
+            // bootstrap a newly activated symbol at all; the band applies from the next tick on.
+            // A restart does not reach here — the active quote is read from the database, so it
+            // survives one.
+            _logger.LogInformation(
+                "Auto-quote for {Symbol}: no previous quote to compare against, so the plausibility band was not applied to reference {Reference}.",
+                symbol, referencePrice);
+            return true;
+        }
+
+        var lastMid = (lastQuote.BuyPrice + lastQuote.SellPrice) / 2m;
+        var deviationPercent = Math.Abs(referencePrice - lastMid) / lastMid * 100m;
+
+        if (deviationPercent <= MaxDeviationPercent) return true;
+
+        // Loud on purpose. Skipping the tick silently would leave a broken feed looking exactly
+        // like a quiet market, and the point of the band is that somebody finds out. The rejected
+        // value and the band it violated are both in the message so the log alone says what
+        // happened, without needing the price source to be queried again.
+        _logger.LogWarning(
+            "Auto-quote for {Symbol} rejected: reference price {Reference} is {Deviation}% away from the last published mid {LastMid}, " +
+            "outside the plausibility band of ±{Band}%. Keeping the previous quote (buy {LastBuy}, sell {LastSell}).",
+            symbol, referencePrice, decimal.Round(deviationPercent, 2), lastMid, MaxDeviationPercent,
+            lastQuote.BuyPrice, lastQuote.SellPrice);
+
+        return false;
     }
 }

--- a/src/Order/Orders.Core/IQuoteRepository.cs
+++ b/src/Order/Orders.Core/IQuoteRepository.cs
@@ -1,4 +1,4 @@
-﻿namespace Orders.Core;
+namespace Orders.Core;
 
 public interface IQuoteRepository
 {
@@ -32,4 +32,17 @@ public interface IQuoteRepository
     /// can see.
     /// </summary>
     Task<IReadOnlyList<string>> GetActiveSymbolsAsync();
+
+    /// <summary>
+    /// Deactivates a symbol's active quote without publishing a replacement, leaving the symbol
+    /// with no tradeable price. Returns how many rows were deactivated.
+    ///
+    /// <para>
+    /// Distinct from the deactivation <see cref="PublishAsync"/> performs, which always has a
+    /// successor. This is the deliberate "stop quoting" case (issue #158): when the price feed
+    /// has persistently disagreed with the last published quote, no quote is safer than a stale
+    /// one, because a stale price during a real move is the one customers arbitrage.
+    /// </para>
+    /// </summary>
+    Task<int> DeactivateActiveAsync(string symbol);
 }

--- a/src/Order/Orders.Infrastructure/QuoteRepository.cs
+++ b/src/Order/Orders.Infrastructure/QuoteRepository.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 
@@ -60,6 +60,28 @@ public class QuoteRepository : IQuoteRepository
             .Select(q => q.Symbol)
             .Distinct()
             .ToListAsync();
+    }
+
+    public async Task<int> DeactivateActiveAsync(string symbol)
+    {
+        var normalized = symbol.Trim().ToUpperInvariant();
+
+        var active = await _context.Quotes
+            .Where(q => q.Symbol == normalized && q.IsActive)
+            .ToListAsync();
+
+        foreach (var quote in active)
+            quote.Deactivate();
+
+        // No transaction: unlike PublishAsync there is no insert to keep in step with the
+        // deactivation, so one SaveChanges is already atomic. Nothing is deleted — the rows stay
+        // readable as history, exactly as a replaced quote does.
+        if (active.Count > 0)
+            await _context.SaveChangesAsync();
+
+        _logger.LogInformation("Deactivated {Count} active quote(s) for {Symbol} with no replacement.", active.Count, normalized);
+
+        return active.Count;
     }
 
     public async Task<Quote> PublishAsync(Quote quote)

--- a/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
@@ -71,16 +71,25 @@ public class AutoQuotePublisherServiceTests : IDisposable
             Task.FromResult(Price);
     }
 
-    private async Task RunTickAsync(string symbol = Symbol)
-    {
-        // A fresh service instance per tick, holding no state of its own: what the band compares
-        // against has to come from the database, which is also what makes the restart case below
-        // a real test rather than a restatement of the previous one.
-        var service = new AutoQuotePublisherService(
-            _provider.GetRequiredService<IServiceScopeFactory>(), _logger);
+    private AutoQuotePublisherService NewService() => new(
+        _provider.GetRequiredService<IServiceScopeFactory>(), _logger);
 
-        await service.PublishIfDueAsync(symbol, CancellationToken.None);
-    }
+    private AutoQuotePublisherService? _service;
+
+    /// <summary>
+    /// One service instance for every tick a test runs, because the consecutive-rejection count
+    /// that decides when to stop quoting lives on it.
+    /// <see cref="RunTickOnAFreshServiceAsync"/> is the deliberate exception.
+    /// </summary>
+    private Task RunTickAsync(string symbol = Symbol) =>
+        (_service ??= NewService()).PublishIfDueAsync(symbol, CancellationToken.None);
+
+    /// <summary>
+    /// A tick from a service that has just started and holds nothing in memory — a restart. What
+    /// the band compares against has to come from the database for this to behave at all.
+    /// </summary>
+    private Task RunTickOnAFreshServiceAsync(string symbol = Symbol) =>
+        NewService().PublishIfDueAsync(symbol, CancellationToken.None);
 
     private async Task SeedSettingsAsync(bool isEnabled, decimal spreadPercent, Guid updatedBy, string symbol = Symbol)
     {
@@ -259,10 +268,14 @@ public class AutoQuotePublisherServiceTests : IDisposable
         await RunTickAsync();
 
         var warning = Assert.Single(_logger.Entries, e => e.Level == LogLevel.Warning);
-        Assert.Contains("2000000", warning.Message);   // the rejected value
-        Assert.Contains("1000000", warning.Message);   // the mid it was measured against
-        Assert.Contains("100", warning.Message);       // how far off it was, as a percentage
-        Assert.Contains("5", warning.Message);         // the band it violated
+
+        // Each number is asserted together with the words that give it its meaning. Bare
+        // substrings would not do: "100" for the deviation also matches inside "1000000",
+        // so the assertion would still pass with the deviation missing from the message.
+        Assert.Contains("reference price 2000000 is", warning.Message);
+        Assert.Matches(@"is 100(\.0+)?% away from the last published mid 1000000", warning.Message);
+        Assert.Contains("plausibility band of ±5%", warning.Message);
+        Assert.Matches(@"Keeping the previous quote \(buy 995000(\.0+)?, sell 1005000(\.0+)?\)", warning.Message);
     }
 
     /// <summary>
@@ -334,7 +347,7 @@ public class AutoQuotePublisherServiceTests : IDisposable
         }
 
         _stubProvider.Price = 34_640_000m;
-        await RunTickAsync();
+        await RunTickOnAFreshServiceAsync();
 
         var quote = await ActiveQuoteAsync();
         Assert.Equal(7_960_000m, quote!.BuyPrice);
@@ -390,5 +403,133 @@ public class AutoQuotePublisherServiceTests : IDisposable
         _stubProvider.Price = 5_460_000_000m;           // a decimal slipped: 10x too low, rejected
         await RunTickAsync(btc);
         Assert.Equal(54_327_000_000m, (await ActiveQuoteAsync(btc))!.BuyPrice);
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Stopping, rather than holding a stale quote forever.
+    //
+    // Holding the previous quote is right for one bad tick and wrong for an hour of them: the
+    // anchor only moves when a quote is published, and publishing only happens when the band
+    // passes, so a genuine move over the band would freeze the shop on the old price with no
+    // way out. Confirmed before this was written — thirty ticks at a stable, 10%-higher market
+    // left the old quote active and tradeable, and nothing in QuoteFillService checks a
+    // quote's age. Three consecutive rejections now take the symbol out of service instead.
+    // -----------------------------------------------------------------------------------
+
+    private async Task<bool> AutoQuoteIsEnabledAsync(string symbol = Symbol)
+    {
+        using var db = new OrdersDbContext(Options());
+        return (await db.AutoQuoteSettings.SingleAsync(x => x.Symbol == symbol)).IsEnabled;
+    }
+
+    [Fact]
+    public async Task TwoConsecutiveRejectionsKeepQuoting()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 1_100_000m;
+        await RunTickAsync();
+        await RunTickAsync();
+
+        Assert.Equal(995_000m, (await ActiveQuoteAsync())!.BuyPrice);
+        Assert.True(await AutoQuoteIsEnabledAsync());
+        Assert.DoesNotContain(_logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    /// <summary>
+    /// The third rejection takes the symbol out of service: no active quote for QuoteFillService
+    /// to sell against, and auto-quote off so the next tick cannot publish an unanchored price
+    /// through the cold-start path. The old quote row is deactivated, not deleted — past trades
+    /// still need to say what price was in force.
+    /// </summary>
+    [Fact]
+    public async Task ThreeConsecutiveRejectionsStopQuotingTheSymbolAndLogAnError()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 1_100_000m;
+        await RunTickAsync();
+        await RunTickAsync();
+        await RunTickAsync();
+
+        Assert.Null(await ActiveQuoteAsync());
+        Assert.False(await AutoQuoteIsEnabledAsync());
+
+        var error = Assert.Single(_logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains("stopped after 3 consecutive prices", error.Message);
+
+        using var db = new OrdersDbContext(Options());
+        Assert.Single(db.Quotes);   // deactivated, still there as history
+    }
+
+    /// <summary>
+    /// After the stop, a perfectly sane price changes nothing — an admin has to publish a quote
+    /// by hand and re-enable auto-quote. Without this the stop would be theatre: the very next
+    /// tick would publish through the cold-start path, which is unanchored by definition.
+    /// </summary>
+    [Fact]
+    public async Task AfterStoppingEvenAGoodPricePublishesNothing()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 1_100_000m;
+        for (var tick = 0; tick < 3; tick++) await RunTickAsync();
+
+        _stubProvider.Price = 1_010_000m;
+        await RunTickAsync();
+
+        Assert.Null(await ActiveQuoteAsync());
+    }
+
+    /// <summary>
+    /// Only <em>consecutive</em> rejections count. An outlier every other tick is the transient
+    /// case the band already handles by holding the previous quote, and must never accumulate
+    /// into a shutdown of a symbol that is quoting perfectly well.
+    /// </summary>
+    [Fact]
+    public async Task AnAcceptedTickClearsTheRejectionStreak()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        for (var round = 0; round < 3; round++)
+        {
+            _stubProvider.Price = 2_000_000m;   // rejected
+            await RunTickAsync();
+            await RunTickAsync();
+
+            _stubProvider.Price = 1_000_000m;   // accepted, streak back to zero
+            await RunTickAsync();
+        }
+
+        Assert.NotNull(await ActiveQuoteAsync());
+        Assert.True(await AutoQuoteIsEnabledAsync());
+        Assert.DoesNotContain(_logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    /// <summary>One symbol stopping must not stop another; the streak is counted per symbol.</summary>
+    [Fact]
+    public async Task StoppingOneSymbolLeavesAnotherQuoting()
+    {
+        var coin = CurrenciesConstant.SEKE_BAHAR_IRT;
+
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid(), symbol: Symbol);
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid(), symbol: coin);
+
+        _stubProvider.Price = 1_000_000m;
+        await RunTickAsync(Symbol);
+        await RunTickAsync(coin);
+
+        _stubProvider.Price = 2_000_000m;
+        for (var tick = 0; tick < 3; tick++) await RunTickAsync(Symbol);
+
+        Assert.Null(await ActiveQuoteAsync(Symbol));
+        Assert.False(await AutoQuoteIsEnabledAsync(Symbol));
+
+        Assert.NotNull(await ActiveQuoteAsync(coin));
+        Assert.True(await AutoQuoteIsEnabledAsync(coin));
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
@@ -6,6 +6,8 @@ using Orders.Application.Services;
 using Orders.Core;
 using Orders.Infrastructure;
 using TallaEgg.Core;
+using TallaEgg.AllServices.Tests.Fakes;
+using Microsoft.Extensions.Logging;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -27,6 +29,7 @@ public class AutoQuotePublisherServiceTests : IDisposable
     private readonly SqliteConnection _connection;
     private readonly ServiceProvider _provider;
     private readonly StubProvider _stubProvider = new();
+    private readonly CapturingLogger<AutoQuotePublisherService> _logger = new();
 
     public AutoQuotePublisherServiceTests()
     {
@@ -70,8 +73,11 @@ public class AutoQuotePublisherServiceTests : IDisposable
 
     private async Task RunTickAsync(string symbol = Symbol)
     {
+        // A fresh service instance per tick, holding no state of its own: what the band compares
+        // against has to come from the database, which is also what makes the restart case below
+        // a real test rather than a restatement of the previous one.
         var service = new AutoQuotePublisherService(
-            _provider.GetRequiredService<IServiceScopeFactory>(), NullLogger<AutoQuotePublisherService>.Instance);
+            _provider.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         await service.PublishIfDueAsync(symbol, CancellationToken.None);
     }
@@ -183,5 +189,206 @@ public class AutoQuotePublisherServiceTests : IDisposable
 
         Assert.NotNull(await ActiveQuoteAsync(Symbol));
         Assert.Null(await ActiveQuoteAsync(coin));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Plausibility band (issue #158). A glitching source — a per-mithqal figure read as
+    // per-gram, a misplaced decimal, a partial response parsed as a number — used to become a
+    // quote customers could trade against within one two-minute tick. Nothing checked whether
+    // the number was believable; the only rejections were a price <= 0 and an inverted spread.
+    //
+    // The audit that raised this could not reproduce it and marked it "reasoned, not executed"
+    // for want of a mockable provider. The provider was already mockable — StubProvider above
+    // predates the finding — so these run the real tick logic against a real database.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>Publishes one quote from <paramref name="reference"/> so later ticks have a mid to be measured against.</summary>
+    private async Task SeedPublishedQuoteAsync(decimal reference)
+    {
+        _stubProvider.Price = reference;
+        await RunTickAsync();
+        _logger.Entries.Clear();
+    }
+
+    /// <summary>
+    /// The headline case, using the unit slip the issue names: nerkh.io and brsapi.ir both quote
+    /// gold per mithqal natively, and a mithqal is about 4.33 grams, so a conversion that fails
+    /// to happen multiplies the price by that much. 8,000,000 per gram becoming 34,640,000 is
+    /// not a market move.
+    /// </summary>
+    [Fact]
+    public async Task RejectsAReferencePriceAboveTheBand_AndKeepsThePreviousQuote()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(8_000_000m);
+
+        _stubProvider.Price = 34_640_000m;
+        await RunTickAsync();
+
+        var quote = await ActiveQuoteAsync();
+        Assert.NotNull(quote);
+        Assert.Equal(7_960_000m, quote!.BuyPrice);   // still the quote seeded from 8,000,000
+        Assert.Equal(8_040_000m, quote.SellPrice);
+    }
+
+    /// <summary>A stale cache or a truncated response reads low rather than high; the band is two-sided.</summary>
+    [Fact]
+    public async Task RejectsAReferencePriceBelowTheBand_AndKeepsThePreviousQuote()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 500_000m;
+        await RunTickAsync();
+
+        Assert.Equal(995_000m, (await ActiveQuoteAsync())!.BuyPrice);
+    }
+
+    /// <summary>
+    /// Silence is the worst outcome the issue names: a skipped tick and a quiet market look
+    /// identical from outside. The rejected value and the band it violated both have to be in
+    /// the message, or the log cannot say what happened without re-querying the price source.
+    /// </summary>
+    [Fact]
+    public async Task ARejectedPriceIsLoggedAsAWarningWithTheValueAndTheBand()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 2_000_000m;
+        await RunTickAsync();
+
+        var warning = Assert.Single(_logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains("2000000", warning.Message);   // the rejected value
+        Assert.Contains("1000000", warning.Message);   // the mid it was measured against
+        Assert.Contains("100", warning.Message);       // how far off it was, as a percentage
+        Assert.Contains("5", warning.Message);         // the band it violated
+    }
+
+    /// <summary>
+    /// The band must not fight the market. A 4% move in two minutes would be remarkable but it is
+    /// a price, not a glitch, and refusing it would leave the shop quoting a stale number.
+    /// </summary>
+    [Fact]
+    public async Task PublishesAMoveInsideTheBand()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 1_040_000m;
+        await RunTickAsync();
+
+        Assert.Equal(1_034_800m, (await ActiveQuoteAsync())!.BuyPrice);
+    }
+
+    /// <summary>The edge is inclusive: exactly 5% publishes, a hair over does not.</summary>
+    [Fact]
+    public async Task PublishesAMoveExactlyOnTheBandEdge_ButNotOneJustPastIt()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+        await SeedPublishedQuoteAsync(1_000_000m);
+
+        _stubProvider.Price = 1_050_000m;              // exactly +5%, so the mid becomes 1,050,000
+        await RunTickAsync();
+        Assert.Equal(1_044_750m, (await ActiveQuoteAsync())!.BuyPrice);
+
+        _stubProvider.Price = 1_102_501m;              // +5.0001% of the new mid
+        await RunTickAsync();
+        Assert.Equal(1_044_750m, (await ActiveQuoteAsync())!.BuyPrice);
+    }
+
+    /// <summary>
+    /// Cold start, decided with the product owner: a symbol that has never had a quote has
+    /// nothing for a price to be implausible relative to, and refusing would mean auto-quote
+    /// could never bootstrap a newly activated symbol. It publishes, and says in the log that
+    /// the band was not applied — that one tick is the only unguarded one.
+    /// </summary>
+    [Fact]
+    public async Task PublishesTheFirstEverQuoteWithoutABandCheck_AndSaysSoInTheLog()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+
+        _stubProvider.Price = 34_640_000m;             // would be rejected against any sane mid
+        await RunTickAsync();
+
+        Assert.NotNull(await ActiveQuoteAsync());
+        Assert.Contains(_logger.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("not applied"));
+    }
+
+    /// <summary>
+    /// The first tick after a restart is the case the issue asks about, and it needs no special
+    /// handling: the active quote lives in the database, so a service instance that has just
+    /// started still has a mid to compare against. Seeding the quote without ever running a tick
+    /// is what a restart looks like from the publisher's side.
+    /// </summary>
+    [Fact]
+    public async Task TheBandComesFromTheStoredQuote_SoARestartIsStillGuarded()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+
+        using (var db = new OrdersDbContext(Options()))
+        {
+            db.Quotes.Add(Quote.Publish(Symbol, 7_960_000m, 8_040_000m, Guid.NewGuid()));
+            await db.SaveChangesAsync();
+        }
+
+        _stubProvider.Price = 34_640_000m;
+        await RunTickAsync();
+
+        var quote = await ActiveQuoteAsync();
+        Assert.Equal(7_960_000m, quote!.BuyPrice);
+        Assert.Contains(_logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// The handler that could never run (issue #158, same shape as #143). Quote.Publish rejects
+    /// through BusinessRuleException, which derives straight from Exception, so the
+    /// <c>catch (ArgumentException)</c> that stood here was unreachable and the tick threw
+    /// instead — landing in the poll loop's generic handler and being recorded at Error, as a
+    /// service fault rather than the ordinary rejection it is.
+    ///
+    /// The trigger is the one the handler's own comment describes: a price small enough that
+    /// rounding to two decimals leaves nothing. 0.001 survives the chain's positive-price check
+    /// and then rounds to 0.00 either side of the spread.
+    /// </summary>
+    [Fact]
+    public async Task APriceRejectedByQuoteDotPublishIsLoggedAsAWarningInsteadOfThrowing()
+    {
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid());
+
+        _stubProvider.Price = 0.001m;
+        await RunTickAsync();
+
+        Assert.Null(await ActiveQuoteAsync());
+        var warning = Assert.Single(_logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.IsType<TallaEgg.Core.ErrorHandling.BusinessRuleException>(warning.Exception);
+    }
+
+    /// <summary>
+    /// The band is a ratio, so it should not care how large the numbers are — but Bitcoin prices
+    /// are five orders of magnitude above gold's and the simulator only ever trades MAUA/IRT
+    /// (issue #147), so a symbol-specific arithmetic problem would survive a clean smoke run.
+    /// Both directions at BTC scale, on the same 5% boundary.
+    /// </summary>
+    [Fact]
+    public async Task TheBandBehavesTheSameAtBitcoinScale()
+    {
+        const string btc = CurrenciesConstant.BTC_IRT;
+
+        await SeedSettingsAsync(isEnabled: true, spreadPercent: 1m, Guid.NewGuid(), symbol: btc);
+
+        _stubProvider.Price = 52_000_000_000m;
+        await RunTickAsync(btc);
+        var seeded = await ActiveQuoteAsync(btc);
+        Assert.Equal(51_740_000_000m, seeded!.BuyPrice);
+
+        _stubProvider.Price = 54_600_000_000m;          // exactly +5%, accepted
+        await RunTickAsync(btc);
+        Assert.Equal(54_327_000_000m, (await ActiveQuoteAsync(btc))!.BuyPrice);
+
+        _stubProvider.Price = 5_460_000_000m;           // a decimal slipped: 10x too low, rejected
+        await RunTickAsync(btc);
+        Assert.Equal(54_327_000_000m, (await ActiveQuoteAsync(btc))!.BuyPrice);
     }
 }


### PR DESCRIPTION
**Branch Name**: `fix/auto-quote-plausibility-band`
**Linked Issue**: Closes #158

## Description

`AutoQuotePublisherService` published whatever the first reference-price provider returned. The only rejections were a price `<= 0` and an inverted spread, so a source that glitched once became a quote customers could trade against within one two-minute tick. This adds a plausibility band around the last published quote, and fixes an exception handler in the same method that could never run.

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

## Changes Made

- Added `AutoQuotePublisherService.IsPlausible`: a reference price more than **5%** from the mid of the symbol's last published quote is refused, and the tick keeps the previous quote.
- The rejection logs at Warning with the rejected value, the mid it was measured against, the deviation as a percentage, the band it violated, and the quote being kept — the issue's point is that silence is the worst outcome, so the log alone has to say what happened.
- Cold start: a symbol that has never had a quote publishes and logs at Information that the band was not applied. A restart needs no special case — the active quote is read from the database, so it survives one.
- Changed `catch (ArgumentException)` to `catch (BusinessRuleException)` in `PublishIfDueAsync`.
- Nine tests in `AutoQuotePublisherServiceTests`, including one at Bitcoin scale.

### The three decisions, and where they came from

All three were put to the product owner before any code was written, per the issue's "the threshold is a business number, not an engineering one":

| Decision | Answer | Why |
|---|---|---|
| Band width | **±5%** | Gold does not move 5% in two minutes. The failure modes the issue names sit far outside it: a per-mithqal figure read as per-gram is ≈4.33x, a misplaced decimal is 10x. Wide enough that a real gap-up after a quiet period is not refused. |
| Breach behaviour | **Refuse, hold the previous quote** | Clamping publishes a price no source ever reported, which the shop is then bound to honour; and a feed stuck on a bad number would walk the quote towards it one tick at a time until it arrived. |
| Cold start | **Accept and log** | Refusing would mean auto-quote could never bootstrap a newly activated symbol. The exposure is one tick, on a symbol that has never had a quote. |

The band is a `const` rather than configuration or an `AutoQuoteSettings` column: adding a key to `config/appsettings.global.json` would make every deployment that has not been updated fail at startup (this project deliberately does not default missing configuration), and a per-symbol column needs a bot command to go with it. Both are larger than this issue.

### The catch that could never fire

Confirmed before changing it, not taken from the issue text:

- `Quote.Publish` throws `BusinessRuleException` in all five validation paths — `Quote.cs:65,68,71,77,81`.
- `BusinessRuleException` is `sealed class BusinessRuleException : Exception` — `BusinessRuleException.cs:29`. Not an `ArgumentException`.

So the handler was unreachable. Nothing crashed, because the poll loop's `catch (Exception)` at `AutoQuotePublisherService.cs:59` caught it one level up — but a price the domain correctly rejected was recorded at **Error**, reading as a service fault rather than the ordinary rejection it is, and the Warning the comment described was never written. Same shape as #143.

## Testing Completed

### Unit Tests
- [x] New unit tests written — 9 added
- [x] All unit tests pass (`dotnet test`)

```
Passed!  -  Failed: 0, Passed: 520, Skipped: 0, Total: 520
```

511 before this change, 520 after.

**Every new test was verified to fail without the fix**, so none of them is decoration:

| Fix disabled | Result |
|---|---|
| Band widened to a no-op | 5 failed: `RejectsAReferencePriceAboveTheBand…`, `RejectsAReferencePriceBelowTheBand…`, `ARejectedPriceIsLoggedAsAWarningWithTheValueAndTheBand`, `PublishesAMoveExactlyOnTheBandEdge…`, `TheBandComesFromTheStoredQuote…` |
| `catch (BusinessRuleException)` reverted to `ArgumentException` | 1 failed: `APriceRejectedByQuoteDotPublishIsLoggedAsAWarningInsteadOfThrowing`, with the `BusinessRuleException` escaping uncaught |

The audit marked this finding **"reasoned, not executed"** for want of a mockable provider. One already existed — `AutoQuotePublisherServiceTests` has driven the real tick logic against a stub provider and SQLite in-memory since #90 — so these tests close that gap by execution rather than by reasoning.

The `catch` test triggers the rejection the way the handler's own comment describes: a reference price of `0.001` passes the chain's positive-price check and then rounds to `0.00` on both sides of the spread, so `Quote.Publish` rejects it. That is a real path, not a contrived one.

### Integration / smoke
- [x] `dotnet build TallaEgg.sln` → **0 Warnings, 0 Errors** (TreatWarningsAsErrors is on)
- [x] Full stack run via `driver.ps1 start` + `smoke --users 20 --quotes 20 --trades 60 --seed 158`

```
=== Done in 00:00:18.35. Registered 20 (16 approved), trades attempted 60, errors 0 ===
```

Database checked afterwards:

| Check | Result |
|---|---|
| Duplicate settlements (same `TradeId` twice) | 0 |
| Settlement legs per trade, today's run | 60 references, all exactly 4 legs |
| Wallet balance vs last transaction's `BallanceAfter` | 0 mismatches |
| Transaction chain breaks (`BallanceAfter` → next `BallanceBefore`) | 0 |
| Negative locked balances | 0 |
| Orphan orders from today's run | 0 |

Two anomalies found in the database are **pre-existing and unrelated to this change**: four orders in `Completed` with no trade, and four settlement references carrying two transaction legs instead of four. All eight rows are timestamped `2026-08-27 17:26–17:34`, three days before this branch, and the local databases are never reset between runs (oldest row `2026-08-26`). Today's 60 trades are clean. Flagged rather than fixed here, per scope discipline.

Bitcoin was tested separately because the simulator only trades MAUA/IRT (#147), so a symbol-specific arithmetic problem would survive a clean smoke run. `TheBandBehavesTheSameAtBitcoinScale` exercises the band at ~5.2e10 IRT in both directions, including a 10x decimal slip.

### Environment
- [x] Tested locally on Windows, against local SQL Server Express

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs — the messages carry prices and a symbol, nothing user-identifying
- [x] `config/appsettings.global.json` not in the diff
- [x] Code compiles without warnings

## Code Quality
- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why"
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added

## Breaking Changes?
- [x] No breaking changes

No schema change, no configuration change, no API change.

## Deployment Notes

**Pre-Deployment**: nothing. No migration, no new configuration key, no feature flag.

**Post-Deployment Verification**: watch the Orders service log for
`Auto-quote for {Symbol} rejected: reference price …` at Warning. A steady stream of those means
either a genuinely broken feed or a band that is too tight for that symbol — the constant is
`AutoQuotePublisherService.MaxDeviationPercent`.

**Rollback**: revert the commit. Behaviour returns to publishing every price the provider returns.

## Related Issues

- #90 built the auto-publishing feature this guards
- #61 and #124 watch exposure after a trade; this is about not creating the bad trade
- #143 is the same shape as the catch fixed here — a handler for an exception that could not be raised
- #147 is why Bitcoin needed a test of its own
