### PR TITLE
[Fix] Bound the wallet concurrency retry by time so a fill is not refused mid-settlement — issue #174

### DIFF
--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -157,6 +157,21 @@ public class WalletRepository : IWalletRepository
     private static readonly TimeSpan InitialConcurrencyDelay = TimeSpan.FromMilliseconds(25);
 
     /// <summary>
+    /// Attempts granted regardless of the clock, matching the fixed cap this replaced.
+    ///
+    /// <para>
+    /// The budget is measured from the start of the first attempt, so it covers the operation as
+    /// well as the waiting — and the operation is a read-modify-write against a contended row,
+    /// which is exactly what gets slow under the load this exists for. Without a floor, a wallet
+    /// write that spent longer than the budget before its first collision would be refused having
+    /// retried nothing at all: worse, precisely when it matters most, than the three attempts it
+    /// used to get unconditionally. The floor makes the budget able only to extend the old
+    /// behaviour, never to cut into it.
+    /// </para>
+    /// </summary>
+    private const int MinimumConcurrencyAttempts = 3;
+
+    /// <summary>
     /// Spreads the backoff over half to one and a half of its nominal length, so two writers that
     /// collided do not wake together and collide again for the same reason they collided the first
     /// time. Without it, doubling keeps a pair of losers in lockstep instead of separating them.
@@ -211,7 +226,9 @@ public class WalletRepository : IWalletRepository
                 // Give up once the next wait would carry this write past the budget, rather than
                 // after a set number of tries. Checking before sleeping is what keeps the ceiling
                 // honest: waiting first and testing afterwards could overshoot by a whole backoff.
-                if (spent.Elapsed + delay > ConcurrencyRetryBudget)
+                // The floor is checked first so a slow operation cannot exhaust the budget before
+                // the first collision and leave the write with no retries at all.
+                if (attempt >= MinimumConcurrencyAttempts && spent.Elapsed + delay > ConcurrencyRetryBudget)
                     throw;
 
                 _context.ChangeTracker.Clear();

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TallaEgg.Core;
@@ -128,11 +129,40 @@ public class WalletRepository : IWalletRepository
 
 
     /// <summary>
-    /// How many times a wallet write is re-attempted after losing an optimistic-concurrency race.
-    /// Three covers a collision with one other writer comfortably; a wallet contended by more than
-    /// that at once is a load problem, not a retry problem.
+    /// How long a wallet write keeps re-attempting after losing an optimistic-concurrency race.
+    ///
+    /// <para>
+    /// This used to be a count — three attempts, 20/40ms apart, a 60ms budget — on the reasoning
+    /// that a wallet contended by more than one other writer at once is a load problem rather than
+    /// a retry problem. The market maker's wallet is that wallet by design: it is the counterparty
+    /// to every quote fill, so the whole shop's writes land on one row (issue #174).
+    /// </para>
+    ///
+    /// <para>
+    /// A budget in time rather than tries is what matches the thing being waited out. The competing
+    /// writer is the outbox draining settlements — a batch of twenty, back to back, roughly one to
+    /// two seconds of near-continuous writes to that same row. Sixty milliseconds could not span
+    /// that, so a fill arriving mid-batch exhausted its tries and was refused; the run that
+    /// produced this value showed four collisions inside 136ms, three retried and the fourth with
+    /// nothing left. Two seconds outlasts a full batch, and the caller is holding a customer's fill
+    /// open, so what has to be bounded is the delay they see, not the number of tries behind it.
+    /// </para>
     /// </summary>
-    private const int ConcurrencyAttempts = 3;
+    private static readonly TimeSpan ConcurrencyRetryBudget = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// First backoff after a lost race; each subsequent wait doubles it. Short enough that an
+    /// uncontended collision costs almost nothing, since most are resolved on the first retry.
+    /// </summary>
+    private static readonly TimeSpan InitialConcurrencyDelay = TimeSpan.FromMilliseconds(25);
+
+    /// <summary>
+    /// Spreads the backoff over half to one and a half of its nominal length, so two writers that
+    /// collided do not wake together and collide again for the same reason they collided the first
+    /// time. Without it, doubling keeps a pair of losers in lockstep instead of separating them.
+    /// </summary>
+    private static TimeSpan WithJitter(TimeSpan delay) =>
+        TimeSpan.FromMilliseconds(delay.TotalMilliseconds * (0.5 + Random.Shared.NextDouble()));
 
     /// <summary>
     /// Runs a read-modify-write against a wallet, re-running it from the start if a concurrent
@@ -165,22 +195,35 @@ public class WalletRepository : IWalletRepository
     private async Task<T> WithConcurrencyRetryAsync<T>(
         Func<Task<T>> operation, string operationName, Guid userId, string asset)
     {
+        var spent = Stopwatch.StartNew();
+        var backoff = InitialConcurrencyDelay;
+
         for (var attempt = 1; ; attempt++)
         {
             try
             {
                 return await operation();
             }
-            catch (DbUpdateConcurrencyException) when (attempt < ConcurrencyAttempts)
+            catch (DbUpdateConcurrencyException)
             {
+                var delay = WithJitter(backoff);
+
+                // Give up once the next wait would carry this write past the budget, rather than
+                // after a set number of tries. Checking before sleeping is what keeps the ceiling
+                // honest: waiting first and testing afterwards could overshoot by a whole backoff.
+                if (spent.Elapsed + delay > ConcurrencyRetryBudget)
+                    throw;
+
                 _context.ChangeTracker.Clear();
 
                 _logger.LogWarning(
                     "Concurrent write to the {Asset} wallet of user {UserId} during {Operation}; " +
-                    "retrying from a fresh read (attempt {Attempt} of {Limit}).",
-                    asset, userId, operationName, attempt, ConcurrencyAttempts);
+                    "retrying from a fresh read (attempt {Attempt}, {Spent}ms of {Budget}ms used).",
+                    asset, userId, operationName, attempt,
+                    (long)spent.Elapsed.TotalMilliseconds, (long)ConcurrencyRetryBudget.TotalMilliseconds);
 
-                await Task.Delay(TimeSpan.FromMilliseconds(20 * attempt));
+                await Task.Delay(delay);
+                backoff += backoff;
             }
         }
     }

--- a/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -174,6 +175,105 @@ public class WalletConcurrencyTests : IDisposable
         // 100 − 25 by the competitor, then − 10 moved into the lock by the retried operation.
         Assert.Equal(65m, stored.Balance);
         Assert.Equal(10m, stored.LockedBalance);
+    }
+
+    // ── The retry budget (issue #174) ───────────────────────────────────────────
+
+    /// <summary>
+    /// The market maker is the counterparty to every quote fill, so its wallet rows take the whole
+    /// shop's writes and a fill can collide with the outbox several times over. Three attempts
+    /// 20/40ms apart could not span a settlement batch, so the fill was refused with
+    /// "در حال حاضر امکان انجام این معامله نیست." while nothing was actually wrong with it.
+    ///
+    /// <para>
+    /// Five collisions is the point of the number: it is more than the old cap of three attempts,
+    /// so this test fails against the previous code and passes against the budget. Driving them
+    /// through <see cref="CollidingContext"/> rather than real parallelism keeps it deterministic —
+    /// a timing-dependent version of this test would be exactly the flake #174 is about.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task LockBalanceAsync_CollidesMoreOftenThanTheOldAttemptCap_StillApplies()
+    {
+        const int Collisions = 5;
+
+        var seeded = await SeedWalletAsync(1000m);
+        var collisions = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            if (collisions >= Collisions) return;
+            collisions++;
+
+            // A different writer takes 10 out of the wallet and commits first, every time.
+            using var competitor = NewContext();
+            var theirs = competitor.Wallets.Single(w => w.Id == seeded.Id);
+            theirs.DecreaseBalance(10m);
+            competitor.SaveChanges();
+        };
+
+        var repository = NewRepository(context);
+        await repository.LockBalanceAsync(seeded.UserId, "IRT", 40m);
+
+        Assert.Equal(Collisions, collisions);
+
+        await using var check = NewContext();
+        var stored = await check.Wallets.SingleAsync(w => w.Id == seeded.Id);
+
+        // 1000 − (5 × 10) by the competitor, then − 40 moved into the lock by the retried
+        // operation. The lock landing on 950 rather than 1000 is the recomputation working: each
+        // retry read the balance as the competitor left it, not as it was first seen.
+        Assert.Equal(910m, stored.Balance);
+        Assert.Equal(40m, stored.LockedBalance);
+    }
+
+    /// <summary>
+    /// The budget has to end the loop as well as extend it. Against a competitor that never stops,
+    /// the write can never land, and what must not happen is retrying forever while a customer
+    /// waits — the ceiling is on the delay they see.
+    ///
+    /// <para>
+    /// Asserted on the attempt count rather than a stopwatch reading: the point is that the budget
+    /// buys more chances than the old fixed cap and still terminates. A tight assertion on elapsed
+    /// time would be measuring the build agent, not the code.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task LockBalanceAsync_NeverWinsTheRace_GivesUpInsteadOfRetryingForever()
+    {
+        var seeded = await SeedWalletAsync(1000m);
+        var attempts = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            attempts++;
+            using var competitor = NewContext();
+            var theirs = competitor.Wallets.Single(w => w.Id == seeded.Id);
+            theirs.DecreaseBalance(1m);
+            competitor.SaveChanges();
+        };
+
+        var repository = NewRepository(context);
+        var elapsed = Stopwatch.StartNew();
+
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+            () => repository.LockBalanceAsync(seeded.UserId, "IRT", 40m));
+
+        elapsed.Stop();
+
+        Assert.True(attempts > 3, $"the budget bought only {attempts} attempts, no more than the old cap");
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(30),
+            $"the retry loop ran for {elapsed.Elapsed} and is not bounded");
+
+        // Nothing was locked: the operation failed whole rather than half-applying.
+        await using var check = NewContext();
+        Assert.Equal(0m, (await check.Wallets.SingleAsync(w => w.Id == seeded.Id)).LockedBalance);
     }
 
     // ── The counter's one weakness ──────────────────────────────────────────────

--- a/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
@@ -186,16 +186,23 @@ public class WalletConcurrencyTests : IDisposable
     /// "در حال حاضر امکان انجام این معامله نیست." while nothing was actually wrong with it.
     ///
     /// <para>
-    /// Five collisions is the point of the number: it is more than the old cap of three attempts,
-    /// so this test fails against the previous code and passes against the budget. Driving them
-    /// through <see cref="CollidingContext"/> rather than real parallelism keeps it deterministic —
-    /// a timing-dependent version of this test would be exactly the flake #174 is about.
+    /// Four collisions is the point of the number: one more than the old cap of three attempts, so
+    /// this fails against the previous code and passes against the budget. Driving them through
+    /// <see cref="CollidingContext"/> rather than real parallelism makes the collisions themselves
+    /// deterministic; a version that raced real threads would be the very flake #174 is about.
+    /// </para>
+    ///
+    /// <para>
+    /// The budget it spends is still real time, so the count is chosen to leave room rather than to
+    /// sit at the limit: four collisions cost at most ~560ms of jittered backoff against a two
+    /// second budget, so the SQLite work in between has well over a second of headroom on a loaded
+    /// agent. Five would have left ~840ms, which is a margin thin enough to lose.
     /// </para>
     /// </summary>
     [Fact]
     public async Task LockBalanceAsync_CollidesMoreOftenThanTheOldAttemptCap_StillApplies()
     {
-        const int Collisions = 5;
+        const int Collisions = 4;
 
         var seeded = await SeedWalletAsync(1000m);
         var collisions = 0;
@@ -223,10 +230,59 @@ public class WalletConcurrencyTests : IDisposable
         await using var check = NewContext();
         var stored = await check.Wallets.SingleAsync(w => w.Id == seeded.Id);
 
-        // 1000 − (5 × 10) by the competitor, then − 40 moved into the lock by the retried
-        // operation. The lock landing on 950 rather than 1000 is the recomputation working: each
+        // 1000 − (4 × 10) by the competitor, then − 40 moved into the lock by the retried
+        // operation. The lock landing on 960 rather than 1000 is the recomputation working: each
         // retry read the balance as the competitor left it, not as it was first seen.
-        Assert.Equal(910m, stored.Balance);
+        Assert.Equal(920m, stored.Balance);
+        Assert.Equal(40m, stored.LockedBalance);
+    }
+
+    /// <summary>
+    /// The budget is measured from the start of the first attempt, so a slow operation can spend it
+    /// before the first collision even happens — and a read-modify-write on a contended row is
+    /// slowest exactly when contention is worst. Left alone, that would hand back <b>fewer</b>
+    /// retries than the fixed cap this replaced, at the moment they matter most.
+    ///
+    /// <para>
+    /// The stall here is deliberate and is what the floor exists for: by the time the first
+    /// collision is raised the budget is already gone, so every retry in this test is one the clock
+    /// would have refused.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task LockBalanceAsync_BudgetSpentBeforeTheFirstCollision_StillRetriesToTheFloor()
+    {
+        var seeded = await SeedWalletAsync(1000m);
+        var collisions = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            if (collisions >= 2) return;
+
+            // Overrun the whole two-second budget inside the first attempt, before it collides.
+            if (collisions == 0) Thread.Sleep(TimeSpan.FromMilliseconds(2100));
+
+            collisions++;
+
+            using var competitor = NewContext();
+            var theirs = competitor.Wallets.Single(w => w.Id == seeded.Id);
+            theirs.DecreaseBalance(10m);
+            competitor.SaveChanges();
+        };
+
+        var repository = NewRepository(context);
+        await repository.LockBalanceAsync(seeded.UserId, "IRT", 40m);
+
+        Assert.Equal(2, collisions);
+
+        await using var check = NewContext();
+        var stored = await check.Wallets.SingleAsync(w => w.Id == seeded.Id);
+
+        // 1000 − (2 × 10) by the competitor, then − 40 into the lock.
+        Assert.Equal(940m, stored.Balance);
         Assert.Equal(40m, stored.LockedBalance);
     }
 


### PR DESCRIPTION
**Branch Name**: `fix/market-maker-wallet-retry-budget`
**Linked Issue**: closes #174

## Description

The market maker is the counterparty to every quote fill, so its wallet rows take the whole shop's
writes on one row. `WalletRepository.WithConcurrencyRetryAsync` allowed three attempts 20/40ms
apart — a **60ms budget** — and a fill that exhausted it was refused with
`در حال حاضر امکان انجام این معامله نیست.` though nothing was wrong with the trade.

The writer it competes with turned out not to be another fill. Fills are sequential; the competitor
is the **outbox draining a batch of twenty settlements**, one to two seconds of near-continuous
writes to that same row. Sixty milliseconds cannot span that.

This replaces the attempt cap with a **two-second budget** and exponential backoff from 25ms,
jittered, floored at the three attempts the cap used to give unconditionally. A budget in time is
what matches the thing being waited out, and what has to be bounded is the delay the customer sees,
not the number of tries behind it.

## Type of Change

- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

## Changes Made

- `WalletRepository`: replaced `ConcurrencyAttempts = 3` with `ConcurrencyRetryBudget = 2s`,
  `InitialConcurrencyDelay = 25ms` and a `WithJitter` helper. `WithConcurrencyRetryAsync` gives up
  when the *next* wait would carry the write past the budget, so the ceiling cannot be overshot by a
  whole backoff.
- `MinimumConcurrencyAttempts = 3`, checked before the clock. The budget is measured from the start
  of the first attempt, so it covers the operation as well as the waiting; without a floor, an
  attempt slower than the budget would raise its first collision with nothing left and retry
  *fewer* times than the cap it replaced — worse, exactly when it matters most. The floor lets the
  budget only extend the old behaviour.
- The retry warning reports elapsed-of-budget instead of attempt-of-limit. The phrase
  `retrying from a fresh read` is unchanged, so existing log greps still match.
- `WalletConcurrencyTests`: three tests, all driven through the existing `CollidingContext` so the
  collisions are deterministic rather than raced — a thread-timing test here would be the very flake
  this issue is about.

## The two numbers

This is the evidence that matters, so the method is written out. `driver.ps1 smoke --users 20
--quotes 20 --trades 60`, five cold runs each way (`stop` + `start` before every run), **with the
outbox drained between runs**.

That drain is not incidental. A run ends with settlements still queued; the next run's `DataReset`
removes the wallets they refer to, so they can never succeed. The queue is FIFO by `CreatedAt`, so
the dead ones are picked up first and the fresh ones are starved — settlement stops happening,
contention disappears, and every run passes while proving nothing. Ten green runs were recorded that
way before the cause was found.

| | runs | refused a fill | lock collisions | of which retried |
|---|---|---|---|---|
| before | 5 | **2** (runs 3, 5) | 11 | 8 |
| after | 5 | **0** | 14 | 14 |

The fingerprint is in the last two columns. Before, the two failing runs each had **4 collisions
against 3 retries** — one collision arrived with the budget already spent. After, collisions equal
retries in every run: one run absorbed **6**, twice the old cap, and still passed. Contention was
*higher* after, not lower, so this is not a quieter machine.

Full evidence chain for one failure, all inside one second on the market maker's MAUA wallet:

```
09:16:34 conflict #1 -> retry (attempt 1 of 3)
09:16:34 conflict #2 -> retry (attempt 1 of 3)
09:16:34 conflict #3 -> retry (attempt 2 of 3)
09:16:34 conflict #4 -> budget spent
09:16:34 HTTP POST /api/wallet/lockBalance responded 500
         Could not create the Sell side of a quote fill for user 5b3f49dd (the market maker)
         trade #16: در حال حاضر امکان انجام این معامله نیست.
```

## Testing Completed

### Unit Tests

- [x] New unit tests written
- [x] All unit tests pass

```
dotnet build TallaEgg.sln   -> Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test  TallaEgg.sln   -> Passed! Failed: 0, Passed: 671, Skipped: 0, Total: 671
```

Each new test was confirmed to **fail without the code it covers**, so they are regression tests
rather than restatements of current behaviour:

| test | covers |
|---|---|
| `LockBalanceAsync_CollidesMoreOftenThanTheOldAttemptCap_StillApplies` | four collisions, one past the old cap |
| `LockBalanceAsync_NeverWinsTheRace_GivesUpInsteadOfRetryingForever` | the budget ends the loop as well as extending it |
| `LockBalanceAsync_BudgetSpentBeforeTheFirstCollision_StillRetriesToTheFloor` | stalls 2100ms inside the first attempt, so every retry is one the clock would have refused |

### Integration

Driven end to end through `driver.ps1` (real handlers, real APIs, real SQL Server), 60 fills per run.

Database checked after the runs:

| check | result |
|---|---|
| duplicate settlements | 0 |
| today's trades with no settlement | 0 of 60 |
| orders left non-terminal | 0 |
| negative `LockedBalance` | 0 |
| balance vs latest transaction's `BallanceAfter` | 39 wallets, 0 mismatched |
| market maker's locked collateral, delta over one clean run | **0.00000000** on both IRT and MAUA |

The two `Failed` orders on the database are the two *before*-run failures, both the market maker's
Sell side, both `قفل وثیقه انجام نشد: خطای داخلی سرور` — the signature this PR removes.

The market maker also holds older stuck collateral from settlements that were orphaned while the
cause above was being diagnosed. Those all predate the measurement window (newest `04:07 UTC`, the
runs start `05:40 UTC`), and the delta row shows a clean run adds none.

## Worth knowing

- **Settlement conflicts went up** (5 before, 31 after). The fill now holds the row longer and wins
  it more often, pushing the collision onto the settlement side. That is the right direction: the
  fill path has no safety net and refuses a customer, while settlement is retried by the outbox and
  self-heals. Every one was absorbed — 0 outbox failures during the window, and all 60 trades
  settled. It costs about ten seconds of settlement delay on a trade that is already recorded.
- **`SettleTradeAsync` has no retry at all**, unlike lock/unlock. Not touched here: it opens its own
  transaction and `ChangeTracker.Clear()` between attempts is not sound mid-transaction, so it is a
  separate change with its own risk to the money path. It is where most of the remaining
  `DbUpdateConcurrencyException` traces come from, and some of the traces #174 reads as "past the
  retry limit" are from this path, which never retries. Worth its own issue.
- **The simulator only trades MAUA/IRT** (#147), so these runs say nothing about other symbols. The
  change is symbol-independent.

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] Code compiles without warnings (`TreatWarningsAsErrors` is on)

## Code Quality

- [x] Code follows naming conventions (`STANDARDS.md`); new tests use `Method_Scenario_ExpectedResult`
- [x] Comments in English and explain the "why"
- [x] No large blocks of commented-out code

## Breaking Changes?

- [x] No breaking changes

The customer-facing Persian message is unchanged.

## Deployment Notes

No migration, no configuration, no feature flag. Behaviour change is confined to how long a wallet
write retries before giving up.

**Rollback**: revert the commit. The previous 60ms budget returns, and with it the intermittent
refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
