### PR TITLE
[Hotfix] The shared config file overrode environment variables and the command line — issue #159

### DIFF
--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -38,6 +38,15 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// Re-registered after the shared file and the section flattened from it so that last-wins
+// puts a host on top of both. WebApplication.CreateBuilder registers these two, but ahead of
+// the AddJsonFile above, which left the file outranking them: no port, URL or connection
+// string could be varied per host without hand-editing config/appsettings.global.json, the
+// one file that holds live credentials and is deliberately untracked (#33). The file stays
+// the source of truth for every value a host does not explicitly override (issue #159).
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
 // نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -54,6 +54,15 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// Re-registered after the shared file and the section flattened from it so that last-wins
+// puts a host on top of both. WebApplication.CreateBuilder registers these two, but ahead of
+// the AddJsonFile above, which left the file outranking them: no port, URL or connection
+// string could be varied per host without hand-editing config/appsettings.global.json, the
+// one file that holds live credentials and is deliberately untracked (#33). The file stays
+// the source of truth for every value a host does not explicitly override (issue #159).
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -42,6 +42,15 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// Re-registered after the shared file and the section flattened from it so that last-wins
+// puts a host on top of both. WebApplication.CreateBuilder registers these two, but ahead of
+// the AddJsonFile above, which left the file outranking them: no port, URL or connection
+// string could be varied per host without hand-editing config/appsettings.global.json, the
+// one file that holds live credentials and is deliberately untracked (#33). The file stays
+// the source of truth for every value a host does not explicitly override (issue #159).
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -53,6 +53,15 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// Re-registered after the shared file and the section flattened from it so that last-wins
+// puts a host on top of both. WebApplication.CreateBuilder registers these two, but ahead of
+// the AddJsonFile above, which left the file outranking them: no port, URL or connection
+// string could be varied per host without hand-editing config/appsettings.global.json, the
+// one file that holds live credentials and is deliberately untracked (#33). The file stays
+// the source of truth for every value a host does not explicitly override (issue #159).
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -49,6 +49,15 @@ var flattened = serviceSection.AsEnumerable(true)
 
 builder.Configuration.AddInMemoryCollection(flattened);
 
+// Re-registered after the shared file and the section flattened from it so that last-wins
+// puts a host on top of both. WebApplication.CreateBuilder registers these two, but ahead of
+// the AddJsonFile above, which left the file outranking them: no port, URL or connection
+// string could be varied per host without hand-editing config/appsettings.global.json, the
+// one file that holds live credentials and is deliberately untracked (#33). The file stays
+// the source of truth for every value a host does not explicitly override (issue #159).
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
+
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
@@ -167,6 +167,24 @@ public class ConfigurationPrecedenceTests
     }
 
     /// <summary>
+    /// The port override rests on a second ordering that no behavioural test can reach: the hosts
+    /// capture <c>serviceSection</c> early but read <c>Urls</c> off it late, and a
+    /// <see cref="IConfigurationSection"/> reads through to its root on every access, so the read
+    /// picks up providers registered after the capture. Move the <c>UseUrls</c> block up beside
+    /// the flattening it reads from and the port override dies silently — with every other test
+    /// in this file still green.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ApiHosts))]
+    public void EveryApiHost_ReadsItsUrls_AfterTheEnvironmentIsRegistered(string hostProgram)
+    {
+        var code = ReadHostProgram(hostProgram);
+
+        AssertRegisteredLast(code, hostProgram, "GetSection(\"Urls\")", "AddEnvironmentVariables");
+        AssertRegisteredLast(code, hostProgram, "UseUrls", "AddEnvironmentVariables");
+    }
+
+    /// <summary>
     /// Builds configuration the way the five API hosts do, in their order: the shared file, then
     /// the service's own section flattened into the root, then the host's own overrides.
     /// </summary>
@@ -216,18 +234,19 @@ public class ConfigurationPrecedenceTests
     }
 
     /// <summary>
-    /// Asserts that the last registration of <paramref name="expectedLast"/> comes after the last
-    /// registration of <paramref name="expectedFirst"/>.
+    /// Asserts that the last occurrence of <paramref name="expectedLast"/> comes after the last
+    /// occurrence of <paramref name="expectedFirst"/>.
     /// </summary>
     private static void AssertRegisteredLast(string code, string hostProgram, string expectedLast, string expectedFirst)
     {
         var last = code.LastIndexOf(expectedLast, StringComparison.Ordinal);
         var first = code.LastIndexOf(expectedFirst, StringComparison.Ordinal);
 
-        Assert.True(first >= 0, $"{hostProgram} no longer calls {expectedFirst} — this test is out of date.");
+        Assert.True(first >= 0, $"{hostProgram} no longer contains {expectedFirst} — this test is out of date.");
         Assert.True(last > first,
-            $"{hostProgram} must call {expectedLast} after {expectedFirst}. Configuration providers are " +
-            "last-wins, so registering it earlier lets the shared config file override the host (#159).");
+            $"{hostProgram} must reach {expectedLast} after {expectedFirst}, or the shared config file " +
+            "wins over the host again (#159): configuration providers are last-wins, and a section reads " +
+            "through to whatever providers exist at the moment it is read.");
     }
 
     /// <summary>

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
@@ -1,0 +1,299 @@
+using Microsoft.Extensions.Configuration;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// A host must be able to override a shared-file value with an environment variable or a
+/// command-line switch (issue #159).
+///
+/// <para>
+/// Configuration providers are last-wins. Every service registered
+/// <c>config/appsettings.global.json</c> — and then the section flattened out of it — <i>after</i>
+/// <c>WebApplication.CreateBuilder</c> had already registered the environment-variable and
+/// command-line providers, so the file outranked both. The practical effect was that ports, URLs
+/// and connection strings could only be changed by hand-editing the one file that holds live
+/// credentials and is deliberately untracked (#33): running a second instance, or pointing
+/// staging at another database, meant editing secrets on the server.
+/// </para>
+///
+/// <para>
+/// <b>Two kinds of test for one rule, deliberately.</b> The behavioural tests below pin what the
+/// precedence chain does, but they build that chain themselves — on their own they would keep
+/// passing after someone reordered a <c>Program.cs</c> back.
+/// <see cref="EveryHost_RegistersTheEnvironment_AfterTheSharedFile"/> is what makes the reordering
+/// fail, by reading the host files themselves. Neither half is worth much without the other.
+/// </para>
+/// </summary>
+public class ConfigurationPrecedenceTests
+{
+    /// <summary>The section name is arbitrary here; only its shape has to match the real file.</summary>
+    private const string ApplicationName = "Wallet.Api";
+
+    /// <summary>
+    /// The five API hosts, whose provider order this fix changed. Repo-relative, forward-slashed.
+    /// </summary>
+    public static TheoryData<string> ApiHosts() => new()
+    {
+        "src/Order/Orders.Api/Program.cs",
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/TallaEgg/TallaEgg.Api/Program.cs",
+        "src/Affiliate/Affiliate.Api/Program.cs",
+    };
+
+    /// <summary>
+    /// Every host that reads the shared file, including the bot and the simulator — which had the
+    /// environment provider in the right place already, and are listed so they cannot drift out
+    /// of it.
+    /// </summary>
+    public static TheoryData<string> AllHosts()
+    {
+        var hosts = ApiHosts();
+        hosts.Add("TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs");
+        hosts.Add("TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs");
+        return hosts;
+    }
+
+    /// <summary>
+    /// The acceptance criterion of #159: a connection string set in the environment reaches the
+    /// service, and everything the host did not override still comes from the file.
+    /// </summary>
+    [Fact]
+    public void EnvironmentVariable_OverridesTheSharedFile()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var hostOverride = new EnvironmentVariable(
+            "ConnectionStrings__WalletDb", "Server=from-the-host;Database=Wallet;");
+
+        var configuration = BuildLikeAHost(sharedFile.Path);
+
+        Assert.Equal("Server=from-the-host;Database=Wallet;", configuration.GetConnectionString("WalletDb"));
+
+        // The half that is easy to break while fixing the other half: the file is still the
+        // source of truth for every value the host said nothing about.
+        Assert.Equal("http://localhost:5140", configuration["OrdersApiUrl"]);
+    }
+
+    /// <summary>
+    /// The same for the command line, which <c>CreateBuilder(args)</c> also registered too early
+    /// to be useful.
+    /// </summary>
+    [Fact]
+    public void CommandLineArgument_OverridesTheSharedFile()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+
+        var configuration = BuildLikeAHost(
+            sharedFile.Path,
+            args: new[] { "--ConnectionStrings:WalletDb=Server=from-the-command-line;Database=Wallet;" });
+
+        Assert.Equal("Server=from-the-command-line;Database=Wallet;", configuration.GetConnectionString("WalletDb"));
+    }
+
+    /// <summary>
+    /// A port is the other value #159 named, and it is reached differently: the hosts read
+    /// <c>Services:{ApplicationName}:Urls</c> straight off the section rather than through the
+    /// flattened copy, so the override has to be written at the nested path.
+    /// </summary>
+    [Fact]
+    public void EnvironmentVariable_OverridesTheConfiguredPort()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var hostOverride = new EnvironmentVariable(
+            $"Services__{ApplicationName}__Urls__0", "http://localhost:61000");
+
+        var configuration = BuildLikeAHost(sharedFile.Path);
+        var urls = configuration.GetSection($"Services:{ApplicationName}:Urls").Get<string[]>();
+
+        Assert.Equal(new[] { "http://localhost:61000" }, urls);
+    }
+
+    /// <summary>
+    /// The negative control. Registering the shared file last is what the services used to do,
+    /// and it is what the tests above have to be ruling out — without this they could pass under
+    /// either provider order for some reason unrelated to precedence.
+    /// </summary>
+    [Fact]
+    public void SharedFileRegisteredLast_OutranksTheEnvironment()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var hostOverride = new EnvironmentVariable(
+            "ConnectionStrings__WalletDb", "Server=from-the-host;Database=Wallet;");
+
+        var builder = new ConfigurationBuilder();
+        builder.AddEnvironmentVariables();
+        AddSharedFileAndItsFlattenedSection(builder, sharedFile.Path);
+
+        Assert.Equal("Server=from-the-file;Database=Wallet;", builder.Build().GetConnectionString("WalletDb"));
+    }
+
+    /// <summary>
+    /// The regression guard: the environment provider has to be registered after the shared file
+    /// <i>and</i> after the section flattened out of it, in the host files themselves. The
+    /// flattening is the easy one to miss — it copies the file's values onto the root keys the
+    /// services actually read, so a chain that put the environment between the two would still be
+    /// overridden.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllHosts))]
+    public void EveryHost_RegistersTheEnvironment_AfterTheSharedFile(string hostProgram)
+    {
+        var code = ReadHostProgram(hostProgram);
+
+        AssertRegisteredLast(code, hostProgram, "AddEnvironmentVariables", "AddJsonFile");
+        AssertRegisteredLast(code, hostProgram, "AddEnvironmentVariables", "AddInMemoryCollection");
+    }
+
+    /// <summary>
+    /// The command line, for the five APIs only.
+    ///
+    /// <para>
+    /// The bot and the simulator are deliberately absent. The simulator builds a bare
+    /// <c>ConfigurationBuilder</c> and parses its own <c>--users</c>/<c>--trades</c> switches in
+    /// <c>SimulationOptions.FromArgs</c>, which a command-line configuration provider has no part
+    /// in. The bot's <c>Host.CreateDefaultBuilder(args)</c> does register one, but early enough
+    /// that the shared file still outranks it — a real if smaller gap, left alone because #159 is
+    /// about the environment and nothing in the bot reads a setting from <c>args</c> today.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ApiHosts))]
+    public void EveryApiHost_RegistersTheCommandLine_AfterTheSharedFile(string hostProgram)
+    {
+        var code = ReadHostProgram(hostProgram);
+
+        AssertRegisteredLast(code, hostProgram, "AddCommandLine", "AddJsonFile");
+        AssertRegisteredLast(code, hostProgram, "AddCommandLine", "AddInMemoryCollection");
+    }
+
+    /// <summary>
+    /// Builds configuration the way the five API hosts do, in their order: the shared file, then
+    /// the service's own section flattened into the root, then the host's own overrides.
+    /// </summary>
+    private static IConfigurationRoot BuildLikeAHost(string sharedConfigPath, string[]? args = null)
+    {
+        var builder = new ConfigurationBuilder();
+        AddSharedFileAndItsFlattenedSection(builder, sharedConfigPath);
+        builder.AddEnvironmentVariables();
+        builder.AddCommandLine(args ?? Array.Empty<string>());
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// The part of every host's startup that has to be reproduced faithfully for the precedence
+    /// question to mean anything — the flattening writes the file's values to root-level keys, so
+    /// it, and not only the file, is what an override has to beat.
+    /// </summary>
+    private static void AddSharedFileAndItsFlattenedSection(IConfigurationBuilder builder, string sharedConfigPath)
+    {
+        builder.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: false);
+
+        var section = builder.Build().GetSection($"Services:{ApplicationName}");
+        var prefix = $"Services:{ApplicationName}:";
+        var flattened = section.AsEnumerable(true)
+            .Where(pair => pair.Value is not null)
+            .Select(pair => new KeyValuePair<string, string?>(
+                pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? pair.Key[prefix.Length..] : pair.Key,
+                pair.Value))
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Key));
+
+        builder.AddInMemoryCollection(flattened);
+    }
+
+    /// <summary>
+    /// Source of a host's <c>Program.cs</c> with comment lines removed, so that a comment naming
+    /// a provider — this fix added several — cannot satisfy or defeat an ordering assertion.
+    /// </summary>
+    private static string ReadHostProgram(string repoRelativePath)
+    {
+        var path = Path.Combine(FindRepositoryRoot(), repoRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Host program not found: {repoRelativePath}");
+
+        var code = File.ReadAllLines(path)
+            .Where(line => !line.TrimStart().StartsWith("//", StringComparison.Ordinal));
+
+        return string.Join(Environment.NewLine, code);
+    }
+
+    /// <summary>
+    /// Asserts that the last registration of <paramref name="expectedLast"/> comes after the last
+    /// registration of <paramref name="expectedFirst"/>.
+    /// </summary>
+    private static void AssertRegisteredLast(string code, string hostProgram, string expectedLast, string expectedFirst)
+    {
+        var last = code.LastIndexOf(expectedLast, StringComparison.Ordinal);
+        var first = code.LastIndexOf(expectedFirst, StringComparison.Ordinal);
+
+        Assert.True(first >= 0, $"{hostProgram} no longer calls {expectedFirst} — this test is out of date.");
+        Assert.True(last > first,
+            $"{hostProgram} must call {expectedLast} after {expectedFirst}. Configuration providers are " +
+            "last-wins, so registering it earlier lets the shared config file override the host (#159).");
+    }
+
+    /// <summary>
+    /// Walks up from the test assembly to the directory holding <c>TallaEgg.sln</c>. The same
+    /// anchor <c>SolutionMembershipTests</c> uses, and duplicated rather than shared because
+    /// extracting it would mean editing a test this change has no business touching.
+    /// </summary>
+    private static string FindRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TallaEgg.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+
+        return dir.FullName;
+    }
+
+    /// <summary>
+    /// A throwaway file shaped like <c>config/appsettings.global.json</c>: a
+    /// <c>Services:{ApplicationName}</c> section holding what a service reads. Real values are
+    /// never involved — the actual file holds live credentials, and CI does not have one.
+    /// </summary>
+    private sealed class SharedConfigFile : IDisposable
+    {
+        public SharedConfigFile(string walletDb)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"tallaegg-{Guid.NewGuid():N}.json");
+            File.WriteAllText(Path, $$"""
+                {
+                  "Services": {
+                    "{{ApplicationName}}": {
+                      "Urls": [ "http://localhost:60933" ],
+                      "OrdersApiUrl": "http://localhost:5140",
+                      "ConnectionStrings": { "WalletDb": "{{walletDb}}" }
+                    }
+                  }
+                }
+                """);
+        }
+
+        public string Path { get; }
+
+        public void Dispose() => File.Delete(Path);
+    }
+
+    /// <summary>
+    /// Sets a process environment variable for the length of a test and puts back whatever was
+    /// there. Nothing else in this suite reads the environment, but a test that leaks one fails
+    /// somewhere else entirely, and those are expensive to find.
+    /// </summary>
+    private sealed class EnvironmentVariable : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _original;
+
+        public EnvironmentVariable(string name, string value)
+        {
+            _name = name;
+            _original = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _original);
+    }
+}


### PR DESCRIPTION
**Branch Name**: `fix/config-precedence-159`
**Linked Issue/Task**: Closes #159

---

## Description

Every API host registered `config/appsettings.global.json` — and then the
`Services:{ApplicationName}` section flattened out of it — *after*
`WebApplication.CreateBuilder` had already registered the environment-variable and
command-line providers. Configuration providers are last-wins, so the shared file
outranked both, and no setting could be varied per host without hand-editing the one
file that holds live credentials and is deliberately untracked (#33).

This re-registers `AddEnvironmentVariables()` and `AddCommandLine(args)` immediately
after `AddInMemoryCollection(flattened)`, which is the order the bot and the simulator
already use. The file stays the source of truth for everything a host does not
explicitly override.

---

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

Marked hotfix only in the sense that it is a defect fix; nothing is on fire, because
everything still runs on one machine. It stops being theoretical the first time a
server exists.

---

## Verified before writing, not assumed

The claim was checked against all seven hosts rather than taken from the audit text. It
held exactly:

| Host | Before |
|---|---|
| `src/Order/Orders.Api/Program.cs` | file + flattened section registered last |
| `src/User/Users.Api/Program.cs` | file + flattened section registered last |
| `src/Wallet/Wallet.Api/Program.cs` | file + flattened section registered last |
| `src/TallaEgg/TallaEgg.Api/Program.cs` | file + flattened section registered last |
| `src/Affiliate/Affiliate.Api/Program.cs` | file + flattened section registered last |
| `TelegramBot/…Infrastructure/Program.cs` | already calls `AddEnvironmentVariables()` after both — correct |
| `TelegramBot/…Simulator/Program.cs` | already calls `AddEnvironmentVariables()` after both — correct |

One detail the suggested fix in the issue does not spell out, and which decides where
the two lines go: it is not enough to register the environment after `AddJsonFile`. The
flattening step copies the file's values onto the root-level keys the services actually
read (`ConnectionStrings:WalletDb`, `OrdersApiUrl`, …) through a second provider, so an
override registered between the file and the flattening would still be overridden. Both
new calls therefore go after `AddInMemoryCollection`, exactly as the bot has them.

---

## Changes Made

- `src/{Order/Orders.Api, User/Users.Api, Wallet/Wallet.Api, TallaEgg/TallaEgg.Api, Affiliate/Affiliate.Api}/Program.cs`:
  re-register `AddEnvironmentVariables()` and `AddCommandLine(args)` after the shared
  file and its flattened section.
- `tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs`: new, 21 tests.

No change to the bot or the simulator — see below.

---

## Decisions this change had to make

**`AddCommandLine(args)` as well as environment variables — yes.** Checked what the
hosts read from `args` first: the five APIs read nothing from it themselves, they only
hand it to `CreateBuilder(args)`, which already registers a command-line provider (when
`args` is non-empty) among the defaults. So this adds no new parsing of anything that
was not already being parsed — it cannot introduce an argument-format failure that did
not already exist — and it changes behaviour only for someone passing a switch who
already expected it to win. Confirmed by running `Wallet.Api` with
`--Services:Wallet.Api:Urls:0=http://localhost:61934`: it bound to 61934.

**`Affiliate.Api` included, although it is outside the audit's scope.** The change is
mechanical and it had the same defect. Leaving it out would leave one service running
the opposite precedence rule from the other four — the specific inconsistency the third
acceptance criterion warns about — and it would have to be found again later. It boots
clean with the change (its EF migrations run as before).

**The bot and the simulator were left alone.** Both already register the environment
after the file and its flattened section, so the defect this issue is about is not
present in either. The bot does have a smaller related gap: `Host.CreateDefaultBuilder(args)`
registers a command-line provider, but early enough that the shared file still outranks
it. Nothing in the bot reads a setting from `args` today, so it is a latent
inconsistency rather than a live problem, and per `STANDARDS.md` on scope discipline it
is flagged here rather than fixed inline. Say the word and it is a one-line follow-up.

**`ConfigurationGuard` was checked, not bypassed.** `RequireConnectionString` reads the
*merged* configuration, so an environment override reaches it like any other value: a
real override satisfies the guard, and an override set to blank still fails startup as
it should. The `Services:{ApplicationName}` existence check is unaffected — it runs
against the file, which is still `optional: false`.

---

## Observation, not a change

`ResolveSharedConfigPath` is copy-pasted verbatim into all seven `Program.cs` files, and
the section-flattening block into six of them. That duplication is why this bug needed
fixing in five places instead of one, and it is what will make the next configuration
change cost five edits again. A shared bootstrap helper would be the real answer.
Deliberately not done here — this issue is about provider order, and widening it into a
startup refactor across every service is exactly what `STANDARDS.md` says not to do.
Worth its own issue.

---

## Testing Completed

### Unit Tests
- [x] New unit tests written
- [x] All unit tests pass (`dotnet test`)

```
dotnet build TallaEgg.sln --configuration Release
-> Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test TallaEgg.sln --configuration Release --no-build
-> Passed! Failed: 0, Passed: 668, Skipped: 0, Total: 668
```

`ConfigurationPrecedenceTests` is in two halves on purpose, because either half alone
would be worth little:

- **Behavioural** (4 tests) — builds the same provider chain the hosts build, against a
  throwaway JSON file shaped like the shared one, and asserts that an environment
  variable beats the file, that a command-line switch does, that a port set through the
  environment reaches `Services:{App}:Urls`, and that an un-overridden key still comes
  from the file. A negative control reproduces the old order and asserts the file wins,
  so the other three cannot pass for a reason unrelated to precedence.
- **Source guard** (17 theory cases) — reads all seven host `Program.cs` files and fails
  if `AddEnvironmentVariables` (all seven) or `AddCommandLine` (the five APIs) is ever
  registered before the shared file or before the flattening. Comment lines are stripped
  first, so a comment mentioning a provider can neither satisfy nor defeat it. A third
  case (added in decbb19, from the review) covers the *second* ordering the port override
  rests on: the hosts capture `serviceSection` early and read `Urls` off it late, and that
  only works because a section reads through to its root on every access, so `UseUrls`
  must stay below `AddEnvironmentVariables`.

The guard was confirmed non-vacuous: reverting `Wallet.Api/Program.cs` alone turns
exactly its two theory cases red.

```
Failed …EveryApiHost_RegistersTheCommandLine_AfterTheSharedFile(hostProgram: "src/Wallet/Wallet.Api/Program.cs")
Failed …EveryHost_RegistersTheEnvironment_AfterTheSharedFile(hostProgram: "src/Wallet/Wallet.Api/Program.cs")
```

### The risk here is boot, not tests

A wrong change to configuration composition breaks every service at startup and no unit
test would show it, so the whole stack was actually run.

**All five services start, no errors, bound to the ports from the file:**

```
[INF] Now listening on: http://localhost:5136    (Users.Api)
[INF] Now listening on: http://localhost:60933   (Wallet.Api)
[INF] Now listening on: http://localhost:5140    (Orders.Api)
[INF] Now listening on: http://localhost:5135    (TallaEgg.Api)
[INF] Now listening on: http://localhost:60812   (Affiliate.Api)
-> 0 [ERR]/[FTL] lines across all five logs
```

**The bot starts and reaches its polling loop:**

```
[INF] Bot connection successful: @…
[INF] Bot is now running and listening for messages...
[INF] PendingQuoteNotifierService started (poll every 30s).
```

**End to end through the real handlers and APIs** (`driver.ps1 smoke`, 5 users /
5 quotes / 10 trades):

```
=== Done in 00:00:29.8. Registered 5 (4 approved), trades attempted 10, errors 0 ===
Restored auto-quote for MAUA/IRT to IsEnabled=True.
```

**A real override, applied by hand, at boot** — the acceptance criterion of the issue:

| What was set | Result |
|---|---|
| `Services__Wallet.Api__Urls__0=http://localhost:61933` | `Now listening on: http://localhost:61933`; port 60933 (the file's) never opened |
| `--Services:Wallet.Api:Urls:0=http://localhost:61934` on the command line | `Now listening on: http://localhost:61934`; port 60933 never opened |
| `ConnectionStrings__WalletDb` pointed at a hostname that exists nowhere | startup failed inside `Migrator.MigrateAsync` with "server was not found" — EF used the environment's value, not the file's, which the same service had started against minutes earlier |

Before this change the environment variable would simply have been ignored and the
service would have come up on 60933 against the file's database.

### Environment
- [x] Tested locally on Windows
- [ ] Tested on staging environment (no staging exists yet — see `STANDARDS.md` §7)

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files (config, .env, secrets)
- [x] Code compiles without warnings (`TreatWarningsAsErrors` is on; 0 warnings)

`config/appsettings.global.json` is untouched and uncommitted, and no value from it
appears in this PR, the tests, or the commit message. The test's throwaway config file
is generated per-test in the temp directory with invented values and deleted afterwards
— CI has no shared config file and this suite still must not need one.

Worth noting the direction of travel: the point of this change is that the next
deployment does **not** have to edit that file to move a port or a database, which is
the friction that ends with someone copying it somewhere they should not.

---

## Code Quality

- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why", not the "what"
- [x] No large blocks of commented-out code
- [x] Consistent indentation and formatting
- [x] No unnecessary dependencies added

`FindRepositoryRoot` is duplicated from `SolutionMembershipTests` rather than extracted,
because extracting it would mean editing a test this change has no business touching.
Noted in the test's own XML docs.

---

## Documentation

- [x] Code comments are clear and in English
- [ ] Updated relevant `.md` files in `docs/` — none needed. `AGENT.md`'s Configuration
      section describes the shared file as the source of truth, which is still true. It
      is now the source of truth *for what a host does not override*, which is the
      normal ASP.NET Core expectation and not something that document asserted otherwise.

---

## Breaking Changes?

- [x] No breaking changes

Nothing changes for any host that sets no environment variable or command-line switch,
which is every host today. Verified by running the whole stack: same ports, same
databases, same simulator result.

The one thing to be aware of: a *pre-existing* environment variable that happens to
collide with a key in the shared file now wins where it previously lost. That is the
intended behaviour, and there is nothing of the sort on this machine or in CI, but it is
the shape of surprise this change makes possible.

---

## Deployment Notes

**Pre-Deployment**: nothing. No migrations, no new environment variables, no feature flag.

**Post-Deployment Verification**:
- [x] Application starts successfully
- [x] Smoke tests pass
- [x] Logs show no errors

**How to use it** (the point of the issue). Any key a service reads at the root — connection
strings, `*ApiUrl`, `AutoQuote:*` — can be set either way, because the flattening runs over a
configuration that already contains the default environment-variable provider:

```
ConnectionStrings__WalletDb=Server=…;Database=…;
Services__Wallet.Api__ConnectionStrings__WalletDb=Server=…;Database=…;   # equivalent
```

A port must use the nested path, because the hosts read `Services:{ApplicationName}:Urls` off
the section rather than through the flattened copy:

```
Services__Wallet.Api__Urls__0=http://0.0.0.0:60933
```

`ASPNETCORE_URLS` and `--urls` remain inert: `UseUrls` is fed unconditionally from the file and
writes through `UseSetting`, which bypasses the provider chain entirely. That is a different
mechanism from the one this issue describes and it is not addressed here — see the review thread
on this PR for the evidence and the one-line fix it would take.

**Rollback Plan**: revert the commit and restart. There is no state to undo — the change
is two lines of provider registration per service.

---

## Related Issues

- Closes #159 (audit finding, `docs/audit/AUDIT_2026-08b.md` §10)
- #105 — this belongs on the production checklist; the first deployment is when it stops
  being theoretical
- #33 — why `config/appsettings.global.json` is untracked, and why editing it on a server
  is the thing worth avoiding
