### PR TITLE
[Hotfix] Admin deduction acts on the spot wallet while top-up acts on credit — make them mirrors

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -58,7 +58,10 @@ namespace TallaEgg.TelegramBot
                     : CurrenciesConstant.Maua; // مقدار پیش‌فرض
                 var currency = CurrenciesConstant.ResolveCurrencyCode(currencyInput);
 
-                if (currency is null)
+                // A credit name resolves, so without this "ش ... اعتبار آبشده" would be prefixed a
+                // second time into CREDIT_CREDIT_MAUA and fail at the wallet as an unknown asset.
+                // Both commands already mean the credit ledger, so naming it adds nothing.
+                if (currency is null || CurrenciesConstant.IsCreditAsset(currency))
                 {
                     await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
@@ -165,12 +168,17 @@ namespace TallaEgg.TelegramBot
                 // The input may be a Persian name or a currency code.
                 // The old default was a Persian word that never matched any asset code, so the
                 // deduction ran against a wallet that did not exist.
+                //
+                // Gold, matching the charge command. The default used to be Toman, so the two
+                // commands disagreed about what an omitted asset meant as well as about which
+                // ledger they touched.
                 var currencyInput = match.Groups["currency"].Success
                     ? match.Groups["currency"].Value
-                    : CurrenciesConstant.Toman; // مقدار پیش‌فرض
+                    : CurrenciesConstant.Maua; // مقدار پیش‌فرض
                 var currency = CurrenciesConstant.ResolveCurrencyCode(currencyInput);
 
-                if (currency is null)
+                // Same guard as the charge command: a credit name would be prefixed twice.
+                if (currency is null || CurrenciesConstant.IsCreditAsset(currency))
                 {
                     await _messenger.SendAsync(message.Chat.Id,
                         string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
@@ -180,14 +188,28 @@ namespace TallaEgg.TelegramBot
                 var userDto = await _usersApi.GetUserAsync(phone);
                 if (userDto != null)
                 {
+                    // The credit ledger, exactly as the charge command writes to it. These two
+                    // commands used to disagree: ش credited CREDIT_<X> while د debited plain <X>,
+                    // from the same Persian word and with the same help text and examples. An admin
+                    // undoing a mistaken top-up with the obvious symmetric command therefore left the
+                    // credit untouched and took the customer's real position instead — one mistake
+                    // becoming two, under a ✅ confirmation (issue #36 carries the evidence).
+                    //
+                    // The bot has never been able to add to a spot balance: this is the only place it
+                    // moves money, and the charge command has always meant credit. So a deduction that
+                    // could reach a spot balance was the asymmetry, not a capability being removed —
+                    // nothing here has a counterpart that adds. Spot balances move by trading, or
+                    // through the wallet API directly.
+                    var creditAsset = CurrenciesConstant.CreditAssetFor(currency);
+
                     var result = await _walletApi.WithdrawalAsync(new TallaEgg.Core.Requests.Wallet.WalletRequest
                     {
-                        Asset = currency,
+                        Asset = creditAsset,
                         Amount = amount,
                         UserId = userDto.Id,
 
                         // Same deduplication as the charge command above (issue #157).
-                        ReferenceId = AdminAdjustmentKey.ForWithdrawal(userDto.Id, currency, amount, DateTime.UtcNow)
+                        ReferenceId = AdminAdjustmentKey.ForWithdrawal(userDto.Id, creditAsset, amount, DateTime.UtcNow)
                     });
                     if (result.Success)
                     {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -51,7 +51,7 @@ namespace TallaEgg.TelegramBot
             if (resolved is null)
             {
                 await _messenger.SendAsync(chatId,
-                    string.Format(BotMsgs.MsgAdminInvalidCurrency, typed, CurrenciesConstant.GetPersianNamesList()));
+                    string.Format(BotMsgs.MsgAdminInvalidCurrency, typed, CurrenciesConstant.GetCreditableNamesList()));
                 return null;
             }
 
@@ -87,7 +87,7 @@ namespace TallaEgg.TelegramBot
                 {
                     // The return is required; without it the code below ran on a failed match and threw.
                     await _messenger.SendAsync(message.Chat.Id,
-                        string.Format(BotMsgs.MsgAdminChargeFormatError, CurrenciesConstant.GetPersianNamesList()));
+                        string.Format(BotMsgs.MsgAdminChargeFormatError, CurrenciesConstant.GetCreditableNamesList()));
                     return true;
                 }
 
@@ -191,7 +191,7 @@ namespace TallaEgg.TelegramBot
                 {
                     // The return is required; without it the code below ran on a failed match and threw.
                     await _messenger.SendAsync(message.Chat.Id,
-                        string.Format(BotMsgs.MsgAdminDeductFormatError, CurrenciesConstant.GetPersianNamesList()));
+                        string.Format(BotMsgs.MsgAdminDeductFormatError, CurrenciesConstant.GetCreditableNamesList()));
                     return true;
                 }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/BotHandlerAdmin.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using TallaEgg.Core;
@@ -30,6 +30,48 @@ namespace TallaEgg.TelegramBot
     public partial class BotHandler : IBotHandler
     {
 
+        /// <summary>
+        /// Whether the asset an admin named can carry credit, answering them specifically when it
+        /// cannot. Shared by ش and د, which both act on the credit ledger and therefore both reject
+        /// exactly the same input.
+        ///
+        /// <para>
+        /// Three refusals, three different sentences, because they send the admin to three different
+        /// places: an unrecognised word is a typo; a credit name ("اعتبار طلا") is a word the
+        /// commands add for themselves; and Toman is a perfectly good asset that simply has no credit
+        /// ledger, which no amount of re-spelling will fix. All three used to be "نوع شناسایی نشد",
+        /// or in Toman's case not caught here at all — it reached the wallet and came back as the
+        /// generic "خطا در بروزرسانی".
+        /// </para>
+        /// </summary>
+        private async Task<string?> ResolveCreditableAssetAsync(long chatId, string typed)
+        {
+            var resolved = CurrenciesConstant.ResolveCurrencyCode(typed);
+
+            if (resolved is null)
+            {
+                await _messenger.SendAsync(chatId,
+                    string.Format(BotMsgs.MsgAdminInvalidCurrency, typed, CurrenciesConstant.GetPersianNamesList()));
+                return null;
+            }
+
+            if (CurrenciesConstant.IsCreditAsset(resolved))
+            {
+                await _messenger.SendAsync(chatId, string.Format(BotMsgs.MsgAdminCreditNameNotNeeded, typed));
+                return null;
+            }
+
+            if (!CurrenciesConstant.HasCreditLedger(resolved))
+            {
+                await _messenger.SendAsync(chatId,
+                    string.Format(BotMsgs.MsgAdminAssetHasNoCredit,
+                        PersianFormat.Asset(resolved), CurrenciesConstant.GetCreditableNamesList()));
+                return null;
+            }
+
+            return resolved;
+        }
+
         private async Task<bool> HandleAdminCommandsAsync(long chatId, long telegramId, Message message, UserDto user)
         {
             var msgText = message.Text ?? "";
@@ -56,17 +98,8 @@ namespace TallaEgg.TelegramBot
                 var currencyInput = match.Groups["currency"].Success
                     ? match.Groups["currency"].Value
                     : CurrenciesConstant.Maua; // مقدار پیش‌فرض
-                var currency = CurrenciesConstant.ResolveCurrencyCode(currencyInput);
-
-                // A credit name resolves, so without this "ش ... اعتبار آبشده" would be prefixed a
-                // second time into CREDIT_CREDIT_MAUA and fail at the wallet as an unknown asset.
-                // Both commands already mean the credit ledger, so naming it adds nothing.
-                if (currency is null || CurrenciesConstant.IsCreditAsset(currency))
-                {
-                    await _messenger.SendAsync(message.Chat.Id,
-                        string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
-                    return true;
-                }
+                var currency = await ResolveCreditableAssetAsync(message.Chat.Id, currencyInput);
+                if (currency is null) return true;
 
                 var userDto = await _usersApi.GetUserAsync(phone);
                 if (userDto != null)
@@ -175,15 +208,8 @@ namespace TallaEgg.TelegramBot
                 var currencyInput = match.Groups["currency"].Success
                     ? match.Groups["currency"].Value
                     : CurrenciesConstant.Maua; // مقدار پیش‌فرض
-                var currency = CurrenciesConstant.ResolveCurrencyCode(currencyInput);
-
-                // Same guard as the charge command: a credit name would be prefixed twice.
-                if (currency is null || CurrenciesConstant.IsCreditAsset(currency))
-                {
-                    await _messenger.SendAsync(message.Chat.Id,
-                        string.Format(BotMsgs.MsgAdminInvalidCurrency, currencyInput, CurrenciesConstant.GetPersianNamesList()));
-                    return true;
-                }
+                var currency = await ResolveCreditableAssetAsync(message.Chat.Id, currencyInput);
+                if (currency is null) return true;
 
                 var userDto = await _usersApi.GetUserAsync(phone);
                 if (userDto != null)

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -365,19 +365,23 @@ namespace TallaEgg.TelegramBot.Infrastructure
 
         /// <summary>{0} = the list of permitted currency names in Persian.</summary>
         public const string MsgAdminChargeFormatError = "❌ قالب دستور درست نیست.\n\n" +
+                                                        "این دستور به اعتبار کاربر اضافه می‌کند.\n\n" +
                                                         "قالب صحیح:\n" +
                                                         "ش [شمارهٔ تلفن] [مقدار] [نوع]\n\n" +
                                                         "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n" +
                                                         "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ سکه\n\n" +
+                                                        "اگر نوع را ننویسید، طلا در نظر گرفته می‌شود.\n" +
                                                         "نوع‌های مجاز: {0}\n" +
                                                         "(به‌جای نام کامل، کلیدواژهٔ کوتاه هم می‌پذیرد: سکه، بیت)";
 
         /// <summary>{0} = the list of permitted currency names in Persian.</summary>
         public const string MsgAdminDeductFormatError = "❌ قالب دستور درست نیست.\n\n" +
+                                                        "این دستور از اعتبار کاربر کم می‌کند (معکوس دستور ش).\n\n" +
                                                         "قالب صحیح:\n" +
                                                         "د [شمارهٔ تلفن] [مقدار] [نوع]\n\n" +
                                                         "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n" +
                                                         "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ سکه\n\n" +
+                                                        "اگر نوع را ننویسید، طلا در نظر گرفته می‌شود.\n" +
                                                         "نوع‌های مجاز: {0}\n" +
                                                         "(به‌جای نام کامل، کلیدواژهٔ کوتاه هم می‌پذیرد: سکه، بیت)";
 
@@ -531,24 +535,27 @@ namespace TallaEgg.TelegramBot.Infrastructure
                                                      "اکنون می‌توانید سفارش خرید یا فروش ثبت کنید.";
 
         /// <summary>
-        /// Deduction confirmation shown to the admin.
+        /// Deduction confirmation shown to the admin. Says "credit" throughout, because that is
+        /// what the command now reduces — it used to debit the spot balance while its counterpart
+        /// credited the credit ledger, and the wording followed the old behaviour.
         /// {0} = the asset's Persian name; {1} = amount with unit; {2} = phone number;
-        /// {3} = the new balance with unit.
+        /// {3} = the new credit with unit.
         /// </summary>
-        public const string MsgAdminDeductDone = "✅ کسر از موجودی انجام شد.\n\n" +
+        public const string MsgAdminDeductDone = "✅ کسر از اعتبار انجام شد.\n\n" +
                                                  "دارایی: {0}\n" +
                                                  "مقدار کسر: {1}\n" +
                                                  "کاربر: {2}\n" +
-                                                 "موجودی جدید: {3}";
+                                                 "اعتبار جدید: {3}";
 
         /// <summary>
-        /// Notifies the user of a deduction. The previous message wrongly called it a top-up.
-        /// {0} = the asset's Persian name; {1} = amount with unit; {2} = the new balance with unit.
+        /// Notifies the user that their credit was reduced. The message named the balance while the
+        /// command debited the spot wallet; it names the credit now, because that is what moved.
+        /// {0} = the asset's Persian name; {1} = amount with unit; {2} = the new credit with unit.
         /// </summary>
-        public const string MsgUserBalanceDeducted = "ℹ️ از موجودی حساب شما کسر شد.\n\n" +
+        public const string MsgUserBalanceDeducted = "ℹ️ اعتبار حساب شما کاهش یافت.\n\n" +
                                                      "دارایی: {0}\n" +
                                                      "مقدار کسر: {1}\n" +
-                                                     "موجودی جدید: {2}";
+                                                     "اعتبار جدید: {2}";
 
         /// <summary>
         /// Shown to the admin when the same top-up was already recorded, so this send changed
@@ -578,11 +585,11 @@ namespace TallaEgg.TelegramBot.Infrastructure
         /// {0} = the asset's Persian name; {1} = amount with unit; {2} = phone number;
         /// {3} = the balance the wallet holds now, with unit.
         /// </summary>
-        public const string MsgAdminDeductAlreadyApplied = "ℹ️ این کسر پیش‌تر ثبت شده بود و دوباره اعمال نشد.\n\n" +
+        public const string MsgAdminDeductAlreadyApplied = "ℹ️ این کسر اعتبار پیش‌تر ثبت شده بود و دوباره اعمال نشد.\n\n" +
                                                           "دارایی: {0}\n" +
                                                           "مقدار: {1}\n" +
                                                           "کاربر: {2}\n" +
-                                                          "موجودی کنونی کاربر: {3}\n\n" +
+                                                          "اعتبار کنونی کاربر: {3}\n\n" +
                                                           "اگر قصد داشتید بار دوم هم کسر کنید، چند دقیقه دیگر دوباره تلاش کنید.";
 
         /// <summary>{0} = the error reason.</summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -339,10 +339,11 @@ namespace TallaEgg.TelegramBot.Infrastructure
         public const string MsgAdminHelp = "🔧 دستورهای مدیریت\n\n" +
                                           "افزایش اعتبار:\n" +
                                           "ش [شمارهٔ تلفن] [مقدار] [نوع]\n" +
-                                          "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n\n" +
-                                          "کسر از موجودی:\n" +
+                                          "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ آبشده\n\n" +
+                                          "کسر از اعتبار (معکوس ش):\n" +
                                           "د [شمارهٔ تلفن] [مقدار] [نوع]\n" +
-                                          "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n\n" +
+                                          "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ آبشده\n" +
+                                          "(هر دو روی اعتبار کار می‌کنند؛ بدون ذکر نوع، آبشده)\n\n" +
                                           "فهرست کاربران: ک [جستجو]\n" +
                                           "موجودی کاربر: م [شمارهٔ تلفن]\n" +
                                           "سفارش‌های فعال کاربر: س [شمارهٔ تلفن]\n\n" +
@@ -368,9 +369,9 @@ namespace TallaEgg.TelegramBot.Infrastructure
                                                         "این دستور به اعتبار کاربر اضافه می‌کند.\n\n" +
                                                         "قالب صحیح:\n" +
                                                         "ش [شمارهٔ تلفن] [مقدار] [نوع]\n\n" +
-                                                        "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n" +
+                                                        "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ آبشده\n" +
                                                         "نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ سکه\n\n" +
-                                                        "اگر نوع را ننویسید، طلا در نظر گرفته می‌شود.\n" +
+                                                        "اگر نوع را ننویسید، آبشده در نظر گرفته می‌شود.\n" +
                                                         "نوع‌های مجاز: {0}\n" +
                                                         "(به‌جای نام کامل، کلیدواژهٔ کوتاه هم می‌پذیرد: سکه، بیت)";
 
@@ -379,11 +380,34 @@ namespace TallaEgg.TelegramBot.Infrastructure
                                                         "این دستور از اعتبار کاربر کم می‌کند (معکوس دستور ش).\n\n" +
                                                         "قالب صحیح:\n" +
                                                         "د [شمارهٔ تلفن] [مقدار] [نوع]\n\n" +
-                                                        "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان\n" +
+                                                        "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ آبشده\n" +
                                                         "نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۱۰۰ سکه\n\n" +
-                                                        "اگر نوع را ننویسید، طلا در نظر گرفته می‌شود.\n" +
+                                                        "اگر نوع را ننویسید، آبشده در نظر گرفته می‌شود.\n" +
                                                         "نوع‌های مجاز: {0}\n" +
                                                         "(به‌جای نام کامل، کلیدواژهٔ کوتاه هم می‌پذیرد: سکه، بیت)";
+
+        /// <summary>
+        /// For an asset that exists but has no credit ledger — today that is Toman, which is a quote
+        /// currency, and credit ledgers are minted per tradable base asset only. Deliberately not
+        /// <see cref="MsgAdminInvalidCurrency"/>: Toman is a perfectly good asset name, and telling
+        /// the admin it was not recognised would send them hunting for a spelling mistake that is
+        /// not there. Before this, the command built CREDIT_IRT and failed at the wallet instead,
+        /// surfacing as the generic "خطا در بروزرسانی".
+        /// {0} = the asset's Persian name; {1} = the assets that do have a credit ledger.
+        /// </summary>
+        public const string MsgAdminAssetHasNoCredit = "❌ «{0}» دفتر اعتبار ندارد.\n\n" +
+                                                       "دستورهای ش و د فقط روی اعتبار کار می‌کنند، و اعتبار فقط برای دارایی‌های قابل معامله تعریف می‌شود.\n\n" +
+                                                       "دارایی‌های مجاز: {1}";
+
+        /// <summary>
+        /// For a name that resolves to a credit ledger, which both commands add for themselves.
+        /// Separate from "not recognised" because the admin typed something meaningful — and it used
+        /// to be the only spelling that could reduce a credit line, so it is worth answering kindly.
+        /// {0} = what they typed.
+        /// </summary>
+        public const string MsgAdminCreditNameNotNeeded = "ℹ️ لازم نیست «{0}» را بنویسید.\n\n" +
+                                                          "هر دو دستور ش و د همیشه روی اعتبار کار می‌کنند.\n" +
+                                                          "فقط نام دارایی را بنویسید — مثلاً «آبشده» یا «سکه».";
 
         /// <summary>{0} = the user's invalid input; {1} = the list of permitted Persian names.</summary>
         public const string MsgAdminInvalidCurrency = "❌ نوع «{0}» شناسایی نشد.\n\n" +

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace TallaEgg.Core
 {
@@ -91,6 +91,14 @@ namespace TallaEgg.Core
         /// ceiling now that there is more than one.
         /// </summary>
         public static string CreditAssetFor(string baseAsset) => "CREDIT_" + baseAsset;
+
+        /// <summary>
+        /// Whether a code is already a credit ledger. Callers that are about to apply
+        /// <see cref="CreditAssetFor"/> use it to refuse input that has been prefixed once already,
+        /// rather than building "CREDIT_CREDIT_MAUA" and failing later with a wallet-not-found.
+        /// </summary>
+        public static bool IsCreditAsset(string? code) =>
+            code is not null && code.StartsWith("CREDIT_", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Merges the "Symbols" section of the shared config file on top of the compiled
@@ -357,10 +365,21 @@ namespace TallaEgg.Core
         /// <summary>
         /// The typeable Persian currency names, for use in an error message instead of Latin codes.
         ///
-        /// Each asset's CREDIT_ variant is deliberately excluded: the top-up and withdraw commands
-        /// always add the CREDIT_ prefix themselves, so an admin typing the credit name directly
-        /// would produce a meaningless double-prefixed code ("CREDIT_CREDIT_MAUA"). This list exists
-        /// to prevent that input, not to invite it.
+        /// <para>
+        /// Each asset's CREDIT_ variant is excluded, because the top-up and deduction commands both
+        /// add the CREDIT_ prefix themselves: an admin typing the credit name would produce a
+        /// double-prefixed code ("CREDIT_CREDIT_MAUA"), which is not an asset. This list exists to
+        /// prevent that input, not to invite it — and <see cref="IsCreditAsset"/> now refuses it
+        /// outright rather than leaving the omission from a help message as the only defence.
+        /// </para>
+        ///
+        /// <para>
+        /// The reason used to be true of the top-up command only. The deduction command passed the
+        /// resolved code through unprefixed, so it read the credit name correctly while the list
+        /// hid that from the admin — the one form that reduced a credit line was the one form
+        /// nobody was told about. Both commands act on the credit ledger now, so the exclusion is
+        /// finally true of both.
+        /// </para>
         /// </summary>
         public static string GetPersianNamesList() =>
             string.Join("، ", _currencies.Values

--- a/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
+++ b/src/TallaEgg/TallaEgg.Core/CurrenciesConstant.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace TallaEgg.Core
 {
@@ -99,6 +99,32 @@ namespace TallaEgg.Core
         /// </summary>
         public static bool IsCreditAsset(string? code) =>
             code is not null && code.StartsWith("CREDIT_", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Whether an asset has a credit ledger at all.
+        ///
+        /// <para>
+        /// Credit ledgers are minted per tradable <b>base</b> asset (see the loop in
+        /// <c>BuildCurrencies</c>), so gold, the coin and Bitcoin have one and Toman — a quote
+        /// currency — does not. <c>CREDIT_IRT</c> is therefore not a currency, and asking the wallet
+        /// to deposit into it fails with "wallet does not exist".
+        /// </para>
+        ///
+        /// <para>
+        /// Worth knowing: <c>ValidateCreditAndBalanceAsync</c> reads <c>CREDIT_&lt;quote&gt;</c> and would
+        /// use it if it existed, so half of the cross-asset credit design is unreachable rather than
+        /// absent. Whether it should exist is the open question on #36; this only reports what is
+        /// true today so the commands can say so plainly instead of failing at the wallet.
+        /// </para>
+        /// </summary>
+        public static bool HasCreditLedger(string? baseAsset) =>
+            baseAsset is not null && IsValidCurrency(CreditAssetFor(baseAsset));
+
+        /// <summary>The Persian names of the assets that do have a credit ledger, for an error message.</summary>
+        public static string GetCreditableNamesList() =>
+            string.Join("، ", _currencies.Values
+                .Where(c => !IsCreditAsset(c.Code) && HasCreditLedger(c.Code))
+                .Select(c => c.PersianName));
 
         /// <summary>
         /// Merges the "Symbols" section of the shared config file on top of the compiled

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -479,6 +479,40 @@ public class WalletApiClient : IWalletApiClient
         }
     }
 
+    /// <summary>
+    /// Turns a non-success wallet response into a failure that still carries the reason.
+    ///
+    /// <para>
+    /// The endpoints answer a rejected request with 400 and the <c>BusinessRuleException</c>
+    /// message in the body — Persian, written for the person reading it, which is the whole
+    /// contract of that exception type. Discarding it and substituting "خطا در بروزرسانی" told an
+    /// admin who tried to deduct more credit than a customer has that something had gone wrong with
+    /// the system, when what actually happened was the wallet correctly refusing them.
+    /// </para>
+    ///
+    /// <para>
+    /// The generic message stays as the fallback, for a body that is empty, not JSON, or carries no
+    /// message — a 500 from an unhandled fault, say, whose detail is not for the customer.
+    /// </para>
+    /// </summary>
+    private static ApiResponse<WalletBallanceDTO> FailureFrom(string responseBody)
+    {
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ApiResponse<WalletBallanceDTO>>(responseBody,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (!string.IsNullOrWhiteSpace(parsed?.Message))
+                return ApiResponse<WalletBallanceDTO>.Fail(parsed!.Message);
+        }
+        catch (JsonException)
+        {
+            // Not JSON at all. Nothing to salvage; fall through to the generic message.
+        }
+
+        return ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
+    }
+
     public async Task<TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>> DepositeAsync(WalletRequest request)
     {
         try
@@ -501,7 +535,7 @@ public class WalletApiClient : IWalletApiClient
                 return result ?? ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
             }
 
-            return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
+            return FailureFrom(respText);
 
         }
         catch (Exception ex)
@@ -534,7 +568,7 @@ public class WalletApiClient : IWalletApiClient
                 return result ?? ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
             }
 
-            return TallaEgg.Core.DTOs.ApiResponse<WalletBallanceDTO>.Fail("خطا در بروزرسانی");
+            return FailureFrom(respText);
 
         }
         catch (Exception ex)

--- a/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
@@ -447,6 +447,45 @@ public class AdminChargeCommandTests
         Assert.StartsWith("admin-withdrawal:", withdrawal.ReferenceId);
         Assert.Contains("CREDIT_SEKE_BAHAR", withdrawal.ReferenceId);
     }
+    /// <summary>
+    /// Whatever these commands offer, they have to accept. Found by testing the bot: the format
+    /// error listed "تومان" among the permitted types and the very next message refused it for
+    /// having no credit ledger — two lists disagreeing one screen apart, inside one command. That
+    /// is the same misleading-text defect this PR exists to close, so it is pinned rather than
+    /// just fixed.
+    /// </summary>
+    [Theory]
+    [InlineData("ش")]
+    [InlineData("د")]
+    public async Task ThePermittedTypesAreExactlyTheTypesTheCommandAccepts(string command)
+    {
+        var handler = Build();
+
+        // A malformed command, to make it print the list.
+        await SayAsync(handler, command + " badphone");
+
+        var help = Assert.Single(_messenger.Texts, t => t.Contains("نوع‌های مجاز"));
+
+        Assert.DoesNotContain("تومان", help);
+        foreach (var creditable in new[] { "آبشده", "سکه تمام بهار آزادی", "بیت‌کوین" })
+            Assert.Contains(creditable, help);
+    }
+
+    /// <summary>
+    /// And the list an unrecognised word is answered with is the same one, so the two ways of
+    /// asking "what may I type here" cannot drift apart.
+    /// </summary>
+    [Fact]
+    public async Task TheUnrecognisedWordListMatchesTheFormatHelpList()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "ش 09158527483 100 نقره");
+
+        var reply = Assert.Single(_messenger.Texts, t => t.Contains("شناسایی نشد"));
+        Assert.DoesNotContain("تومان", reply);
+        Assert.Contains("آبشده", reply);
+    }
     private sealed class RecordingWalletApiClient : StubWalletApiClient
     {
         public List<WalletRequest> Deposits { get; } = [];

--- a/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core;
 using TallaEgg.Core.Utilties;
 using TallaEgg.Core.DTOs;
@@ -186,7 +186,7 @@ public class AdminChargeCommandTests
     {
         var handler = Build();
 
-        await SayAsync(handler, "د 09158527483 100 تومان");
+        await SayAsync(handler, "د 09158527483 100 آبشده");
 
         var withdrawal = Assert.Single(_walletApi.Withdrawals);
         Assert.StartsWith("admin-withdrawal:", withdrawal.ReferenceId);
@@ -250,10 +250,10 @@ public class AdminChargeCommandTests
         _walletApi.ReportAlreadyApplied = true;
         _walletApi.CurrentBalance = 4_200m;
 
-        await SayAsync(handler, "د 09158527483 500 تومان");
+        await SayAsync(handler, "د 09158527483 500 آبشده");
 
         var reply = Assert.Single(_messenger.Texts, t => t.Contains("پیش‌تر ثبت شده بود"));
-        Assert.Contains(PersianFormat.Amount(4_200m, "IRT"), reply);
+        Assert.Contains(PersianFormat.Amount(4_200m, "CREDIT_MAUA"), reply);
     }
 
     /// <summary>
@@ -316,7 +316,7 @@ public class AdminChargeCommandTests
     /// <summary>The property that was broken, stated directly: the same words reach the same wallet.</summary>
     [Theory]
     [InlineData("سکه")]
-    [InlineData("تومان")]
+    [InlineData("آبشده")]
     [InlineData("بیت‌کوین")]
     [InlineData("")]
     public async Task ChargingAndDeductingTheSameWordsReachTheSameWallet(string asset)
@@ -360,6 +360,49 @@ public class AdminChargeCommandTests
 
         Assert.Empty(_walletApi.Deposits);
         Assert.Empty(_walletApi.Withdrawals);
+
+        // Its own sentence, not "unrecognised": the admin typed something meaningful, and being
+        // told to check their spelling would send them looking for a mistake that is not there.
+        Assert.Contains(_messenger.Texts, t => t.Contains("لازم نیست"));
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("شناسایی نشد"));
+    }
+
+    /// <summary>
+    /// Toman has no credit ledger. Credit ledgers are minted per tradable base asset, and Toman is
+    /// a quote currency — CREDIT_IRT is not a currency, and the wallet rejects a deposit into it.
+    ///
+    /// <para>
+    /// This was already true of the top-up command before these commands were made mirrors: it has
+    /// always built CREDIT_IRT for "تومان" and always failed, opaquely, at the wallet — while the
+    /// bot's own help offered exactly that as its example. Both commands now say so directly.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("ش")]
+    [InlineData("د")]
+    public async Task TomanIsRefusedBecauseItHasNoCreditLedger(string command)
+    {
+        var handler = Build();
+
+        await SayAsync(handler, command + " 09158527483 500 تومان");
+
+        Assert.Empty(_walletApi.Deposits);
+        Assert.Empty(_walletApi.Withdrawals);
+
+        // Not "unrecognised" either: "تومان" is a real asset, it simply cannot carry credit.
+        Assert.Contains(_messenger.Texts, t => t.Contains("دفتر اعتبار ندارد"));
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("شناسایی نشد"));
+    }
+
+    /// <summary>An unrecognised word still gets the spelling message, so the three refusals stay distinct.</summary>
+    [Fact]
+    public async Task AnUnrecognisedWordStillGetsTheSpellingMessage()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "ش 09158527483 100 نقره");
+
+        Assert.Empty(_walletApi.Deposits);
         Assert.Contains(_messenger.Texts, t => t.Contains("شناسایی نشد"));
     }
 

--- a/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AdminChargeCommandTests.cs
@@ -293,6 +293,117 @@ public class AdminChargeCommandTests
         // Anchored to its label: a bare PersianFormat.Amount(0) is "۰", which also sits inside "۱۰۰".
         Assert.Contains("اعتبار کنونی کاربر: " + PersianFormat.Amount(100m, "CREDIT_SEKE_BAHAR"), reply);
     }
+    // -----------------------------------------------------------------------------------
+    // ش and د as mirrors (evidence recorded on #36).
+    //
+    // They used to write to different wallets from the same Persian word: ش credited
+    // CREDIT_<X> while د debited plain <X>, with identical help text and identical examples.
+    // An admin undoing a mistaken top-up with the obvious symmetric command left the credit
+    // untouched and took the customer's real position instead. Nothing in this suite covered
+    // which asset د targeted, so the whole asymmetry was invisible to it.
+    // -----------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeductingTargetsTheCreditLedgerNotTheSpotWallet()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "د 09158527483 100 سکه");
+
+        Assert.Equal("CREDIT_SEKE_BAHAR", Assert.Single(_walletApi.Withdrawals).Asset);
+    }
+
+    /// <summary>The property that was broken, stated directly: the same words reach the same wallet.</summary>
+    [Theory]
+    [InlineData("سکه")]
+    [InlineData("تومان")]
+    [InlineData("بیت‌کوین")]
+    [InlineData("")]
+    public async Task ChargingAndDeductingTheSameWordsReachTheSameWallet(string asset)
+    {
+        var handler = Build();
+        var suffix = asset.Length == 0 ? "" : " " + asset;
+
+        await SayAsync(handler, "ش 09158527483 100" + suffix);
+        await SayAsync(handler, "د 09158527483 100" + suffix);
+
+        Assert.Equal(Assert.Single(_walletApi.Deposits).Asset, Assert.Single(_walletApi.Withdrawals).Asset);
+    }
+
+    /// <summary>
+    /// With no asset named, both default to gold. د used to default to Toman, so even the
+    /// shorthand forms disagreed about what they meant.
+    /// </summary>
+    [Fact]
+    public async Task DeductingWithNoCurrencyGivenDefaultsToGoldCredit()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "د 09158527483 100");
+
+        Assert.Equal("CREDIT_MAUA", Assert.Single(_walletApi.Withdrawals).Asset);
+    }
+
+    /// <summary>
+    /// Naming the credit ledger is refused on both commands, rather than being prefixed a second
+    /// time into CREDIT_CREDIT_MAUA — an asset that does not exist and would fail at the wallet
+    /// with a confusing "wallet not found". Both commands already mean the credit ledger.
+    /// </summary>
+    [Theory]
+    [InlineData("ش")]
+    [InlineData("د")]
+    public async Task NamingTheCreditLedgerIsRefusedRatherThanDoublePrefixed(string command)
+    {
+        var handler = Build();
+
+        await SayAsync(handler, command + " 09158527483 100 اعتبار آبشده");
+
+        Assert.Empty(_walletApi.Deposits);
+        Assert.Empty(_walletApi.Withdrawals);
+        Assert.Contains(_messenger.Texts, t => t.Contains("شناسایی نشد"));
+    }
+
+    /// <summary>
+    /// The customer is told their credit fell, not their balance. The wording followed the old
+    /// behaviour and would otherwise now describe a wallet the command no longer touches.
+    /// </summary>
+    [Fact]
+    public async Task TheCustomerIsToldTheirCreditFellNotTheirBalance()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "د 09158527483 100 سکه");
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("اعتبار حساب شما کاهش یافت"));
+        Assert.DoesNotContain(_messenger.Texts, t => t.Contains("از موجودی حساب شما کسر شد"));
+    }
+
+    /// <summary>And the admin's own confirmation says credit too.</summary>
+    [Fact]
+    public async Task TheAdminConfirmationSaysCredit()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "د 09158527483 100 سکه");
+
+        Assert.Contains(_messenger.Texts, t => t.Contains("کسر از اعتبار انجام شد"));
+    }
+
+    /// <summary>
+    /// The deduplication key follows the ledger the command actually touches, so a top-up and a
+    /// deduction of the same amount still cannot be mistaken for one another.
+    /// </summary>
+    [Fact]
+    public async Task TheDeductionKeyNamesTheCreditLedger()
+    {
+        var handler = Build();
+
+        await SayAsync(handler, "د 09158527483 100 سکه");
+
+        var withdrawal = Assert.Single(_walletApi.Withdrawals);
+        Assert.StartsWith("admin-withdrawal:", withdrawal.ReferenceId);
+        Assert.Contains("CREDIT_SEKE_BAHAR", withdrawal.ReferenceId);
+    }
     private sealed class RecordingWalletApiClient : StubWalletApiClient
     {
         public List<WalletRequest> Deposits { get; } = [];

--- a/tests/TallaEgg.AllServices.Tests/WalletApiClientFailureMessageTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletApiClientFailureMessageTests.cs
@@ -1,0 +1,98 @@
+﻿using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core.Requests.Wallet;
+using TallaEgg.Infrastructure.Clients;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// A rejected wallet operation has to reach the admin with the reason the wallet gave.
+///
+/// <para>
+/// The endpoints answer a refusal with 400 and the <c>BusinessRuleException</c> message in the
+/// body — Persian, written for the person reading it, which is that exception type's entire
+/// contract. The client discarded it and substituted "خطا در بروزرسانی", so an admin who asked to
+/// deduct more credit than a customer holds was told the system had failed rather than that the
+/// wallet had refused them.
+/// </para>
+///
+/// <para>
+/// Found by driving the real bot: deducting 100 against a credit of 50 produced
+/// "❌ عملیات انجام نشد. دلیل: خطا در بروزرسانی", while the wallet had in fact answered
+/// "مقدار کسر از حساب بیشتر از حد مجاز است". It matters more now that the deduction command is
+/// the way credit is reduced: asking for more than exists is an ordinary mistake, not an exotic one.
+/// </para>
+/// </summary>
+public class WalletApiClientFailureMessageTests
+{
+    private const string TheWalletsReason = "مقدار کسر از حساب بیشتر از حد مجاز است";
+
+    /// <summary>Answers every request with one canned response, so the client is the only thing under test.</summary>
+    private sealed class CannedHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+    }
+
+    private static WalletApiClient ClientAnswering(HttpStatusCode status, string body) =>
+        new(new HttpClient(new CannedHandler(status, body)) { BaseAddress = new Uri("http://wallet.test/") },
+            new ConfigurationBuilder().Build(),
+            NullLogger<WalletApiClient>.Instance);
+
+    private static WalletRequest AnyRequest() => new()
+    {
+        UserId = Guid.NewGuid(),
+        Asset = "CREDIT_MAUA",
+        Amount = 100m
+    };
+
+    [Fact]
+    public async Task AWithdrawalRefusedByTheWalletKeepsTheWalletsReason()
+    {
+        var client = ClientAnswering(HttpStatusCode.BadRequest,
+            $"{{\"success\":false,\"message\":\"{TheWalletsReason}\",\"data\":null}}");
+
+        var result = await client.WithdrawalAsync(AnyRequest());
+
+        Assert.False(result.Success);
+        Assert.Equal(TheWalletsReason, result.Message);
+    }
+
+    [Fact]
+    public async Task ADepositRefusedByTheWalletKeepsTheWalletsReason()
+    {
+        const string reason = "کیف پول وجود ندارد";
+
+        var client = ClientAnswering(HttpStatusCode.BadRequest,
+            $"{{\"success\":false,\"message\":\"{reason}\",\"data\":null}}");
+
+        var result = await client.DepositeAsync(AnyRequest());
+
+        Assert.False(result.Success);
+        Assert.Equal(reason, result.Message);
+    }
+
+    /// <summary>
+    /// A failure with nothing to say falls back to the generic sentence. An unhandled fault's detail
+    /// is not written for a customer, so there is nothing here worth passing on.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("<html>500 Internal Server Error</html>")]
+    [InlineData("{\"success\":false,\"message\":null,\"data\":null}")]
+    [InlineData("{\"success\":false,\"message\":\"   \",\"data\":null}")]
+    public async Task AFailureWithNoUsableMessageFallsBackToTheGenericOne(string body)
+    {
+        var client = ClientAnswering(HttpStatusCode.InternalServerError, body);
+
+        var result = await client.WithdrawalAsync(AnyRequest());
+
+        Assert.False(result.Success);
+        Assert.Equal("خطا در بروزرسانی", result.Message);
+    }
+}


### PR DESCRIPTION
**Branch Name**: `fix/symmetric-admin-credit-commands`
**Linked Issue**: Related to #36 (evidence recorded [there](https://github.com/MohKardan/TallaEgg/issues/36#issuecomment-5474366458))

## Description

`ش` (top-up) and `د` (deduct) wrote to **different wallets from the same Persian word**: `ش` credited `CREDIT_<X>`, `د` debited plain `<X>`. Both now act on the credit ledger, and both default to gold.

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

## The problem

```csharp
// ش  — top-up
Asset = CurrenciesConstant.CreditAssetFor(currency)   // always CREDIT_<X>

// د  — deduct
Asset = currency                                       // always plain <X>
```

The help text presented them as a matched pair, down to identical examples:

```
ش [شمارهٔ تلفن] [مقدار] [نوع]     نمونه: ش ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان
د [شمارهٔ تلفن] [مقدار] [نوع]     نمونه: د ۰۹۱۲۱۲۳۴۵۶۷ ۵۰۰۰۰۰ تومان
```

So an admin correcting a mistaken top-up reaches for `د <phone> <amount> <same word>`, and gets: the mistaken credit untouched, and the customer's **real** position debited instead. One mistake becomes two, under `✅ کسر از موجودی انجام شد`.

From live data on a test account:

```
CREDIT_MAUA    100.00      ← the limit the admin granted
MAUA           -39.81      ← the position that limit is backing
```

`د <phone> 100 آبشده` would have left the 100 alone and taken the spot to `-139.81`.

The two also disagreed about an omitted asset — `ش` defaulted to gold, `د` to Toman — so even the shorthand forms meant different things.

## Changes Made

- **`د` targets `CREDIT_<X>`**, like `ش`. Its deduplication key follows.
- **`د` defaults to gold**, like `ش`.
- **Both refuse a credit name.** `اعتبار آبشده` resolves to `CREDIT_MAUA`, which `ش` then prefixed again into `CREDIT_CREDIT_MAUA` — not an asset, and it failed at the wallet as a confusing "wallet not found". New `CurrenciesConstant.IsCreditAsset` makes this an explicit check.
- **The `GetPersianNamesList` comment is corrected.** It claimed both commands add the prefix themselves; that was true of `ش` only. `د` passed the resolved code through unprefixed, so it read credit names correctly while the list hid them from the admin — the only form that could reduce a credit line was the only form nobody was told about.
- **Wording follows behaviour**: the admin confirmation, the customer notification and the deduplicated-repeat message all say credit rather than balance, and both help texts now state which ledger they act on and what an omitted asset means.

## What this removes, and why it is not a loss

Deducting a **spot** balance from the bot is gone.

That is the asymmetry being removed, not a capability. `BotHandlerAdmin` is the only place the bot moves money at all, and the top-up has always meant credit — so there has never been a way to *add* to a spot balance. A deduction that could reach one had no counterpart. Spot balances move by trading and settlement, or through the wallet API directly (`POST /api/wallet/withdrawal`).

## Why now, rather than waiting for #36

#36 replaces this model entirely — credit becomes a `CreditLimit` column with `Balance >= -CreditLimit`, and none of the above can be expressed, let alone typed wrong. That is the right fix.

But #36 is blocked on an unanswered business question ("should 50g of gold credit also fund IRR purchases?"), and engineering is paused for customer discovery, so it may sit for a while. The trap is live in the meantime and costs a customer's real assets when it fires. This is deliberately the smaller, interim change; the evidence is recorded on #36 so the two stay connected.

## Testing Completed

### Unit tests
- [x] New unit tests written — 11 added
- [x] All unit tests pass

```
Passed!  -  Failed: 0, Passed: 575, Skipped: 0, Total: 575
```

564 before, 575 after.

**The suite had nothing covering which asset `د` targeted** — all 564 existing tests pass unchanged against the new behaviour. That is why the asymmetry survived: it was invisible to every test in the project.

**Verified load-bearing.** Restoring the old behaviour fails 7 of the new tests:

```
Failed  ChargingAndDeductingTheSameWordsReachTheSameWallet(asset: "")
Failed  ChargingAndDeductingTheSameWordsReachTheSameWallet(asset: "سکه")
Failed  ChargingAndDeductingTheSameWordsReachTheSameWallet(asset: "تومان")
Failed  ChargingAndDeductingTheSameWordsReachTheSameWallet(asset: "بیت‌کوین")
Failed  DeductingWithNoCurrencyGivenDefaultsToGoldCredit
Failed  TheDeductionKeyNamesTheCreditLedger
Failed  DeductingTargetsTheCreditLedgerNotTheSpotWallet
```

`ChargingAndDeductingTheSameWordsReachTheSameWallet` states the broken property directly rather than restating the implementation: charge and deduct with the same words, assert the same asset, across four inputs including the omitted one.

### Integration
- [x] `dotnet build TallaEgg.sln` → **0 Warnings, 0 Errors**
- [x] Simulator

```
=== Done in 00:00:20.48. Registered 20 (18 approved), trades attempted 60, errors 0 ===
new outbox failures: 0
```

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or messages
- [x] `config/appsettings.global.json` not in the diff
- [x] Code compiles without warnings

## Code Quality
- [x] Follows `STANDARDS.md`
- [x] Comments in English, explaining the "why"
- [x] No new dependencies

## Breaking Changes?
- [x] **Breaking** — `د` changes meaning

`د <phone> <amount> <asset>` now reduces the customer's **credit** rather than their spot balance, and an omitted asset means gold rather than Toman. Anyone with the old muscle memory will find the command does something different.

This is intended and was decided deliberately: the previous meaning was the defect. The confirmation messages state which ledger moved, so a wrong assumption is visible in the reply rather than silent.

**Migration path**: for a genuine spot adjustment, call the wallet API directly.

## Deployment Notes

No migration, no configuration, no schema change. Revert the commit to roll back.

**Post-deployment verification**: `ش <phone> 100 سکه` then `د <phone> 100 سکه` and confirm the customer's `CREDIT_SEKE_BAHAR` returns to where it started and their `SEKE_BAHAR` is untouched.

## Related

- #36 — the model this is an interim fix for, with the field evidence
- #157 / #176 — the deduplication these commands carry
