### PR TITLE
[Feature] Leases and leader election so Orders.Api can run on more than one instance — closes #160

### DIFF
--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -133,6 +133,10 @@ builder.Services.AddScoped<Orders.Application.Services.QuoteFillService>();
 builder.Services.AddScoped<Orders.Application.Services.MarketModeStartupValidator>();
 builder.Services.AddScoped<Orders.Application.Services.PositionService>();
 
+// Names this instance and lets the background loops agree on which of them runs (issue #160).
+// Registered before the hosted services below, all three of which depend on it.
+builder.Services.AddInstanceCoordination();
+
 // Outbox processor: reliably delivers trade settlements to the Wallet service.
 builder.Services.AddHostedService<Orders.Application.Services.OutboxProcessorService>();
 
@@ -215,6 +219,13 @@ using (var scope = app.Services.CreateScope())
     var services = scope.ServiceProvider;
     var context = services.GetRequiredService<OrdersDbContext>();
     await context.Database.MigrateAsync(); // اجرای مایگریشن‌ها
+
+    // Says who this instance is before anything it writes to the database carries that name
+    // (issue #160). Running a second Orders.Api is supported now, but it is rarely intended here:
+    // this line and the follower warnings from the background loops are what make it visible
+    // instead of leaving the constraint in a code comment nobody deploying will read.
+    Log.Information("Orders.Api instance identity is {InstanceId}. Background loops coordinate through the ServiceLeases table.",
+        services.GetRequiredService<InstanceIdentity>().Value);
 
     // A symbol with an active quote but not in dealer mode means the admin's published price and
     // the configuration disagree. Logged only; it does not stop the service (issue #73).
@@ -1042,7 +1053,12 @@ app.MapGet("/api/outbox/unsettled", async (OrdersDbContext db, bool includeAband
             m.NextAttemptAt,
             m.LastError,
             m.AbandonReason,
-            m.AbandonedAt
+            m.AbandonedAt,
+            // Which instance is holding this message and until when (issue #160). A message that
+            // looks stuck while an unexpired lease sits on it is being worked on right now; one
+            // whose lease has passed was dropped by an instance that died mid-attempt.
+            m.LeasedBy,
+            m.LeaseExpiresAt
         })
         .ToListAsync();
 

--- a/src/Order/Orders.Application/InstanceCoordinationRegistration.cs
+++ b/src/Order/Orders.Application/InstanceCoordinationRegistration.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orders.Application.Services;
+
+namespace Orders.Application;
+
+/// <summary>
+/// Registers what the background services need to coordinate with other instances (issue #160).
+///
+/// A shared method for the same reason <see cref="MatchingEngineRegistration"/> is one: the
+/// matching engine and the outbox processor both take these dependencies, so a test that built
+/// its own copy of the registration would keep passing after <c>Program.cs</c> changed.
+/// </summary>
+public static class InstanceCoordinationRegistration
+{
+    /// <summary>
+    /// Both are singletons. The identity must be, or one process would answer to several names and
+    /// could not renew its own leases; the lease implementation must be, because the hosted
+    /// services that consume it are singletons themselves and open their own scopes per call.
+    /// </summary>
+    public static IServiceCollection AddInstanceCoordination(this IServiceCollection services)
+    {
+        services.AddSingleton<InstanceIdentity>();
+        services.AddSingleton<ILeaderLease, DatabaseLeaderLease>();
+
+        return services;
+    }
+}

--- a/src/Order/Orders.Application/InstanceIdentity.cs
+++ b/src/Order/Orders.Application/InstanceIdentity.cs
@@ -1,0 +1,39 @@
+namespace Orders.Application;
+
+/// <summary>
+/// Names this running copy of the service, so a claim written to the database says who wrote it.
+///
+/// Both coordination mechanisms added for issue #160 need an owner: the per-row lease on the
+/// outbox, and the leader lease the background loops hold. Sharing one identity means a stuck
+/// claim points at a process an operator can actually go and look at.
+///
+/// The random suffix matters. Machine name and process id alone can repeat — Windows reuses
+/// process ids — and a restarted instance inheriting the identity of the one that crashed would
+/// consider itself the owner of claims it knows nothing about. A fresh suffix per start makes
+/// those claims belong to nobody, so they expire and are picked up normally.
+/// </summary>
+public sealed class InstanceIdentity
+{
+    public InstanceIdentity()
+        : this($"{Environment.MachineName}#{Environment.ProcessId}#{Guid.NewGuid().ToString("N")[..8]}")
+    {
+    }
+
+    /// <summary>Explicit identity, so a test can act as two separate instances against one database.</summary>
+    public InstanceIdentity(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("An instance identity cannot be empty.", nameof(value));
+
+        // Truncated rather than rejected: the column is length-limited, and a machine name long
+        // enough to overflow it is not a reason to refuse to start.
+        Value = value.Length > MaxLength ? value[..MaxLength] : value;
+    }
+
+    /// <summary>Matches the length of the owner columns that store this value.</summary>
+    public const int MaxLength = 100;
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+}

--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -30,13 +30,41 @@ public class AutoQuotePublisherService : BackgroundService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromMinutes(2);
 
+    /// <summary>
+    /// Comfortably longer than a tick (issue #160), because a tick fetches a reference price per
+    /// symbol over the network and losing the lease mid-tick would let a second instance start
+    /// publishing the same prices.
+    /// </summary>
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(6);
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<AutoQuotePublisherService> _logger;
+    private readonly LeaderGate _leaderGate;
 
-    public AutoQuotePublisherService(IServiceScopeFactory scopeFactory, ILogger<AutoQuotePublisherService> logger)
+    public AutoQuotePublisherService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<AutoQuotePublisherService> logger,
+        ILeaderLease leaderLease)
     {
         _scopeFactory = scopeFactory;
         _logger = logger;
+        _leaderGate = new LeaderGate(ServiceLeaseRoles.AutoQuotePublisher, LeaseDuration, leaderLease, logger);
+    }
+
+    /// <summary>internal so a test can ask the gate directly, without driving the loop's timing.</summary>
+    internal Task<bool> TryLeadAsync(CancellationToken ct = default) => _leaderGate.TryLeadAsync(ct);
+
+    /// <summary>
+    /// Hands publishing back on a graceful shutdown so another instance takes over at once rather
+    /// than leaving the shop on a stale price for up to a lease period (issue #160).
+    /// </summary>
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken);
+
+        // Not the caller's token: during a forced shutdown it is already cancelled, and this is a
+        // single UPDATE worth finishing.
+        await _leaderGate.ReleaseAsync(CancellationToken.None);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -45,6 +73,20 @@ public class AutoQuotePublisherService : BackgroundService
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            // Only one instance publishes (issue #160). Two would write two quote rows per tick
+            // for the same symbol, and — worse — an out-of-band price would put the same approval
+            // request in front of the admin twice.
+            if (!await _leaderGate.TryLeadAsync(stoppingToken))
+            {
+                try
+                {
+                    await Task.Delay(PollInterval, stoppingToken);
+                }
+                catch (OperationCanceledException) { break; }
+
+                continue;
+            }
+
             await ExpireStaleProposalsAsync();
 
             var activeSymbols = await ActiveSymbolsAsync(stoppingToken);

--- a/src/Order/Orders.Application/Services/DatabaseLeaderLease.cs
+++ b/src/Order/Orders.Application/Services/DatabaseLeaderLease.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orders.Core;
+using Orders.Infrastructure;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// Leader election over the Orders database (issue #160).
+///
+/// The database is used because it is the only thing every instance can see. An in-process lock
+/// such as the <c>SemaphoreSlim</c> in <see cref="MatchingEngineService"/> serialises a loop
+/// against itself and is invisible to a second process, which is precisely how the constraint
+/// this replaces could be broken without anyone noticing.
+///
+/// <para>
+/// Every claim is one statement whose conditions live in its WHERE clause. That is what makes it
+/// safe: reading "the lease is free" and then writing "the lease is mine" as two operations lets
+/// two instances both read free before either writes, which is the same race the plain SELECT in
+/// the outbox processor had.
+/// </para>
+///
+/// <para>
+/// Times come from <see cref="DateTime.UtcNow"/> on the application server, consistent with the
+/// rest of the outbox scheduling. Instances therefore have to agree roughly on the time; two
+/// hosts with clocks minutes apart would hand the same role to both.
+/// </para>
+///
+/// Registered as a singleton and opens its own scope per call, because the callers are singletons
+/// (a hosted service cannot depend on a scoped <c>DbContext</c>) — the same reason
+/// <see cref="MatchingEngineService"/> takes an <see cref="IServiceScopeFactory"/>.
+/// </summary>
+public class DatabaseLeaderLease : ILeaderLease
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly InstanceIdentity _identity;
+    private readonly ILogger<DatabaseLeaderLease> _logger;
+
+    public DatabaseLeaderLease(
+        IServiceScopeFactory scopeFactory,
+        InstanceIdentity identity,
+        ILogger<DatabaseLeaderLease> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _identity = identity;
+        _logger = logger;
+    }
+
+    public async Task<LeaderLeaseResult> TryAcquireOrRenewAsync(
+        string role, TimeSpan duration, CancellationToken ct = default)
+    {
+        var owner = _identity.Value;
+        var now = DateTime.UtcNow;
+        var expiresAt = now.Add(duration);
+
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
+
+        // 1. Renewal — the role is ours and has not run out. AcquiredAt is left alone so it keeps
+        //    recording when this instance first took over, which is what tells an operator whether
+        //    leadership is stable or flapping between two hosts.
+        var renewed = await db.ServiceLeases
+            .Where(l => l.Role == role && l.Owner == owner && l.ExpiresAt > now)
+            .ExecuteUpdateAsync(s => s.SetProperty(l => l.ExpiresAt, expiresAt), ct);
+
+        if (renewed > 0) return LeaderLeaseResult.Leader;
+
+        // 2. Takeover — nobody holds it any more. This also covers our own expired lease: an
+        //    instance that stalled past its expiry has genuinely lost the role and comes back
+        //    through the same door as everyone else.
+        var takenOver = await db.ServiceLeases
+            .Where(l => l.Role == role && l.ExpiresAt <= now)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(l => l.Owner, owner)
+                .SetProperty(l => l.AcquiredAt, now)
+                .SetProperty(l => l.ExpiresAt, expiresAt), ct);
+
+        if (takenOver > 0) return LeaderLeaseResult.Leader;
+
+        // 3. Neither: either somebody else holds a live lease, or this role has never been claimed
+        //    and has no row yet.
+        var current = await db.ServiceLeases.AsNoTracking()
+            .FirstOrDefaultAsync(l => l.Role == role, ct);
+
+        if (current is not null) return LeaderLeaseResult.FollowerOf(current.Owner);
+
+        return await TryCreateAsync(db, role, owner, expiresAt, ct);
+    }
+
+    /// <summary>
+    /// First claim of a role that has no row yet. Two instances starting together both reach here,
+    /// and the primary key on Role settles it: one insert succeeds, the other is refused. Losing
+    /// that race is a normal outcome, not a fault — it means the other instance is the leader.
+    /// </summary>
+    private async Task<LeaderLeaseResult> TryCreateAsync(
+        OrdersDbContext db, string role, string owner, DateTime expiresAt, CancellationToken ct)
+    {
+        try
+        {
+            db.ServiceLeases.Add(ServiceLease.CreateHeldBy(role, owner, expiresAt));
+            await db.SaveChangesAsync(ct);
+            return LeaderLeaseResult.Leader;
+        }
+        catch (DbUpdateException)
+        {
+            // Read back who won, so the caller can name them. A second failure here leaves the
+            // holder unknown, which only costs a less specific log line.
+            var winner = await db.ServiceLeases.AsNoTracking()
+                .FirstOrDefaultAsync(l => l.Role == role, ct);
+
+            return LeaderLeaseResult.FollowerOf(winner?.Owner);
+        }
+    }
+
+    public async Task ReleaseAsync(string role, CancellationToken ct = default)
+    {
+        try
+        {
+            var owner = _identity.Value;
+
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
+
+            // Expired rather than deleted: the row keeps saying who held the role last, and the
+            // Owner check means a shutting-down instance can never release a lease that has
+            // already been taken over by someone still running.
+            await db.ServiceLeases
+                .Where(l => l.Role == role && l.Owner == owner)
+                .ExecuteUpdateAsync(s => s.SetProperty(l => l.ExpiresAt, DateTime.UtcNow), ct);
+        }
+        catch (Exception ex)
+        {
+            // Swallowed by contract. The lease expires on its own; failing to hand it back early
+            // costs one lease period of nobody running the loop, and throwing here during
+            // shutdown would obscure whatever is actually stopping the host.
+            _logger.LogWarning(ex, "Could not release the {Role} lease on shutdown; it will expire instead.", role);
+        }
+    }
+}

--- a/src/Order/Orders.Application/Services/ILeaderLease.cs
+++ b/src/Order/Orders.Application/Services/ILeaderLease.cs
@@ -1,0 +1,45 @@
+namespace Orders.Application.Services;
+
+/// <summary>
+/// Decides which instance runs a background loop that must have exactly one writer (issue #160).
+///
+/// The contract is deliberately narrow: ask whether you may run, and say when you stop. Everything
+/// about how long a lease lasts and when it is renewed belongs to the caller, because the two
+/// loops using this run on very different clocks — the order-book sweep every second, quote
+/// publishing every two minutes.
+/// </summary>
+public interface ILeaderLease
+{
+    /// <summary>
+    /// Claims <paramref name="role"/> for this instance for <paramref name="duration"/>, or renews
+    /// a claim it already holds. Returns whether this instance may act.
+    ///
+    /// Both are one operation on purpose. A renewal and a takeover differ only in who held the
+    /// role a moment ago, and asking "am I still the leader?" separately from "may I become the
+    /// leader?" opens a window between the two questions in which the answer changes.
+    /// </summary>
+    Task<LeaderLeaseResult> TryAcquireOrRenewAsync(string role, TimeSpan duration, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gives up <paramref name="role"/> if this instance holds it, so the next instance can take
+    /// over at once instead of waiting out the lease. Called on graceful shutdown; a crash skips
+    /// it and the expiry does the same job more slowly.
+    ///
+    /// Never throws: it runs while the host is already stopping, where an exception would be
+    /// noise at best and would mask the real reason for the shutdown at worst.
+    /// </summary>
+    Task ReleaseAsync(string role, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The outcome of a claim. <paramref name="Holder"/> is filled in when the claim was refused and
+/// the current holder could be read — it is what turns "this instance is idle" in the log into
+/// "another instance is running this loop", which is the whole point of noticing a second
+/// deployment.
+/// </summary>
+public readonly record struct LeaderLeaseResult(bool IsLeader, string? Holder)
+{
+    public static LeaderLeaseResult Leader { get; } = new(true, null);
+
+    public static LeaderLeaseResult FollowerOf(string? holder) => new(false, holder);
+}

--- a/src/Order/Orders.Application/Services/LeaderGate.cs
+++ b/src/Order/Orders.Application/Services/LeaderGate.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.Logging;
+
+namespace Orders.Application.Services;
+
+/// <summary>
+/// One background loop's side of leader election (issue #160): holds the lease for a single role,
+/// paces the renewals, and reports the moment this instance gains or loses the role.
+///
+/// <para>
+/// It exists so the two loops that need this do not each grow their own copy of the same three
+/// decisions — how often to renew, what to believe between renewals, and what to say when the
+/// answer changes. The loops themselves just ask "may I run?" once per tick.
+/// </para>
+///
+/// <para>
+/// Renewal happens at half the lease, in both directions. A leader that renews with half its
+/// lease still to run cannot be overtaken by its own slowness; a follower that re-asks on the same
+/// clock takes over within about one and a half lease periods of a leader dying, without a
+/// database round trip on every tick of a loop that may run every second.
+/// </para>
+///
+/// Not thread-safe, and does not need to be: each instance belongs to one background loop, which
+/// asks from one place.
+/// </summary>
+public sealed class LeaderGate
+{
+    private readonly string _role;
+    private readonly TimeSpan _leaseDuration;
+    private readonly ILeaderLease _lease;
+    private readonly ILogger _logger;
+
+    private bool _isLeader;
+    private bool _hasReported;
+    private DateTime _nextCheckAt = DateTime.MinValue;
+
+    public LeaderGate(string role, TimeSpan leaseDuration, ILeaderLease lease, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            throw new ArgumentException("A lease role cannot be empty.", nameof(role));
+        if (leaseDuration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(leaseDuration), "A lease must last a positive amount of time.");
+
+        _role = role;
+        _leaseDuration = leaseDuration;
+        _lease = lease;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Whether this instance may run the loop for this tick.
+    ///
+    /// Never throws. The order-book sweep's error handling sits outside its <c>while</c> loop, so
+    /// an exception escaping here would not skip one tick — it would end background matching for
+    /// the lifetime of the process.
+    /// </summary>
+    public async Task<bool> TryLeadAsync(CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+
+        // Inside the half of the lease we already claimed, the answer cannot have changed.
+        if (now < _nextCheckAt) return _isLeader;
+
+        LeaderLeaseResult result;
+        try
+        {
+            result = await _lease.TryAcquireOrRenewAsync(_role, _leaseDuration, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // shutting down — the caller's loop is ending anyway
+        }
+        catch (Exception ex)
+        {
+            // The lease could not be confirmed, so this instance stands down until the next check.
+            // Standing down on an unconfirmed lease is the safe direction: acting on a lease we
+            // cannot verify is exactly the duplicate work the lease exists to prevent.
+            _logger.LogWarning(ex,
+                "Could not confirm the {Role} lease; this instance will not run that loop until the next check.", _role);
+
+            Report(isLeader: false, holder: null, unconfirmed: true);
+            _nextCheckAt = now.Add(_leaseDuration / 2);
+            return false;
+        }
+
+        Report(result.IsLeader, result.Holder, unconfirmed: false);
+
+        // Measured from before the call rather than after it, so a slow round trip shortens the
+        // gap to the next renewal instead of eating into the lease.
+        _nextCheckAt = now.Add(_leaseDuration / 2);
+        return result.IsLeader;
+    }
+
+    /// <summary>
+    /// Hands the role back on graceful shutdown so another instance can pick it up immediately.
+    /// Does nothing if this instance was not the leader.
+    /// </summary>
+    public async Task ReleaseAsync(CancellationToken ct = default)
+    {
+        if (!_isLeader) return;
+
+        await _lease.ReleaseAsync(_role, ct);
+        _isLeader = false;
+        _nextCheckAt = DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Logs only when the answer changes, plus once on the first decision. A follower re-checks
+    /// every half lease forever; saying so every time would bury the transition that matters.
+    ///
+    /// The follower line is deliberately a warning naming the other instance. Two copies of
+    /// Orders.Api against one database is a legitimate thing to do now, but it is almost never
+    /// intended on this deployment, and an operator scaling out for an unrelated reason needs to
+    /// meet that fact somewhere other than a code comment.
+    /// </summary>
+    private void Report(bool isLeader, string? holder, bool unconfirmed)
+    {
+        var changed = !_hasReported || isLeader != _isLeader;
+        _isLeader = isLeader;
+        _hasReported = true;
+
+        if (!changed || unconfirmed) return;
+
+        if (isLeader)
+        {
+            _logger.LogInformation("This instance is now running the {Role} loop.", _role);
+        }
+        else if (holder is null)
+        {
+            _logger.LogWarning(
+                "This instance is not running the {Role} loop: the lease is held elsewhere.", _role);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "This instance is NOT running the {Role} loop — instance {Holder} holds that lease. " +
+                "More than one Orders.Api is running against this database; each background loop runs on one of them.",
+                _role, holder);
+        }
+    }
+}

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -47,18 +47,34 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     // If peer-to-peer trading is ever opened, the rule has to be restated in terms of the new
     // model — probably "at least one side is an administrator" — rather than restored as it was.
 
+    /// <summary>
+    /// Decides whether this instance runs the background sweep (issue #160).
+    ///
+    /// Thirty seconds, renewed at the halfway mark, so a loop that ticks every second makes one
+    /// database round trip every fifteen rather than one per tick — and a host that dies still
+    /// hands the sweep over within about a minute.
+    /// </summary>
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromSeconds(30);
+
+    private readonly LeaderGate _leaderGate;
+
     public MatchingEngineService(
         IServiceScopeFactory scopeFactory,
         ILogger<MatchingEngineService> logger,
         IServiceProvider serviceProvider,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ILeaderLease leaderLease)
     {
         _scopeFactory = scopeFactory;
 
         _logger = logger;
         _serviceProvider = serviceProvider;
 
+        _leaderGate = new LeaderGate(ServiceLeaseRoles.MatchingEngine, LeaseDuration, leaderLease, logger);
     }
+
+    /// <summary>internal so a test can ask the gate directly, without driving the loop's timing.</summary>
+    internal Task<bool> TryLeadAsync(CancellationToken ct = default) => _leaderGate.TryLeadAsync(ct);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -69,6 +85,19 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         {
             while (!stoppingToken.IsCancellationRequested && _isRunning)
             {
+                // Only one instance sweeps the order book (issue #160). The semaphore below
+                // serialises this loop against itself within one process and is invisible to a
+                // second one; the lease is not.
+                //
+                // The sweep alone is gated. ProcessOrderAsync, which OrderService calls on the
+                // request path, stays available on every instance — gating that would mean an
+                // order placed against a follower was never matched at all.
+                if (!await _leaderGate.TryLeadAsync(stoppingToken))
+                {
+                    await Task.Delay(_processingInterval, stoppingToken);
+                    continue;
+                }
+
                 using var scope = _scopeFactory.CreateScope();
                 var _walletApiClient = scope.ServiceProvider.GetRequiredService<IWalletApiClient>();
 
@@ -102,6 +131,20 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
             _isRunning = false;
             _logger.LogInformation("🛑 Matching Engine Service has stopped");
         }
+    }
+
+    /// <summary>
+    /// Hands the sweep back on a graceful shutdown so another instance can take it over at once
+    /// rather than waiting out the lease (issue #160). A crash skips this, which is what the
+    /// lease expiry is for.
+    /// </summary>
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken);
+
+        // Not the caller's token: on a forced shutdown it is already cancelled, and the release is
+        // a single UPDATE worth finishing so the next instance does not sit idle for half a minute.
+        await _leaderGate.ReleaseAsync(CancellationToken.None);
     }
 
     /// <summary>

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -17,12 +17,15 @@ namespace Orders.Application.Services;
 /// idempotent (keyed on the trade id), redelivering a message that actually succeeded
 /// is harmless — the wallet reports "already settled".
 ///
-/// Assumes a single Orders.Api instance (MVP). For multi-instance, add a claim/lease
-/// column so two processors can't grab the same message.
+/// Safe to run on more than one instance (issue #160): each message is claimed with a lease
+/// before it is dispatched, so two processors cannot both take the same one. That idempotency
+/// remains the backstop, not the mechanism — it bounded the damage while nothing enforced the
+/// single-instance assumption this replaces.
 /// </summary>
 public class OutboxProcessorService : BackgroundService
 {
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly InstanceIdentity _identity;
     private readonly ILogger<OutboxProcessorService> _logger;
 
     private readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
@@ -30,9 +33,20 @@ public class OutboxProcessorService : BackgroundService
     private const int MaxRetries = 5;
     private static readonly TimeSpan BaseRetryDelay = TimeSpan.FromSeconds(10);
 
-    public OutboxProcessorService(IServiceScopeFactory scopeFactory, ILogger<OutboxProcessorService> logger)
+    /// <summary>
+    /// How long a claimed message stays claimed. Long enough that a slow wallet call cannot have
+    /// its message taken away mid-flight, short enough that a processor killed mid-message does
+    /// not strand a settlement for long. Dispatch is a single HTTP call measured in seconds.
+    /// </summary>
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(2);
+
+    public OutboxProcessorService(
+        IServiceScopeFactory scopeFactory,
+        InstanceIdentity identity,
+        ILogger<OutboxProcessorService> logger)
     {
         _scopeFactory = scopeFactory;
+        _identity = identity;
         _logger = logger;
     }
 
@@ -75,13 +89,7 @@ public class OutboxProcessorService : BackgroundService
         var db = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
         var walletClient = scope.ServiceProvider.GetRequiredService<IWalletApiClient>();
 
-        var now = DateTime.UtcNow;
-        var due = await db.OutboxMessages
-            .Where(m => m.Status == OutboxMessageStatus.Pending
-                        && (m.NextAttemptAt == null || m.NextAttemptAt <= now))
-            .OrderBy(m => m.CreatedAt)
-            .Take(BatchSize)
-            .ToListAsync(ct);
+        var due = await ClaimDueMessagesAsync(db, ct);
 
         if (due.Count == 0) return;
 
@@ -167,6 +175,63 @@ public class OutboxProcessorService : BackgroundService
                 db.Entry(message).State = EntityState.Detached;
             }
         }
+    }
+
+    /// <summary>
+    /// Takes ownership of the due messages and returns the ones this instance won (issue #160).
+    ///
+    /// <para>
+    /// The claim is the point of this method. It used to be a plain SELECT, which meant two
+    /// instances read the same rows and both dispatched them; the second settlement was refused by
+    /// the wallet's key on the trade id, so nothing was paid twice, but nothing prevented the
+    /// duplicate work either and nothing said the constraint existed.
+    /// </para>
+    ///
+    /// <para>
+    /// Selecting the candidates and claiming them are two statements, but only the second decides
+    /// anything: it repeats every condition from the first in its own WHERE clause, so a row that
+    /// another instance claimed in between simply is not updated. Reading first and trusting what
+    /// was read would reintroduce the race — both instances would see "unclaimed" before either
+    /// wrote. The rows are then re-read by owner, which is why the count from the claim is not
+    /// itself used as the batch.
+    /// </para>
+    ///
+    /// The claim runs before any message is tracked, because <c>ExecuteUpdateAsync</c> goes
+    /// straight to the database and would not be reflected in entities already loaded.
+    /// </summary>
+    private async Task<List<OutboxMessage>> ClaimDueMessagesAsync(OrdersDbContext db, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var leaseExpiresAt = now.Add(LeaseDuration);
+
+        var candidateIds = await db.OutboxMessages
+            .AsNoTracking()
+            .Where(m => m.Status == OutboxMessageStatus.Pending
+                        && (m.NextAttemptAt == null || m.NextAttemptAt <= now)
+                        && (m.LeaseExpiresAt == null || m.LeaseExpiresAt <= now))
+            .OrderBy(m => m.CreatedAt)
+            .Take(BatchSize)
+            .Select(m => m.Id)
+            .ToListAsync(ct);
+
+        if (candidateIds.Count == 0) return new List<OutboxMessage>();
+
+        var claimed = await db.OutboxMessages
+            .Where(m => candidateIds.Contains(m.Id)
+                        && m.Status == OutboxMessageStatus.Pending
+                        && (m.NextAttemptAt == null || m.NextAttemptAt <= now)
+                        && (m.LeaseExpiresAt == null || m.LeaseExpiresAt <= now))
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.LeasedBy, _identity.Value)
+                .SetProperty(m => m.LeaseExpiresAt, leaseExpiresAt), ct);
+
+        // Every candidate went to another instance. Normal under contention, not a problem.
+        if (claimed == 0) return new List<OutboxMessage>();
+
+        return await db.OutboxMessages
+            .Where(m => candidateIds.Contains(m.Id) && m.LeasedBy == _identity.Value)
+            .OrderBy(m => m.CreatedAt)
+            .ToListAsync(ct);
     }
 
     /// <summary>

--- a/src/Order/Orders.Core/OutboxMessage.cs
+++ b/src/Order/Orders.Core/OutboxMessage.cs
@@ -63,6 +63,25 @@ public class OutboxMessage
     /// <summary>When the message was abandoned. Null unless <see cref="Status"/> is <see cref="OutboxMessageStatus.Abandoned"/>.</summary>
     public DateTime? AbandonedAt { get; private set; }
 
+    /// <summary>
+    /// The instance currently processing this message, or null if none holds it (issue #160).
+    ///
+    /// Written by the atomic claim in the processor, not by any method here: the claim has to be
+    /// a single UPDATE with its conditions in the WHERE clause, or two instances both read "free"
+    /// before either writes. Cleared here once the attempt finishes.
+    /// </summary>
+    public string? LeasedBy { get; private set; }
+
+    /// <summary>
+    /// When the claim on this message stops being honoured. Null if it is not claimed.
+    ///
+    /// The expiry is what makes this a lease rather than a lock. A processor that crashes
+    /// mid-message leaves the claim behind; without an expiry the message would stay claimed
+    /// forever, which for a settlement means a recorded trade nobody ever pays out and collateral
+    /// locked with it. With one, the row simply becomes claimable again.
+    /// </summary>
+    public DateTime? LeaseExpiresAt { get; private set; }
+
     // EF Core
     private OutboxMessage() { }
 
@@ -95,6 +114,7 @@ public class OutboxMessage
         ProcessedAt = DateTime.UtcNow;
         NextAttemptAt = null;
         LastError = null;
+        ClearLease();
     }
 
     /// <summary>
@@ -117,6 +137,11 @@ public class OutboxMessage
             var delayTicks = baseDelay.Ticks * (long)Math.Pow(2, RetryCount - 1);
             NextAttemptAt = DateTime.UtcNow.Add(TimeSpan.FromTicks(delayTicks));
         }
+
+        // Released even though the attempt failed: the backoff in NextAttemptAt already decides
+        // when this message may run again, and holding the lease on top of it would only delay
+        // the retry by however much of the lease was left.
+        ClearLease();
     }
 
     /// <summary>
@@ -141,6 +166,10 @@ public class OutboxMessage
         RetryCount = 0;
         NextAttemptAt = DateTime.UtcNow;
         ProcessedAt = null;
+
+        // A message that failed while an instance held it can keep a stale claim. An operator
+        // re-driving it means "run this now", so the claim goes with the rest of the old attempt.
+        ClearLease();
     }
 
     /// <summary>
@@ -167,5 +196,19 @@ public class OutboxMessage
         AbandonReason = reason;
         AbandonedAt = DateTime.UtcNow;
         NextAttemptAt = null;
+        ClearLease();
+    }
+
+    /// <summary>
+    /// Gives up this instance's claim on the message (issue #160).
+    ///
+    /// Private because releasing is only ever the tail of finishing an attempt — completing it,
+    /// failing it, re-driving it or abandoning it. A caller able to release a claim on its own
+    /// could hand a message another instance is still working on to a second processor.
+    /// </summary>
+    private void ClearLease()
+    {
+        LeasedBy = null;
+        LeaseExpiresAt = null;
     }
 }

--- a/src/Order/Orders.Core/ServiceLease.cs
+++ b/src/Order/Orders.Core/ServiceLease.cs
@@ -1,0 +1,68 @@
+namespace Orders.Core;
+
+/// <summary>
+/// A named, time-limited claim on work only one instance may perform at a time (issue #160).
+///
+/// The outbox can be coordinated per row, because each unit of work is a row an instance can put
+/// its name on. The background loops cannot: <c>MatchingEngineService</c> sweeps the whole order
+/// book on a timer and <c>AutoQuotePublisherService</c> publishes on a timer, and neither has a
+/// queue row to claim. What they share is that only one instance should be running the loop, so
+/// what gets claimed is the role itself — one row per role, held for a while, renewed while the
+/// holder is alive.
+///
+/// The expiry does the same job as it does on an outbox message: an instance that dies holding
+/// the role does not take the role down with it. The gap between the holder dying and the lease
+/// expiring is a gap in which nobody sweeps or publishes, which is why the holder also releases
+/// the lease on a graceful shutdown instead of leaving it to time out.
+/// </summary>
+public class ServiceLease
+{
+    /// <summary>Names the work being claimed — see <see cref="ServiceLeaseRoles"/>. The key: one row per role.</summary>
+    public string Role { get; private set; } = "";
+
+    /// <summary>The <c>InstanceIdentity</c> of the holder.</summary>
+    public string Owner { get; private set; } = "";
+
+    /// <summary>When the current holder first took the role, kept for diagnosing flapping.</summary>
+    public DateTime AcquiredAt { get; private set; }
+
+    /// <summary>When the claim stops being honoured and another instance may take the role.</summary>
+    public DateTime ExpiresAt { get; private set; }
+
+    // EF Core
+    private ServiceLease() { }
+
+    /// <summary>
+    /// Creates the row for a role nobody has ever held. Only used on the insert path — from then
+    /// on the row exists and is taken over by UPDATE, never re-created.
+    /// </summary>
+    public static ServiceLease CreateHeldBy(string role, string owner, DateTime expiresAt)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            throw new ArgumentException("A lease role cannot be empty.", nameof(role));
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("A lease owner cannot be empty.", nameof(owner));
+
+        return new ServiceLease
+        {
+            Role = role,
+            Owner = owner,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = expiresAt
+        };
+    }
+}
+
+/// <summary>
+/// The roles that are coordinated. Constants rather than free strings so a typo in one service
+/// cannot silently give it a role of its own that nothing else contends for — which would look
+/// exactly like working correctly right up until two instances ran.
+/// </summary>
+public static class ServiceLeaseRoles
+{
+    /// <summary>The background order-book sweep. Does not cover request-path matching.</summary>
+    public const string MatchingEngine = "MatchingEngine";
+
+    /// <summary>The automatic quote publishing tick.</summary>
+    public const string AutoQuotePublisher = "AutoQuotePublisher";
+}

--- a/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/OutboxMessageConfiguration.cs
@@ -23,9 +23,13 @@ public class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage
         builder.Property(m => m.LastError).HasMaxLength(2000);
         builder.Property(m => m.AbandonReason).HasMaxLength(2000);
         builder.Property(m => m.AbandonedAt);
+        builder.Property(m => m.LeasedBy).HasMaxLength(100);
+        builder.Property(m => m.LeaseExpiresAt);
 
-        // Hot-path query for the background processor: pending messages that are due.
-        builder.HasIndex(m => new { m.Status, m.NextAttemptAt });
+        // Hot-path query for the background processor: pending messages that are due and not
+        // already claimed by another instance. LeaseExpiresAt joined the index when the claim
+        // joined the query (issue #160) — the processor filters on all three every cycle.
+        builder.HasIndex(m => new { m.Status, m.NextAttemptAt, m.LeaseExpiresAt });
 
         // Idempotency guard: at most one outbox row per aggregate per message type,
         // so a retried match cannot enqueue the same settlement twice.

--- a/src/Order/Orders.Infrastructure/Configurations/ServiceLeaseConfiguration.cs
+++ b/src/Order/Orders.Infrastructure/Configurations/ServiceLeaseConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Orders.Core;
+
+namespace Orders.Infrastructure.Configurations;
+
+public class ServiceLeaseConfiguration : IEntityTypeConfiguration<ServiceLease>
+{
+    public void Configure(EntityTypeBuilder<ServiceLease> builder)
+    {
+        builder.ToTable("ServiceLeases");
+
+        // The role is the key, which is what makes the whole mechanism work: the database refuses
+        // a second row for the same role, so two instances racing to create a lease nobody holds
+        // yet cannot both succeed. The loser sees a unique-key violation and reads it as "someone
+        // else got there first" rather than as an error.
+        builder.HasKey(l => l.Role);
+        builder.Property(l => l.Role).HasMaxLength(100);
+
+        builder.Property(l => l.Owner).IsRequired().HasMaxLength(100);
+        builder.Property(l => l.AcquiredAt).IsRequired();
+        builder.Property(l => l.ExpiresAt).IsRequired();
+    }
+}

--- a/src/Order/Orders.Infrastructure/Migrations/20260831145858_AddInstanceCoordinationLeases.Designer.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260831145858_AddInstanceCoordinationLeases.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Orders.Infrastructure;
 
@@ -11,9 +12,11 @@ using Orders.Infrastructure;
 namespace Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831145858_AddInstanceCoordinationLeases")]
+    partial class AddInstanceCoordinationLeases
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Order/Orders.Infrastructure/Migrations/20260831145858_AddInstanceCoordinationLeases.cs
+++ b/src/Order/Orders.Infrastructure/Migrations/20260831145858_AddInstanceCoordinationLeases.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Orders.Infrastructure.Migrations
+{
+    /// <summary>
+    /// Everything the background services need to run on more than one instance (issue #160).
+    ///
+    /// Two changes, shipped together because they are one mechanism: a per-row claim on outbox
+    /// messages, so two processors cannot dispatch the same settlement, and a ServiceLeases table
+    /// naming which instance runs each background loop that must have a single writer.
+    ///
+    /// Both columns are nullable and the table starts empty, so this applies to a running database
+    /// with nothing to backfill: an unclaimed message is one with no lease, which is exactly what
+    /// every existing row becomes.
+    ///
+    /// The outbox index gains LeaseExpiresAt because the processor's hot-path query now filters on
+    /// it alongside Status and NextAttemptAt.
+    /// </summary>
+    public partial class AddInstanceCoordinationLeases : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_Status_NextAttemptAt",
+                table: "OutboxMessages");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LeaseExpiresAt",
+                table: "OutboxMessages",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LeasedBy",
+                table: "OutboxMessages",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ServiceLeases",
+                columns: table => new
+                {
+                    Role = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Owner = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    AcquiredAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceLeases", x => x.Role);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Status_NextAttemptAt_LeaseExpiresAt",
+                table: "OutboxMessages",
+                columns: new[] { "Status", "NextAttemptAt", "LeaseExpiresAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServiceLeases");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_Status_NextAttemptAt_LeaseExpiresAt",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "LeaseExpiresAt",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropColumn(
+                name: "LeasedBy",
+                table: "OutboxMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_Status_NextAttemptAt",
+                table: "OutboxMessages",
+                columns: new[] { "Status", "NextAttemptAt" });
+        }
+    }
+}

--- a/src/Order/Orders.Infrastructure/OrdersDbContext.cs
+++ b/src/Order/Orders.Infrastructure/OrdersDbContext.cs
@@ -24,6 +24,9 @@ public class OrdersDbContext : DbContext
     /// <summary>Whether each symbol is enabled for trading — changeable by an admin bot command.</summary>
     public DbSet<SymbolSettings> SymbolSettings => Set<SymbolSettings>();
 
+    /// <summary>Which instance is currently running each single-writer background loop (issue #160).</summary>
+    public DbSet<ServiceLease> ServiceLeases => Set<ServiceLease>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new OrderConfigurations());
@@ -33,5 +36,6 @@ public class OrdersDbContext : DbContext
         modelBuilder.ApplyConfiguration(new AutoQuoteSettingsConfiguration());
         modelBuilder.ApplyConfiguration(new PendingQuoteConfiguration());
         modelBuilder.ApplyConfiguration(new SymbolSettingsConfiguration());
+        modelBuilder.ApplyConfiguration(new ServiceLeaseConfiguration());
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
@@ -72,8 +72,10 @@ public class AutoQuotePublisherServiceTests : IDisposable
             Task.FromResult(Price);
     }
 
+    // These tests drive PublishIfDueAsync directly, so the leader gate never runs; the lease is
+    // stubbed to "yes" purely to satisfy the constructor.
     private AutoQuotePublisherService NewService() => new(
-        _provider.GetRequiredService<IServiceScopeFactory>(), _logger);
+        _provider.GetRequiredService<IServiceScopeFactory>(), _logger, new AlwaysLeaderLease());
 
     private AutoQuotePublisherService? _service;
 

--- a/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
@@ -1,0 +1,280 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.AllServices.Tests.Fakes;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// How the two timer-driven background services use leader election (issue #160), and — the part
+/// that is easy to get wrong — what it must NOT gate.
+///
+/// The gate is asked through each service's <c>TryLeadAsync</c> rather than by starting the loops
+/// and waiting, for the same reason <c>PublishIfDueAsync</c> is internal: a test that depends on a
+/// one-second timer proves less and fails at random.
+/// </summary>
+public class BackgroundLeaderGateTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+    private const decimal Price = 16_967_542.36m;
+    private const decimal Quantity = 2m;
+
+    public BackgroundLeaderGateTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using var setup = NewContext();
+        setup.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private OrdersDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+    // ── The matching engine's background sweep ──────────────────────────────────
+
+    [Fact]
+    public async Task TheMatchingSweep_RunsWhenThisInstanceHoldsTheLease()
+    {
+        using var provider = BuildMatchingProvider(new AlwaysLeaderLease());
+        var engine = provider.GetRequiredService<MatchingEngineService>();
+
+        Assert.True(await engine.TryLeadAsync());
+    }
+
+    [Fact]
+    public async Task TheMatchingSweep_StandsDownWhenAnotherInstanceHoldsTheLease()
+    {
+        using var provider = BuildMatchingProvider(new HeldElsewhereLease());
+        var engine = provider.GetRequiredService<MatchingEngineService>();
+
+        Assert.False(await engine.TryLeadAsync());
+    }
+
+    /// <summary>
+    /// The one thing the gate must never touch. <c>OrderService</c> calls the engine on the
+    /// request path, so gating that would mean an order placed against a follower instance was
+    /// never matched at all — trading would silently half-work on every instance but one.
+    ///
+    /// <para>
+    /// Asserted by whether the order book is consulted, not by whether a trade appears, for the
+    /// reason <see cref="DealerModeSkipsBackgroundMatchingTests"/> already records: the order-book
+    /// query orders by <c>Price</c>, and SQLite rejects a decimal in ORDER BY. Production runs on
+    /// SQL Server. "The engine reached the order book" is the part the gate decides anyway.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task OnAFollowerInstance_TheRequestPathStillReachesTheOrderBook()
+    {
+        var log = new CapturingLoggerProvider();
+        using var provider = BuildMatchingProvider(new HeldElsewhereLease(), log);
+        var engine = provider.GetRequiredService<MatchingEngineService>();
+
+        var (buyId, _) = SeedMatchablePair();
+
+        Assert.False(await engine.TryLeadAsync()); // this instance does not run the sweep
+
+        // The overload OrderService calls when an order is placed.
+        await engine.ProcessOrderAsync(buyId);
+
+        Assert.Contains(log.Messages, m => m.Contains("sell orders for asset"));
+    }
+
+    // ── The auto-quote publisher ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheQuotePublisher_PublishesWhenThisInstanceHoldsTheLease()
+    {
+        using var provider = BuildPublisherProvider();
+        var publisher = new AutoQuotePublisherService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<AutoQuotePublisherService>.Instance,
+            new AlwaysLeaderLease());
+
+        Assert.True(await publisher.TryLeadAsync());
+    }
+
+    [Fact]
+    public async Task TheQuotePublisher_StandsDownWhenAnotherInstanceHoldsTheLease()
+    {
+        using var provider = BuildPublisherProvider();
+        var publisher = new AutoQuotePublisherService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<AutoQuotePublisherService>.Instance,
+            new HeldElsewhereLease());
+
+        Assert.False(await publisher.TryLeadAsync());
+    }
+
+    // ── Noticing the second instance ────────────────────────────────────────────
+
+    /// <summary>
+    /// The acceptance criterion of the issue: it must be impossible to deploy a second instance
+    /// without noticing. The warning naming the other instance is how that happens, so it is
+    /// asserted rather than left as a hopeful log line.
+    /// </summary>
+    [Fact]
+    public async Task AFollower_WarnsOnceAndNamesTheInstanceHoldingTheLease()
+    {
+        var logger = new CapturingLogger<BackgroundLeaderGateTests>();
+        var gate = new LeaderGate(
+            ServiceLeaseRoles.MatchingEngine,
+            TimeSpan.FromSeconds(30),
+            new HeldElsewhereLease("the-other-host"),
+            logger);
+
+        Assert.False(await gate.TryLeadAsync());
+
+        var warning = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains("the-other-host", warning.Message);
+    }
+
+    /// <summary>
+    /// A follower re-checks for as long as it runs. Saying so every time would bury the transition
+    /// that matters under a line every few seconds, so only changes are reported.
+    /// </summary>
+    [Fact]
+    public async Task AFollowerThatKeepsChecking_DoesNotRepeatTheWarning()
+    {
+        var logger = new CapturingLogger<BackgroundLeaderGateTests>();
+
+        // A lease of zero would be rejected, so the shortest usable one is used and the gate is
+        // asked twice with the renewal interval already elapsed.
+        var gate = new LeaderGate(
+            ServiceLeaseRoles.MatchingEngine,
+            TimeSpan.FromTicks(1),
+            new HeldElsewhereLease("the-other-host"),
+            logger);
+
+        Assert.False(await gate.TryLeadAsync());
+        Assert.False(await gate.TryLeadAsync());
+        Assert.False(await gate.TryLeadAsync());
+
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// A lease that cannot be reached leaves this instance standing down rather than acting on a
+    /// claim it could not confirm — and, critically, does not throw. The sweep's error handling
+    /// sits outside its while loop, so an exception here would end background matching for the
+    /// life of the process rather than skipping one tick.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheLeaseCannotBeReached_TheGateStandsDownWithoutThrowing()
+    {
+        var logger = new CapturingLogger<BackgroundLeaderGateTests>();
+        var gate = new LeaderGate(
+            ServiceLeaseRoles.MatchingEngine,
+            TimeSpan.FromSeconds(30),
+            new ThrowingLease(),
+            logger);
+
+        Assert.False(await gate.TryLeadAsync());
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Exception is not null);
+    }
+
+    private sealed class ThrowingLease : ILeaderLease
+    {
+        public Task<LeaderLeaseResult> TryAcquireOrRenewAsync(string role, TimeSpan duration, CancellationToken ct = default) =>
+            throw new InvalidOperationException("database unreachable");
+
+        public Task ReleaseAsync(string role, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    // ── Wiring ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Goes through the production <c>AddMatchingEngine</c>, with the lease swapped for a double
+    /// so the test decides whether this instance leads.
+    /// </summary>
+    private ServiceProvider BuildMatchingProvider(ILeaderLease lease, ILoggerProvider? log = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+
+        if (log is null)
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        else
+            services.AddLogging(b => b.AddProvider(log));
+
+        services.AddScoped(_ => NewContext());
+        services.AddScoped<OrderMatchingRepository>();
+        services.AddScoped<IOrderRepository, OrderRepository>();
+        services.AddScoped<MarketModeProvider>();
+        services.AddScoped<IWalletApiClient, StubWalletApiClient>();
+        services.AddSingleton(lease);
+        services.AddMatchingEngine();
+
+        return services.BuildServiceProvider();
+    }
+
+    private ServiceProvider BuildPublisherProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped(_ => NewContext());
+
+        return services.BuildServiceProvider();
+    }
+
+    private (Guid BuyId, Guid SellId) SeedMatchablePair()
+    {
+        using var db = NewContext();
+
+        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Buy, TradingType.Spot);
+        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Sell, TradingType.Spot);
+        buy.Confirm();
+        sell.Confirm();
+
+        db.Orders.AddRange(buy, sell);
+        db.SaveChanges();
+
+        return (buy.Id, sell.Id);
+    }
+
+    /// <summary>
+    /// Collects log messages so a test can tell whether the engine reached the order book. A
+    /// private copy rather than a shared one, because the only other user is a test that owns its
+    /// own and changing that file is not part of this issue.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new Sink(Messages);
+
+        public void Dispose() { }
+
+        private sealed class Sink(List<string> messages) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                lock (messages) messages.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
@@ -81,6 +81,10 @@ public class DealerModeSkipsBackgroundMatchingTests : IDisposable
         services.AddScoped<IOrderRepository, OrderRepository>();
         services.AddScoped<MarketModeProvider>();
         services.AddScoped<IWalletApiClient, StubWalletApiClient>();
+
+        // The engine takes a lease to decide whether it runs the background sweep (issue #160).
+        // These tests call ProcessAllPendingOrdersAsync directly, so the gate is never consulted.
+        services.AddInstanceCoordination();
         services.AddMatchingEngine();
 
         return services.BuildServiceProvider();

--- a/tests/TallaEgg.AllServices.Tests/Fakes/LeaderLeaseDoubles.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/LeaderLeaseDoubles.cs
@@ -1,0 +1,31 @@
+using Orders.Application.Services;
+
+namespace TallaEgg.AllServices.Tests.Fakes;
+
+/// <summary>
+/// Grants the role to whoever asks. For tests that are about something other than leader
+/// election and only need the background service to consider itself in charge (issue #160).
+/// </summary>
+public sealed class AlwaysLeaderLease : ILeaderLease
+{
+    public Task<LeaderLeaseResult> TryAcquireOrRenewAsync(string role, TimeSpan duration, CancellationToken ct = default) =>
+        Task.FromResult(LeaderLeaseResult.Leader);
+
+    public Task ReleaseAsync(string role, CancellationToken ct = default) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Refuses the role and names someone else as the holder — a second instance, from the point of
+/// view of the one under test.
+/// </summary>
+public sealed class HeldElsewhereLease : ILeaderLease
+{
+    public HeldElsewhereLease(string holder = "another-instance") => Holder = holder;
+
+    public string Holder { get; }
+
+    public Task<LeaderLeaseResult> TryAcquireOrRenewAsync(string role, TimeSpan duration, CancellationToken ct = default) =>
+        Task.FromResult(LeaderLeaseResult.FollowerOf(Holder));
+
+    public Task ReleaseAsync(string role, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/tests/TallaEgg.AllServices.Tests/LeaderLeaseTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/LeaderLeaseTests.cs
@@ -1,0 +1,183 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Leader election for the background loops that must have exactly one writer (issue #160).
+///
+/// The outbox can be coordinated per message, because each unit of work is a row. The order-book
+/// sweep and the quote publisher cannot: both are timers with nothing to claim, so what they claim
+/// is the role. Two instances publishing quotes on the same tick would write two quote rows per
+/// symbol and, when a price falls outside the plausibility band, put the same approval request in
+/// front of the admin twice.
+///
+/// The real <see cref="DatabaseLeaderLease"/> is exercised against SQLite here rather than a
+/// double, because the whole mechanism is the atomicity of its statements — a stub would prove
+/// nothing about it.
+/// </summary>
+public class LeaderLeaseTests : IDisposable
+{
+    private const string Role = ServiceLeaseRoles.MatchingEngine;
+    private static readonly TimeSpan Lease = TimeSpan.FromSeconds(30);
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+
+    public LeaderLeaseTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var setup = new OrdersDbContext(Options()))
+            setup.Database.EnsureCreated();
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => new OrdersDbContext(Options()));
+        _provider = services.BuildServiceProvider();
+    }
+
+    private DbContextOptions<OrdersDbContext> Options() =>
+        new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    private DatabaseLeaderLease LeaseFor(string instance) => new(
+        _provider.GetRequiredService<IServiceScopeFactory>(),
+        new InstanceIdentity(instance),
+        NullLogger<DatabaseLeaderLease>.Instance);
+
+    /// <summary>
+    /// The first claim of a role that has never been held. Both instances reach the insert, and
+    /// the primary key on Role decides it — losing is a normal answer, not an error.
+    /// </summary>
+    [Fact]
+    public async Task WhenTwoInstancesClaimAnUnheldRole_OnlyOneBecomesLeader()
+    {
+        var a = await LeaseFor("instance-a").TryAcquireOrRenewAsync(Role, Lease);
+        var b = await LeaseFor("instance-b").TryAcquireOrRenewAsync(Role, Lease);
+
+        Assert.True(a.IsLeader);
+        Assert.False(b.IsLeader);
+    }
+
+    /// <summary>
+    /// The follower is told who holds the role. That name is what turns "this instance is idle"
+    /// in the log into "a second Orders.Api is running", which is the point of the whole issue:
+    /// deploying a second instance must not be silent.
+    /// </summary>
+    [Fact]
+    public async Task AFollower_IsToldWhichInstanceHoldsTheRole()
+    {
+        await LeaseFor("instance-a").TryAcquireOrRenewAsync(Role, Lease);
+
+        var b = await LeaseFor("instance-b").TryAcquireOrRenewAsync(Role, Lease);
+
+        Assert.False(b.IsLeader);
+        Assert.Equal("instance-a", b.Holder);
+    }
+
+    /// <summary>The holder keeps the role by asking again; renewing is not a takeover.</summary>
+    [Fact]
+    public async Task TheHolder_KeepsTheRoleOnRenewal()
+    {
+        var lease = LeaseFor("instance-a");
+
+        Assert.True((await lease.TryAcquireOrRenewAsync(Role, Lease)).IsLeader);
+        Assert.True((await lease.TryAcquireOrRenewAsync(Role, Lease)).IsLeader);
+
+        // AcquiredAt still records the original takeover, so a flapping leader is visible.
+        var row = await SingleLeaseAsync();
+        Assert.Equal("instance-a", row.Owner);
+        Assert.True(row.ExpiresAt > row.AcquiredAt);
+    }
+
+    /// <summary>
+    /// An instance that dies holding the role must not take the loop down with it. Nothing runs
+    /// the sweep until the lease runs out, and then someone does.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheHoldersLeaseExpires_AnotherInstanceTakesOver()
+    {
+        await LeaseFor("instance-a").TryAcquireOrRenewAsync(Role, Lease);
+        ExpireTheLease();
+
+        var b = await LeaseFor("instance-b").TryAcquireOrRenewAsync(Role, Lease);
+
+        Assert.True(b.IsLeader);
+        Assert.Equal("instance-b", (await SingleLeaseAsync()).Owner);
+    }
+
+    /// <summary>
+    /// A graceful shutdown hands the role back rather than leaving the next instance to wait out
+    /// the lease — half a minute of nobody sweeping the order book, for no reason.
+    /// </summary>
+    [Fact]
+    public async Task AfterTheHolderReleases_AnotherInstanceTakesOverImmediately()
+    {
+        var a = LeaseFor("instance-a");
+        await a.TryAcquireOrRenewAsync(Role, Lease);
+
+        await a.ReleaseAsync(Role);
+
+        Assert.True((await LeaseFor("instance-b").TryAcquireOrRenewAsync(Role, Lease)).IsLeader);
+    }
+
+    /// <summary>
+    /// Releasing only affects a role this instance still holds. A slow shutdown must not hand away
+    /// a lease that has already expired and been taken over by an instance that is running.
+    /// </summary>
+    [Fact]
+    public async Task ReleasingARoleTakenOverByAnotherInstance_DoesNothing()
+    {
+        var a = LeaseFor("instance-a");
+        await a.TryAcquireOrRenewAsync(Role, Lease);
+
+        ExpireTheLease();
+        await LeaseFor("instance-b").TryAcquireOrRenewAsync(Role, Lease);
+
+        await a.ReleaseAsync(Role);
+
+        // B still holds a live lease, so a third instance cannot step in.
+        var c = await LeaseFor("instance-c").TryAcquireOrRenewAsync(Role, Lease);
+        Assert.False(c.IsLeader);
+        Assert.Equal("instance-b", c.Holder);
+    }
+
+    /// <summary>Roles are independent: holding one says nothing about the other.</summary>
+    [Fact]
+    public async Task DifferentRoles_AreHeldSeparately()
+    {
+        await LeaseFor("instance-a").TryAcquireOrRenewAsync(ServiceLeaseRoles.MatchingEngine, Lease);
+
+        var b = await LeaseFor("instance-b")
+            .TryAcquireOrRenewAsync(ServiceLeaseRoles.AutoQuotePublisher, Lease);
+
+        Assert.True(b.IsLeader);
+    }
+
+    private async Task<ServiceLease> SingleLeaseAsync()
+    {
+        using var db = new OrdersDbContext(Options());
+        return await db.ServiceLeases.AsNoTracking().SingleAsync(l => l.Role == Role);
+    }
+
+    /// <summary>Ages the lease out, standing in for an instance that stopped renewing it.</summary>
+    private void ExpireTheLease()
+    {
+        using var db = new OrdersDbContext(Options());
+        db.ServiceLeases
+            .Where(l => l.Role == Role)
+            .ExecuteUpdate(s => s.SetProperty(l => l.ExpiresAt, DateTime.UtcNow.AddSeconds(-1)));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/MatchingEngineRegistrationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/MatchingEngineRegistrationTests.cs
@@ -36,6 +36,8 @@ public class MatchingEngineRegistrationTests
             new ConfigurationBuilder().AddInMemoryCollection().Build());
         services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
 
+        // The engine takes a lease to decide whether it runs the background sweep (issue #160).
+        services.AddInstanceCoordination();
         services.AddMatchingEngine();
 
         return services.BuildServiceProvider();

--- a/tests/TallaEgg.AllServices.Tests/OutboxBatchResilienceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxBatchResilienceTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
 using Orders.Application.Services;
 using Orders.Core;
 using Orders.Infrastructure;
@@ -105,6 +106,7 @@ public class OutboxBatchResilienceTests : IDisposable
 
         var processor = new OutboxProcessorService(
             _provider.GetRequiredService<IServiceScopeFactory>(),
+            new InstanceIdentity("batch-resilience-tests"),
             NullLogger<OutboxProcessorService>.Instance);
 
         // Must not throw — the loop absorbs the persistence failure.

--- a/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
 using Orders.Application.Services;
 using Orders.Core;
 using Orders.Infrastructure;
@@ -96,6 +97,7 @@ public class OutboxDueSelectionTests : IDisposable
     {
         var processor = new OutboxProcessorService(
             _provider.GetRequiredService<IServiceScopeFactory>(),
+            new InstanceIdentity("due-selection-tests"),
             NullLogger<OutboxProcessorService>.Instance);
 
         await processor.ProcessDueMessagesAsync(CancellationToken.None);

--- a/tests/TallaEgg.AllServices.Tests/OutboxLeaseTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxLeaseTests.cs
@@ -1,0 +1,265 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.AllServices.Tests.Fakes;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Two instances of the outbox processor must not dispatch the same message (issue #160).
+///
+/// The processor used to select due messages with a plain query and start work on whatever came
+/// back, so two instances read the same rows and both called the wallet. Nothing was paid twice —
+/// <c>TradeSettlement</c> is keyed on the trade id and the second settlement was refused — but the
+/// duplicate work was invisible, and the "single instance only" rule that made it acceptable lived
+/// in a code comment.
+///
+/// These tests drive two processors with different identities against one database, which is what
+/// two hosts sharing a database look like from the outbox's point of view.
+/// </summary>
+public class OutboxLeaseTests : IDisposable
+{
+    private const int MaxRetries = 5;
+    private static readonly TimeSpan BaseDelay = TimeSpan.FromSeconds(10);
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+    private readonly CountingWalletClient _wallet = new();
+
+    public OutboxLeaseTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var setup = new OrdersDbContext(Options()))
+            setup.Database.EnsureCreated();
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => new OrdersDbContext(Options()));
+        services.AddScoped<IWalletApiClient>(_ => _wallet);
+        _provider = services.BuildServiceProvider();
+    }
+
+    private DbContextOptions<OrdersDbContext> Options() =>
+        new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    /// <summary>
+    /// Counts settlement calls and can be told to block, so a second processor can be run while
+    /// the first is still mid-dispatch — which is the only moment the lease has to hold.
+    /// </summary>
+    private sealed class CountingWalletClient : StubWalletApiClient
+    {
+        private readonly List<Guid> _settled = new();
+
+        public IReadOnlyList<Guid> SettledTradeIds
+        {
+            get { lock (_settled) return _settled.ToList(); }
+        }
+
+        /// <summary>Set to have the client fail, so the failure path can be checked.</summary>
+        public bool Reject { get; set; }
+
+        /// <summary>Runs while the wallet call is in flight. Used to act as a second instance mid-dispatch.</summary>
+        public Func<Task>? WhileDispatching { get; set; }
+
+        public override async Task<(bool Success, string Message)> TradeTransactionAndBalanceChangeAsync(TradeDto trade)
+        {
+            lock (_settled) _settled.Add(trade.Id);
+
+            if (WhileDispatching is not null)
+                await WhileDispatching();
+
+            return Reject ? (false, "rejected") : (true, "settled");
+        }
+    }
+
+    private OutboxProcessorService ProcessorFor(string instance) => new(
+        _provider.GetRequiredService<IServiceScopeFactory>(),
+        new InstanceIdentity(instance),
+        NullLogger<OutboxProcessorService>.Instance);
+
+    private static string PayloadFor(Guid tradeId) =>
+        System.Text.Json.JsonSerializer.Serialize(new TradeDto
+        {
+            Id = tradeId,
+            BuyerUserId = Guid.NewGuid(),
+            SellerUserId = Guid.NewGuid(),
+            Symbol = "MAUA/IRT",
+            Quantity = 10m,
+            QuoteQuantity = 184_680_733m
+        });
+
+    private (Guid MessageId, Guid TradeId) Seed(Action<OutboxMessage>? arrange = null)
+    {
+        using var db = new OrdersDbContext(Options());
+        var tradeId = Guid.NewGuid();
+        var message = OutboxMessage.Create("TradeSettlement", tradeId, PayloadFor(tradeId));
+        arrange?.Invoke(message);
+        db.OutboxMessages.Add(message);
+        db.SaveChanges();
+        return (message.Id, tradeId);
+    }
+
+    private async Task<OutboxMessage> ReloadAsync(Guid messageId)
+    {
+        using var db = new OrdersDbContext(Options());
+        return await db.OutboxMessages.AsNoTracking().SingleAsync(m => m.Id == messageId);
+    }
+
+    /// <summary>
+    /// The claim is what this whole change is for. While one instance is mid-dispatch, a second
+    /// one runs a full cycle over the same database and must find nothing to do.
+    ///
+    /// Running the second processor from inside the wallet call is deliberate: at that moment the
+    /// message is claimed but not yet completed, which is the only window in which the old code
+    /// could hand the same settlement to both.
+    /// </summary>
+    [Fact]
+    public async Task WhileOneInstanceIsDispatching_ASecondInstanceSettlesNothing()
+    {
+        var (messageId, tradeId) = Seed();
+
+        var second = ProcessorFor("instance-b");
+
+        // Fires once. Without the claim the second processor dispatches the same message, which
+        // would re-enter this hook and recurse until the test host died — a crash that takes the
+        // whole run's results with it. Firing once turns that regression into a failed assertion
+        // on the settlement count.
+        var secondHasRun = false;
+        _wallet.WhileDispatching = async () =>
+        {
+            if (secondHasRun) return;
+            secondHasRun = true;
+
+            await second.ProcessDueMessagesAsync(CancellationToken.None);
+        };
+
+        await ProcessorFor("instance-a").ProcessDueMessagesAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { tradeId }, _wallet.SettledTradeIds);
+        Assert.Equal(OutboxMessageStatus.Completed, (await ReloadAsync(messageId)).Status);
+    }
+
+    /// <summary>
+    /// A message another instance holds is not picked up at all — the same rule as above, stated
+    /// against a lease sitting in the database rather than one taken during the test.
+    /// </summary>
+    [Fact]
+    public async Task AMessageLeasedByAnotherInstance_IsNotPickedUp()
+    {
+        var (messageId, _) = Seed();
+        LeaseTo(messageId, "instance-b", DateTime.UtcNow.AddMinutes(1));
+
+        await ProcessorFor("instance-a").ProcessDueMessagesAsync(CancellationToken.None);
+
+        Assert.Empty(_wallet.SettledTradeIds);
+
+        var message = await ReloadAsync(messageId);
+        Assert.Equal(OutboxMessageStatus.Pending, message.Status);
+        Assert.Equal("instance-b", message.LeasedBy); // claim untouched
+    }
+
+    /// <summary>
+    /// The expiry is what separates a lease from a lock. An instance that died holding a message
+    /// must not strand it: a recorded trade nobody settles leaves the participants' collateral
+    /// locked with nothing to release it.
+    /// </summary>
+    [Fact]
+    public async Task AMessageWhoseLeaseHasExpired_IsClaimedAgain()
+    {
+        var (messageId, tradeId) = Seed();
+        LeaseTo(messageId, "instance-that-died", DateTime.UtcNow.AddMinutes(-1));
+
+        await ProcessorFor("instance-a").ProcessDueMessagesAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { tradeId }, _wallet.SettledTradeIds);
+        Assert.Equal(OutboxMessageStatus.Completed, (await ReloadAsync(messageId)).Status);
+    }
+
+    [Fact]
+    public async Task AfterASuccessfulDispatch_TheLeaseIsReleased()
+    {
+        var (messageId, _) = Seed();
+
+        await ProcessorFor("instance-a").ProcessDueMessagesAsync(CancellationToken.None);
+
+        var message = await ReloadAsync(messageId);
+        Assert.Null(message.LeasedBy);
+        Assert.Null(message.LeaseExpiresAt);
+    }
+
+    /// <summary>
+    /// A failed attempt releases the claim too. Holding it would add the remainder of the lease to
+    /// the backoff that has already been scheduled, delaying the retry for no reason.
+    /// </summary>
+    [Fact]
+    public async Task AfterAFailedDispatch_TheLeaseIsReleasedAndTheBackoffDecidesTheRetry()
+    {
+        var (messageId, _) = Seed();
+        _wallet.Reject = true;
+
+        await ProcessorFor("instance-a").ProcessDueMessagesAsync(CancellationToken.None);
+
+        var message = await ReloadAsync(messageId);
+        Assert.Null(message.LeasedBy);
+        Assert.Null(message.LeaseExpiresAt);
+        Assert.Equal(1, message.RetryCount);
+        Assert.NotNull(message.NextAttemptAt);
+    }
+
+    /// <summary>
+    /// An operator re-driving a message clears whatever claim was left on it, so "run this now"
+    /// means now rather than after a lease belonging to an instance that already failed.
+    /// </summary>
+    [Fact]
+    public async Task ReDrivingAFailedMessage_ClearsAStaleLease()
+    {
+        var (messageId, _) = Seed(arrange: m =>
+        {
+            for (var i = 0; i < MaxRetries; i++)
+                m.MarkAttemptFailed("boom", MaxRetries, BaseDelay);
+        });
+
+        LeaseTo(messageId, "instance-that-died", DateTime.UtcNow.AddMinutes(30));
+
+        using (var db = new OrdersDbContext(Options()))
+        {
+            var message = await db.OutboxMessages.SingleAsync(m => m.Id == messageId);
+            message.ResetForRetry();
+            await db.SaveChangesAsync();
+        }
+
+        var reloaded = await ReloadAsync(messageId);
+        Assert.Null(reloaded.LeasedBy);
+        Assert.Null(reloaded.LeaseExpiresAt);
+    }
+
+    /// <summary>
+    /// Writes a claim straight to the database, the way another instance would have.
+    /// The entity deliberately has no public way to do this — claiming is one atomic UPDATE in the
+    /// processor, not something a caller can do to a loaded object.
+    /// </summary>
+    private void LeaseTo(Guid messageId, string owner, DateTime expiresAt)
+    {
+        using var db = new OrdersDbContext(Options());
+        db.OutboxMessages
+            .Where(m => m.Id == messageId)
+            .ExecuteUpdate(s => s
+                .SetProperty(m => m.LeasedBy, owner)
+                .SetProperty(m => m.LeaseExpiresAt, expiresAt));
+    }
+}


### PR DESCRIPTION
**Branch**: `fix/160-outbox-lease-leader-election`
**Linked Issue**: #160

## Description

The outbox processor claimed messages with a plain `SELECT`, so two `Orders.Api` instances read the same rows and both dispatched them. The real problem was not the duplicate work — `TradeSettlement.HasKey(s => s.TradeId)` refused the second settlement and no money moved — it was that the single-instance rule making that acceptable lived only in a code comment. Not in the deployment docs, not asserted at startup, invisible to whoever eventually configures the Windows service.

This implements the "proper" route from the issue for the outbox, and extends the same idea to the other two background loops, so a second instance is both safe and impossible to deploy unnoticed.

## Type of Change

- [x] Feature (new capability)

## Changes Made

**Outbox: a lease per message**

- `OutboxMessage` gains `LeasedBy` / `LeaseExpiresAt`. Cleared by `MarkCompleted`, `MarkAttemptFailed`, `ResetForRetry` and `MarkAbandoned` — the claim is released the moment an attempt ends, so the backoff alone decides the retry.
- `OutboxProcessorService.ClaimDueMessagesAsync` replaces the plain select: candidates are read, then a single `ExecuteUpdateAsync` repeats every condition in its `WHERE` clause and stamps the claim. A row another instance took in between is simply not updated, and the batch is re-read by owner. Lease: 2 minutes.
- The hot-path index becomes `(Status, NextAttemptAt, LeaseExpiresAt)`, matching the new query.

**The timer loops: a lease per role**

These have no work rows to claim, so what they claim is the role. New `ServiceLeases` table (one row per role, `Role` as the key), `ILeaderLease` / `DatabaseLeaderLease` (atomic renew, then takeover, then insert-and-lose-on-key-violation), and `LeaderGate`, which paces renewals at half the lease and reports transitions.

- `MatchingEngineService` gates **only the background sweep**. `ProcessOrderAsync`, which `OrderService` calls on the request path, stays available on every instance — gating it would mean an order placed against a follower was never matched at all. Lease: 30s. Note the existing `SemaphoreSlim` is an in-process lock and was never visible to a second process; that is the gap being closed.
- `AutoQuotePublisherService` gates the whole tick. Two publishers write duplicate quote rows and, when a price falls outside the plausibility band, put the same approval request in front of the admin twice. Lease: 6 minutes.
- Both release their lease in `StopAsync`, so a graceful shutdown hands over immediately instead of waiting out the expiry.

**Noticing a second instance** (the issue's acceptance criterion)

- A follower logs a **warning naming the instance that holds the lease**, once per transition rather than every check.
- Startup logs this instance's identity.
- `/api/outbox/unsettled` now returns `LeasedBy` / `LeaseExpiresAt`, so a message being worked on right now is distinguishable from one dropped by an instance that died.

## Testing Completed

- [x] New unit tests written
- [x] All tests pass (`dotnet test`) — **647 passed, 0 failed**

New: `OutboxLeaseTests` (6), `LeaderLeaseTests` (7), `BackgroundLeaderGateTests` (7). `LeaderLeaseTests` exercises the real `DatabaseLeaderLease` against SQLite rather than a double, since the whole mechanism *is* the atomicity of its statements.

**Verified by execution, not assumed.** With the claim removed from `ClaimDueMessagesAsync`, `WhileOneInstanceIsDispatching_ASecondInstanceSettlesNothing` fails with the same trade settled twice:

```
Expected: Guid[]     [be27826e-...]
Actual:   List<Guid> [be27826e-..., be27826e-...]
```

That first run also crashed the test host: without the lease the nested processor re-entered the dispatch hook forever. The hook now fires once, so a regression fails an assertion instead of aborting the run and taking every other result with it.

`OnAFollowerInstance_TheRequestPathStillReachesTheOrderBook` asserts the order book is consulted rather than that a trade appears, for the reason `DealerModeSkipsBackgroundMatchingTests` already records: SQLite rejects a decimal in `ORDER BY`, so a trade is not reachable in tests. Production runs on SQL Server.

- [x] Tested locally on Windows
- [ ] Tested on staging — no staging environment exists yet

## What this does NOT cover

Stated explicitly so it is not assumed closed:

1. **Request-path matching is still not serialised across processes.** Leader election makes the background sweep single-writer. Two concurrent requests on two instances remain guarded only by the `RemainingAmount` concurrency token — which turns the money bug into an exception, but does not prevent the wasted work. Serialising that path is a separate architectural decision.
2. **Leases rely on the app servers' clocks.** `DateTime.UtcNow`, consistent with how `NextAttemptAt` already works. Two hosts with clocks minutes apart would hand the same role to both.

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs — the instance identity is machine name, process id and a random suffix
- [x] Code compiles without warnings (0 warnings, 0 errors)

## Code Quality

- [x] Follows `STANDARDS.md` naming conventions
- [x] Comments in English, explaining the "why"
- [x] No commented-out code

## Breaking Changes?

- [x] No breaking changes

## Deployment Notes

**Pre-Deployment**: one migration, `AddInstanceCoordinationLeases` — two nullable columns on `OutboxMessages`, one index swap, one new empty table. Applied automatically by `MigrateAsync` at startup. **Orders database only**; Users, Wallet and Affiliate are untouched. Nothing to backfill: an existing row with no lease is exactly an unclaimed message. No new configuration.

**Post-Deployment Verification**:
- [ ] Application starts; the startup log names the instance identity
- [ ] Settlements still complete (`/api/outbox/unsettled` stays empty of new entries)
- [ ] If a second instance is ever started, each loop logs its follower warning on exactly one of them

**Rollback**: revert the commit and `dotnet ef database update AddPendingQuotes`. The lease columns carry no state worth preserving — an unclaimed message is the default.

## Related Issues

- Closes #160 (audit finding, `AUDIT_2026-08b.md` §9/§11, roadmap item 6)
- Related to #105 (production checklist) — the issue's cheaper alternative was to document the constraint there; this removes the constraint for the outbox and both loops instead
- The settlement idempotency that bounded the damage is the same barrier #157 asked for on the deposit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
