### PR TITLE
[Hotfix] Deduplicated admin adjustments reported a stale balance and logged nothing — follow-up to #157

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -98,13 +98,20 @@ namespace TallaEgg.TelegramBot
                         // told, and told that it was a repeat (issue #157).
                         var alreadyApplied = result.Data?.WasAlreadyApplied ?? false;
 
+                        // The repeat reports the original transaction, so its BalanceAfter is the credit
+                        // as it stood at that earlier moment. Anything charged or deducted since is
+                        // missing from it, which is why the repeat quotes CurrentBalance instead.
+                        var creditNowText = alreadyApplied
+                            ? $"{PersianFormat.Amount(result.Data?.CurrentBalance ?? 0m, currency)} {PersianFormat.Unit(currency)}"
+                            : newCreditText;
+
                         await _messenger.SendAsync(
                            message.Chat.Id,
                            string.Format(alreadyApplied ? BotMsgs.MsgAdminChargeAlreadyApplied : BotMsgs.MsgAdminChargeDone,
                                PersianFormat.Asset(currency),
                                amountText,
                                PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
-                               newCreditText));
+                               creditNowText));
 
                         if (!alreadyApplied)
                         {
@@ -190,13 +197,19 @@ namespace TallaEgg.TelegramBot
                         // customer is not told a second deduction happened (issue #157).
                         var alreadyApplied = result.Data?.WasAlreadyApplied ?? false;
 
+                        // Same reason as the charge command above: on a repeat the figure that means
+                        // "what this customer holds" is CurrentBalance, not the earlier BalanceAfter.
+                        var balanceNowText = alreadyApplied
+                            ? $"{PersianFormat.Amount(result.Data?.CurrentBalance ?? 0m, currency)} {PersianFormat.Unit(currency)}"
+                            : newBalanceText;
+
                         await _messenger.SendAsync(
                                message.Chat.Id,
                                string.Format(alreadyApplied ? BotMsgs.MsgAdminDeductAlreadyApplied : BotMsgs.MsgAdminDeductDone,
                                    PersianFormat.Asset(currency),
                                    deductAmountText,
                                    PersianFormat.Ltr(PersianFormat.ToPersianDigits(phone)),
-                                   newBalanceText));
+                                   balanceNowText));
 
                         if (!alreadyApplied)
                         {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -101,8 +101,14 @@ namespace TallaEgg.TelegramBot
                         // The repeat reports the original transaction, so its BalanceAfter is the credit
                         // as it stood at that earlier moment. Anything charged or deducted since is
                         // missing from it, which is why the repeat quotes CurrentBalance instead.
+                        //
+                        // Falling back to BalanceAfter, not to zero: a wallet that predates
+                        // CurrentBalance sends no such field, and the services restart independently.
+                        // The stale figure is the thing being fixed here, but telling an admin their
+                        // customer holds nothing would be the worse of the two answers.
+                        var creditNow = result.Data?.CurrentBalance ?? result.Data?.BalanceAfter ?? 0m;
                         var creditNowText = alreadyApplied
-                            ? $"{PersianFormat.Amount(result.Data?.CurrentBalance ?? 0m, currency)} {PersianFormat.Unit(currency)}"
+                            ? $"{PersianFormat.Amount(creditNow, currency)} {PersianFormat.Unit(currency)}"
                             : newCreditText;
 
                         await _messenger.SendAsync(
@@ -197,10 +203,12 @@ namespace TallaEgg.TelegramBot
                         // customer is not told a second deduction happened (issue #157).
                         var alreadyApplied = result.Data?.WasAlreadyApplied ?? false;
 
-                        // Same reason as the charge command above: on a repeat the figure that means
-                        // "what this customer holds" is CurrentBalance, not the earlier BalanceAfter.
+                        // Same reason as the charge command above, including the fallback: on a repeat
+                        // the figure that means "what this customer holds" is CurrentBalance, and a
+                        // wallet too old to send it must not turn into a reported balance of zero.
+                        var balanceNow = result.Data?.CurrentBalance ?? result.Data?.BalanceAfter ?? 0m;
                         var balanceNowText = alreadyApplied
-                            ? $"{PersianFormat.Amount(result.Data?.CurrentBalance ?? 0m, currency)} {PersianFormat.Unit(currency)}"
+                            ? $"{PersianFormat.Amount(balanceNow, currency)} {PersianFormat.Unit(currency)}"
                             : newBalanceText;
 
                         await _messenger.SendAsync(

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -555,26 +555,34 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// nothing. Deliberately not an error: the charge they wanted did happen, and the figures
         /// are the ones it produced. Sent instead of MsgAdminChargeDone, and the customer gets no
         /// notification at all, because no money moved this time (issue #157).
+        ///
+        /// <para>
+        /// {3} is the credit the wallet holds <b>now</b>, which is not the same number as the one
+        /// the original top-up left behind: anything that happened in between is in it. An admin
+        /// re-sends precisely when they are unsure what has taken effect, so this is the worst
+        /// moment to hand them a figure whose label says "now" when it means "then".
+        /// </para>
         /// {0} = the asset's Persian name; {1} = amount with unit; {2} = phone number;
-        /// {3} = the credit with unit.
+        /// {3} = the credit the wallet holds now, with unit.
         /// </summary>
         public const string MsgAdminChargeAlreadyApplied = "ℹ️ این شارژ پیش‌تر ثبت شده بود و دوباره اعمال نشد.\n\n" +
                                                           "دارایی: {0}\n" +
                                                           "مقدار: {1}\n" +
                                                           "کاربر: {2}\n" +
-                                                          "اعتبار فعلی: {3}\n\n" +
+                                                          "اعتبار کنونی کاربر: {3}\n\n" +
                                                           "اگر قصد داشتید بار دوم هم شارژ کنید، چند دقیقه دیگر دوباره تلاش کنید.";
 
         /// <summary>
-        /// The deduction counterpart of <see cref="MsgAdminChargeAlreadyApplied"/>.
+        /// The deduction counterpart of <see cref="MsgAdminChargeAlreadyApplied"/>, and {3} carries
+        /// the same meaning: the balance the wallet holds now, not the one that deduction produced.
         /// {0} = the asset's Persian name; {1} = amount with unit; {2} = phone number;
-        /// {3} = the balance with unit.
+        /// {3} = the balance the wallet holds now, with unit.
         /// </summary>
         public const string MsgAdminDeductAlreadyApplied = "ℹ️ این کسر پیش‌تر ثبت شده بود و دوباره اعمال نشد.\n\n" +
                                                           "دارایی: {0}\n" +
                                                           "مقدار: {1}\n" +
                                                           "کاربر: {2}\n" +
-                                                          "موجودی فعلی: {3}\n\n" +
+                                                          "موجودی کنونی کاربر: {3}\n\n" +
                                                           "اگر قصد داشتید بار دوم هم کسر کنید، چند دقیقه دیگر دوباره تلاش کنید.";
 
         /// <summary>{0} = the error reason.</summary>

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
@@ -38,8 +38,17 @@ namespace TallaEgg.Core.DTOs.Wallet
         /// BalanceAfter is the balance at that earlier moment, and anything that happened since is
         /// not in it. Any caller writing the words "current balance" has to use this one.
         /// </para>
+        ///
+        /// <para>
+        /// <b>Nullable so that "the wallet did not send this" stays distinguishable from "the wallet
+        /// holds nothing".</b> The services are installed and restarted individually, so a bot that
+        /// comes back before the wallet does will deserialize a response without this field. As a
+        /// plain decimal that is silently zero, and the admin would be told the customer holds
+        /// nothing — a worse answer than the stale figure this field exists to replace. Callers fall
+        /// back to <see cref="BalanceAfter"/> when it is null.
+        /// </para>
         /// </summary>
-        public decimal CurrentBalance { get; set; }
+        public decimal? CurrentBalance { get; set; }
     }
 
   

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Wallet/WalletBallanceDTO.cs
@@ -27,6 +27,19 @@ namespace TallaEgg.Core.DTOs.Wallet
         /// </para>
         /// </summary>
         public bool WasAlreadyApplied { get; set; }
+
+        /// <summary>
+        /// What the wallet holds now, as opposed to <see cref="BalanceAfter"/>, which is what the
+        /// operation being reported left behind.
+        ///
+        /// <para>
+        /// The two are the same for an operation that just ran, and differ whenever
+        /// <see cref="WasAlreadyApplied"/> is true: a repeat reports the original transaction, so its
+        /// BalanceAfter is the balance at that earlier moment, and anything that happened since is
+        /// not in it. Any caller writing the words "current balance" has to use this one.
+        /// </para>
+        /// </summary>
+        public decimal CurrentBalance { get; set; }
     }
 
   

--- a/src/Wallet/Wallet.Application/WalletService.cs
+++ b/src/Wallet/Wallet.Application/WalletService.cs
@@ -7,6 +7,7 @@ using TallaEgg.Core.Utilties;
 using Wallet.Application.Mappers;
 using Wallet.Core;
 using TallaEgg.Core.ErrorHandling;
+using Microsoft.Extensions.Logging;
 
 namespace Wallet.Application;
 
@@ -14,11 +15,13 @@ public class WalletService : IWalletService
 {
     private readonly IWalletRepository _walletRepository;
     private readonly WalletMapper _walletMapper;
+    private readonly ILogger<WalletService> _logger;
 
-    public WalletService(IWalletRepository walletRepository, WalletMapper walletMapper)
+    public WalletService(IWalletRepository walletRepository, WalletMapper walletMapper, ILogger<WalletService> logger)
     {
         _walletRepository = walletRepository;
         _walletMapper = walletMapper;
+        _logger = logger;
     }
 
     public async Task<WalletDTO> GetBalanceAsync(Guid userId, string asset)
@@ -141,11 +144,29 @@ public class WalletService : IWalletService
     /// <summary>
     /// The transaction this reference already produced on this wallet, or null if it is new.
     /// A caller with no reference can never be deduplicated and always gets null.
+    ///
+    /// <para>
+    /// A hit is logged here rather than in the repository. The repository logs its own
+    /// absorptions, but those only cover the concurrent case now that this check runs first — so
+    /// the ordinary repeat, which is the one that actually happens, left no trace anywhere in the
+    /// wallet service and could not be confirmed afterwards for an admin asking whether their
+    /// command had taken effect.
+    /// </para>
     /// </summary>
-    private async Task<Transaction?> AlreadyAppliedAsync(WalletEntity wallet, string? refId) =>
-        string.IsNullOrWhiteSpace(refId)
-            ? null
-            : await _walletRepository.FindTransactionByReferenceAsync(wallet.Id, refId);
+    private async Task<Transaction?> AlreadyAppliedAsync(WalletEntity wallet, string? refId)
+    {
+        if (string.IsNullOrWhiteSpace(refId)) return null;
+
+        var previous = await _walletRepository.FindTransactionByReferenceAsync(wallet.Id, refId);
+
+        if (previous is not null)
+            _logger.LogInformation(
+                "Reference {ReferenceId} was already applied to the {Asset} wallet of user {UserId} as transaction {TransactionId}; " +
+                "nothing moved and the original is being reported (idempotent).",
+                refId, wallet.Asset, wallet.UserId, previous.Id);
+
+        return previous;
+    }
 
 
 
@@ -190,6 +211,7 @@ public class WalletService : IWalletService
             UpdatedAt = result.walletEntity.UpdatedAt,
             TrackingCode = result.transactionEntity.TrackingCode,
             WasAlreadyApplied = result.wasAlreadyApplied,
+            CurrentBalance = result.walletEntity.Balance,
         };
     }
 
@@ -207,6 +229,7 @@ public class WalletService : IWalletService
             UpdatedAt = result.walletEntity.UpdatedAt,
             TrackingCode = result.transactionEntity.TrackingCode,
             WasAlreadyApplied = result.wasAlreadyApplied,
+            CurrentBalance = result.walletEntity.Balance,
         };
     }
 

--- a/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
+using TallaEgg.Core.Utilties;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.DTOs.Wallet;
@@ -221,6 +222,54 @@ public class AdminChargeCommandTests
         Assert.DoesNotContain(_messenger.Texts, t => t.Contains("پیش‌تر ثبت شده بود"));
     }
 
+    /// <summary>
+    /// The figure a deduplicated repeat shows has to be what the customer holds now, not what the
+    /// original operation left behind. Found against the running bot: a deduction, then a second
+    /// larger deduction, then the first one re-sent — the reply quoted the balance from before the
+    /// second deduction, labelled as the current one.
+    /// </summary>
+    [Fact]
+    public async Task ADeduplicatedChargeQuotesTheBalanceAsItStandsNow()
+    {
+        var handler = Build();
+        _walletApi.ReportAlreadyApplied = true;
+        _walletApi.CurrentBalance = 700m;          // the wallet has moved on since
+
+        await SayAsync(handler, "ش 09158527483 100 سکه");
+
+        var reply = Assert.Single(_messenger.Texts, t => t.Contains("پیش‌تر ثبت شده بود"));
+        Assert.Contains(PersianFormat.Amount(700m, "CREDIT_SEKE_BAHAR"), reply);
+        Assert.DoesNotContain("کنونی کاربر: " + PersianFormat.Amount(100m, "CREDIT_SEKE_BAHAR"), reply);
+    }
+
+    /// <summary>The deduction command carries the same correction.</summary>
+    [Fact]
+    public async Task ADeduplicatedDeductionQuotesTheBalanceAsItStandsNow()
+    {
+        var handler = Build();
+        _walletApi.ReportAlreadyApplied = true;
+        _walletApi.CurrentBalance = 4_200m;
+
+        await SayAsync(handler, "د 09158527483 500 تومان");
+
+        var reply = Assert.Single(_messenger.Texts, t => t.Contains("پیش‌تر ثبت شده بود"));
+        Assert.Contains(PersianFormat.Amount(4_200m, "IRT"), reply);
+    }
+
+    /// <summary>
+    /// An ordinary charge is untouched: the balance it just produced is both figures, so the
+    /// message reads exactly as it did before.
+    /// </summary>
+    [Fact]
+    public async Task AnOrdinaryChargeStillQuotesWhatItJustProduced()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "ش 09158527483 100 سکه");
+
+        var reply = Assert.Single(_messenger.Texts, t => t.Contains("افزایش اعتبار انجام شد"));
+        Assert.Contains(PersianFormat.Amount(100m, "CREDIT_SEKE_BAHAR"), reply);
+    }
     private sealed class RecordingWalletApiClient : StubWalletApiClient
     {
         public List<WalletRequest> Deposits { get; } = [];
@@ -228,6 +277,12 @@ public class AdminChargeCommandTests
 
         /// <summary>Makes the wallet answer the way it does for a reference it has already applied.</summary>
         public bool ReportAlreadyApplied { get; set; }
+
+        /// <summary>
+        /// What the wallet holds now. Set it apart from the amount to reproduce the case that
+        /// matters: a repeat whose original BalanceAfter is no longer what the customer holds.
+        /// </summary>
+        public decimal? CurrentBalance { get; set; }
 
         public override Task<TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>> DepositeAsync(WalletRequest request)
         {
@@ -237,7 +292,8 @@ public class AdminChargeCommandTests
                 Asset = request.Asset,
                 BalanceBefore = 0,
                 BalanceAfter = request.Amount,
-                WasAlreadyApplied = ReportAlreadyApplied
+                WasAlreadyApplied = ReportAlreadyApplied,
+                CurrentBalance = CurrentBalance ?? request.Amount
             }));
         }
 
@@ -248,7 +304,9 @@ public class AdminChargeCommandTests
             {
                 Asset = request.Asset,
                 BalanceBefore = request.Amount,
-                BalanceAfter = 0
+                BalanceAfter = 0,
+                WasAlreadyApplied = ReportAlreadyApplied,
+                CurrentBalance = CurrentBalance ?? 0m
             }));
         }
     }

--- a/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
@@ -257,18 +257,41 @@ public class AdminChargeCommandTests
     }
 
     /// <summary>
-    /// An ordinary charge is untouched: the balance it just produced is both figures, so the
-    /// message reads exactly as it did before.
+    /// An ordinary charge quotes the balance it just produced, not the live one. The two are the
+    /// same number in practice, so the stub is given a deliberately different CurrentBalance —
+    /// otherwise this passes whether or not the handler still distinguishes the two cases.
     /// </summary>
     [Fact]
     public async Task AnOrdinaryChargeStillQuotesWhatItJustProduced()
     {
         var handler = Build();
+        _walletApi.CurrentBalance = 999m;          // must not appear: this charge was applied
 
         await SayAsync(handler, "ش 09158527483 100 سکه");
 
         var reply = Assert.Single(_messenger.Texts, t => t.Contains("افزایش اعتبار انجام شد"));
         Assert.Contains(PersianFormat.Amount(100m, "CREDIT_SEKE_BAHAR"), reply);
+        Assert.DoesNotContain(PersianFormat.Amount(999m, "CREDIT_SEKE_BAHAR"), reply);
+    }
+
+    /// <summary>
+    /// A wallet too old to send CurrentBalance must not turn into a reported balance of zero. The
+    /// services are installed and restarted individually, so a bot running ahead of the wallet is
+    /// an ordinary deployment state, and the reply falls back to the figure the older wallet does
+    /// send rather than to nothing.
+    /// </summary>
+    [Fact]
+    public async Task AWalletThatSendsNoCurrentBalanceFallsBackInsteadOfReportingZero()
+    {
+        var handler = Build();
+        _walletApi.ReportAlreadyApplied = true;
+        _walletApi.OmitCurrentBalance = true;
+
+        await SayAsync(handler, "ش 09158527483 100 سکه");
+
+        var reply = Assert.Single(_messenger.Texts, t => t.Contains("پیش‌تر ثبت شده بود"));
+        // Anchored to its label: a bare PersianFormat.Amount(0) is "۰", which also sits inside "۱۰۰".
+        Assert.Contains("اعتبار کنونی کاربر: " + PersianFormat.Amount(100m, "CREDIT_SEKE_BAHAR"), reply);
     }
     private sealed class RecordingWalletApiClient : StubWalletApiClient
     {
@@ -284,6 +307,9 @@ public class AdminChargeCommandTests
         /// </summary>
         public decimal? CurrentBalance { get; set; }
 
+        /// <summary>Answers the way a wallet that predates the field does: without it at all.</summary>
+        public bool OmitCurrentBalance { get; set; }
+
         public override Task<TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>> DepositeAsync(WalletRequest request)
         {
             Deposits.Add(request);
@@ -293,7 +319,7 @@ public class AdminChargeCommandTests
                 BalanceBefore = 0,
                 BalanceAfter = request.Amount,
                 WasAlreadyApplied = ReportAlreadyApplied,
-                CurrentBalance = CurrentBalance ?? request.Amount
+                CurrentBalance = OmitCurrentBalance ? null : CurrentBalance ?? request.Amount
             }));
         }
 
@@ -306,7 +332,7 @@ public class AdminChargeCommandTests
                 BalanceBefore = request.Amount,
                 BalanceAfter = 0,
                 WasAlreadyApplied = ReportAlreadyApplied,
-                CurrentBalance = CurrentBalance ?? 0m
+                CurrentBalance = OmitCurrentBalance ? null : CurrentBalance ?? 0m
             }));
         }
     }

--- a/tests/TallaEgg.AllServices.Tests/DepositIdempotencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DepositIdempotencyTests.cs
@@ -7,6 +7,8 @@ using Wallet.Application;
 using Wallet.Application.Mappers;
 using Wallet.Core;
 using Wallet.Infrastructure;
+using TallaEgg.AllServices.Tests.Fakes;
+using Microsoft.Extensions.Logging;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -34,6 +36,7 @@ public class DepositIdempotencyTests : IDisposable
     private readonly HookedWalletDbContext _context;
     private readonly WalletRepository _repository;
     private readonly WalletService _service;
+    private readonly CapturingLogger<WalletService> _serviceLogger = new();
     private readonly Guid _userId = Guid.NewGuid();
 
     /// <summary>
@@ -67,7 +70,7 @@ public class DepositIdempotencyTests : IDisposable
         _context.Database.EnsureCreated();
 
         _repository = new WalletRepository(NullLogger<WalletRepository>.Instance, _context);
-        _service = new WalletService(_repository, new WalletMapper());
+        _service = new WalletService(_repository, new WalletMapper(), _serviceLogger);
 
         _context.Wallets.Add(WalletEntity.Create(_userId, Asset));
         _context.SaveChanges();
@@ -264,6 +267,97 @@ public class DepositIdempotencyTests : IDisposable
         Assert.True((await _service.DepositAsync(_userId, Asset, 100m, reference)).WasAlreadyApplied);
     }
 
+    /// <summary>
+    /// The number an admin reads as "what this customer holds" has to be what the wallet holds
+    /// now. A repeat reports the <em>original</em> transaction, so its BalanceAfter is the balance
+    /// at that earlier moment — correct for what it describes, and wrong for the question being
+    /// asked, because anything that happened since is missing from it.
+    ///
+    /// <para>
+    /// Found by testing the real bot: a 500 deduction, then a 1500 deduction, then the 500
+    /// re-sent. The repeat answered with the balance from before the 1500 came out, under a label
+    /// that said "current".
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task ARepeatReportsTheBalanceAsItStandsNow_NotAsTheOriginalLeftIt()
+    {
+        const string reference = "admin-withdrawal:stale-figure";
+
+        await _service.DepositAsync(_userId, Asset, 10_000m);
+
+        var first = await _service.WithdrawalAsync(_userId, Asset, 500m, reference);
+        await _service.WithdrawalAsync(_userId, Asset, 1_500m, "admin-withdrawal:something-else");
+
+        var repeat = await _service.WithdrawalAsync(_userId, Asset, 500m, reference);
+
+        Assert.True(repeat.WasAlreadyApplied);
+
+        // What that first deduction left behind, unchanged: the repeat still reports the original.
+        Assert.Equal(9_500m, first.BalanceAfter);
+        Assert.Equal(9_500m, repeat.BalanceAfter);
+
+        // And what the wallet actually holds, which is the figure the admin is shown.
+        Assert.Equal(8_000m, repeat.CurrentBalance);
+        Assert.Equal(8_000m, await BalanceAsync());
+    }
+
+    /// <summary>
+    /// With nothing in between, the two agree — so quoting the live balance never makes an
+    /// ordinary repeat read differently from how it did before.
+    /// </summary>
+    [Fact]
+    public async Task WithNothingInBetweenTheRepeatsTwoFiguresAgree()
+    {
+        const string reference = "admin-deposit:agree";
+
+        await _service.DepositAsync(_userId, Asset, 300m, reference);
+        var repeat = await _service.DepositAsync(_userId, Asset, 300m, reference);
+
+        Assert.Equal(repeat.BalanceAfter, repeat.CurrentBalance);
+    }
+
+    /// <summary>An ordinary application reports the balance it just produced, as it always did.</summary>
+    [Fact]
+    public async Task AnOrdinaryApplicationReportsTheBalanceItProduced()
+    {
+        var result = await _service.DepositAsync(_userId, Asset, 250m, "admin-deposit:ordinary");
+
+        Assert.False(result.WasAlreadyApplied);
+        Assert.Equal(250m, result.BalanceAfter);
+        Assert.Equal(250m, result.CurrentBalance);
+    }
+
+    /// <summary>
+    /// A deduplicated repeat has to leave a trace in the wallet service, which is the system of
+    /// record. It did not: moving the check into the service to fix an earlier review finding
+    /// meant the ordinary repeat returned before reaching the repository, whose log line was the
+    /// only one — so an admin asking afterwards whether their command took effect could not be
+    /// answered from the wallet log at all.
+    /// </summary>
+    [Fact]
+    public async Task ADeduplicatedRepeatIsLogged()
+    {
+        const string reference = "admin-deposit:logged";
+
+        await _service.DepositAsync(_userId, Asset, 100m, reference);
+        _serviceLogger.Entries.Clear();
+
+        await _service.DepositAsync(_userId, Asset, 100m, reference);
+
+        var entry = Assert.Single(_serviceLogger.Entries, e => e.Level == LogLevel.Information);
+        Assert.Contains(reference, entry.Message);
+        Assert.Contains("idempotent", entry.Message);
+    }
+
+    /// <summary>And an ordinary application logs nothing, so the line stays a signal.</summary>
+    [Fact]
+    public async Task AnOrdinaryApplicationLogsNothing()
+    {
+        await _service.DepositAsync(_userId, Asset, 100m, "admin-deposit:quiet");
+
+        Assert.Empty(_serviceLogger.Entries);
+    }
     /// <summary>A deposit with no reference can never be a repeat, so the flag stays false.</summary>
     [Fact]
     public async Task AnUnreferencedDepositIsNeverFlagged()

--- a/tests/TallaEgg.AllServices.Tests/WalletLazyCreationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletLazyCreationTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.Sqlite;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
@@ -40,7 +40,8 @@ public class WalletLazyCreationTests : IDisposable
         new(new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
 
     private WalletService NewService(WalletDbContext context) =>
-        new(new WalletRepository(NullLogger<WalletRepository>.Instance, context), new WalletMapper());
+        new(new WalletRepository(NullLogger<WalletRepository>.Instance, context), new WalletMapper(),
+            NullLogger<WalletService>.Instance);
 
     [Fact]
     public async Task DepositingAKnownAssetWithNoExistingWallet_CreatesOneRatherThanFailing()


### PR DESCRIPTION
**Branch Name**: `fix/deduplicated-adjustment-reporting`
**Linked Issue**: Follow-up to #157

## Description

Two defects in the idempotency #157 added, both found by driving the real bot rather than by reading the code: a deduplicated repeat showed the admin a stale balance under a label saying "current", and left no trace at all in the wallet service log.

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Bug 1 — a stale balance labelled "current"

A repeat reports the *original* transaction. That is deliberate and matches settlement. But that transaction's `BalanceAfter` is the balance at that earlier moment, and anything that has happened since is not in it.

Observed against the running bot, in this order:

| step | effect |
|---|---|
| deduct 500 | 184,887,309 → 184,886,809 |
| deduct 1500 | 184,886,809 → **184,885,309** |
| re-send the 500 (×3) | deduplicated, nothing moved |

Each repeat answered `موجودی فعلی: ۱۸۴٬۸۸۶٬۸۰۹` — the balance from before the 1500 came out. The customer's actual balance was 184,885,309.

The number was right for what it described and wrong for what it was labelled. **An admin re-sends precisely when they are unsure what has taken effect**, so this is the worst moment to hand them a figure whose label says "now" and whose value means "then". Here the gap was 1,500 toman because that is what happened to be deducted in between; nothing bounds it.

### Fix

`WalletBallanceDTO` gains `CurrentBalance` — what the wallet holds — alongside `BalanceAfter`, which keeps its meaning as what the reported operation produced. The two are equal except on a repeat, so nothing else changes shape.

The bot quotes `CurrentBalance` in the two already-applied messages only. `MsgAdminChargeDone` and `MsgAdminDeductDone` are untouched, because on an ordinary application the two figures are the same number.

The labels are also now specific — `اعتبار کنونی کاربر` / `موجودی کنونی کاربر` rather than `اعتبار فعلی` / `موجودی فعلی` — so the sentence says whose balance and as of when.

## Bug 2 — the repeat was invisible in the wallet service

`/code-review` on #157 found that a repeated deduction was refused by `DecreaseBalance` when the amount exceeded what was left. The fix was to move the idempotency check up into `WalletService`, before the entity is touched. Correct, but it meant the ordinary repeat now returns *before* reaching the repository — and the repository held the only log line.

So the case that actually happens became silent in the system of record. The bot log has the reply; the wallet service, which is where anyone would look to confirm what happened to a balance, had nothing. Confirmed on the session above: three deduplicated repeats, zero lines in `wallet-api-*.log`.

### Fix

`AlreadyAppliedAsync` logs the hit at Information with the reference, the wallet's asset and owner, and the id of the transaction being reported. The repository keeps its own line for the concurrent case, which is a different path and still reachable.

`WalletService` now takes an `ILogger<WalletService>`. Only two places construct it outside DI, both tests, both updated. (`.audit-work/repro` also constructs it but is untracked and outside the solution.)

## Testing Completed

### Unit tests
- [x] New unit tests written — 8 added
- [x] All unit tests pass

```
Passed!  -  Failed: 0, Passed: 563, Skipped: 0, Total: 563
```

555 before this change, 563 after.

**Verified load-bearing.** With both fixes reverted:

```
Failed  DepositIdempotencyTests.ADeduplicatedRepeatIsLogged
Failed  AdminChargeCommandTests.ADeduplicatedChargeQuotesTheBalanceAsItStandsNow
Failed  AdminChargeCommandTests.ADeduplicatedDeductionQuotesTheBalanceAsItStandsNow
```

`ARepeatReportsTheBalanceAsItStandsNow_NotAsTheOriginalLeftIt` reproduces the exact live sequence at the service level: deduct 500, deduct 1500, re-send the 500, then assert that `BalanceAfter` is still 9,500 (the original, correctly unchanged) while `CurrentBalance` is 8,000 (what the wallet holds).

Two tests guard against over-correcting: `WithNothingInBetweenTheRepeatsTwoFiguresAgree` and `AnOrdinaryApplicationReportsTheBalanceItProduced` pin that the ordinary path reads exactly as before. `AnOrdinaryApplicationLogsNothing` keeps the new log line a signal rather than noise.

### Live check

The same sequence through the running Wallet API:

```
deduct  500 -> balanceAfter 9500  currentBalance 9500  alreadyApplied False
deduct 1500 -> balanceAfter 8000  currentBalance 8000  alreadyApplied False
re-send 500 -> balanceAfter 9500  currentBalance 8000  alreadyApplied True

what the wallet actually holds      : 8000
what the repeat reported as current : 8000
the stale figure it used to report  : 9500
```

- [x] `dotnet build TallaEgg.sln` → **0 Warnings, 0 Errors**

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs — the new line carries a reference key, an asset, a user id and a transaction id; no phone number or name
- [x] `config/appsettings.global.json` not in the diff
- [x] Code compiles without warnings

## Code Quality
- [x] Follows `STANDARDS.md`
- [x] Comments in English, explaining the "why"
- [x] No new dependencies

## Breaking Changes?
- [x] No breaking changes

`CurrentBalance` is an added field; existing consumers reading `BalanceAfter` are unaffected, and it keeps its old meaning. `WalletService`'s constructor changed, but it is only ever resolved through DI in production.

## Deployment Notes

No migration, no configuration, no schema change. Revert the commit to roll back.

**Post-deployment verification**: send the same `ش` or `د` command twice inside five minutes with something else in between, and check the second reply quotes the balance the customer actually holds. `wallet-api-*.log` should carry one Information line per deduplicated repeat.

## Related

- #157 introduced the idempotency this corrects
- #174 and #175 are the two unrelated defects found in the same session
