### PR TITLE
[Fix] Settle before resetting, and make smoke assert that settlement happened — closes #184, closes #175

### DIFF
--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -111,11 +111,41 @@ A clean run ends with a line like:
 exits 0 no matter how much failed, so `driver.ps1 smoke` parses that summary line and throws if
 the count isn't zero or the line never appeared.
 
+**That line is not the end of the run.** It is printed when the trading phase ends, but
+settlement is queued through the Orders outbox and drains tens of seconds later, so `errors 0`
+only means the conversations and the matching worked. After the summary, `driver.ps1 smoke`
+polls the Orders database until no outbox message is `Pending` and then fails if the number of
+permanently `Failed` messages went up (issue #175). A green run now means the trades settled,
+not just that they were recorded. Expect an extra 5–15s per run for the drain:
+
+```
+Waiting for settlement: 43 outbox message(s) still pending...
+Simulation completed with errors 0; outbox drained with no new failed settlements.
+```
+
+The count is compared as a **delta**, not against zero: these databases already carry failures
+from earlier work that belong to nobody's current change. If the check fires, the message names
+the before/after counts and points at `/api/outbox/unsettled`, where each stuck settlement can
+be re-driven (once the cause is fixed) or abandoned.
+
 ### What a run changes on the database
 
 - **Rows with `TelegramId < 0`.** Every simulated user is in that range, and each run's first
   phase (`DataReset`) wipes only that range before starting, so repeated runs are self-cleaning
   and a real (positive-id) user's data is never touched.
+- **`OutboxMessages` rows, which are never deleted.** Each trade queues one settlement message
+  and it stays in the Orders database as `Completed` afterwards. `DataReset` does not remove
+  them; it *waits* for them instead, blocking until nothing is `Pending` before it deletes
+  anything (issues #184, #175). Deleting a wallet out from under a queued settlement is what
+  used to strand it permanently, so on a queue that has not drained the reset now says so and
+  waits rather than starting:
+
+  ```
+  Reset: 1 settlement(s) from the previous run are still queued; waiting for the outbox to drain before deleting anything.
+  Reset: outbox drained.
+  ```
+
+  It gives up after 10 minutes rather than waiting forever, and says where to look when it does.
 - **The auto-quote flag for `MAUA/IRT`.** The Simulator turns it off in Phase 2 — a background
   publisher replacing the run's quotes breaks quote-fill trades — and never turns it back on.
   That is per-symbol Orders-DB state, not `TelegramId`-scoped, so `DataReset` does not restore

--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -113,20 +113,29 @@ the count isn't zero or the line never appeared.
 
 **That line is not the end of the run.** It is printed when the trading phase ends, but
 settlement is queued through the Orders outbox and drains tens of seconds later, so `errors 0`
-only means the conversations and the matching worked. After the summary, `driver.ps1 smoke`
-polls the Orders database until no outbox message is `Pending` and then fails if the number of
-permanently `Failed` messages went up (issue #175). A green run now means the trades settled,
-not just that they were recorded. Expect an extra 5–15s per run for the drain:
+only means the conversations and the matching worked. `driver.ps1 smoke` therefore drains the
+queue before the run, takes its counts, and after the run polls until no outbox message is
+`Pending` again before checking two things (issue #175):
+
+- **no settlement failed** — the number of permanently `Failed` messages must not have gone up
+- **settlements actually happened** — `Completed` must have gone up, or a regression that stops
+  queueing settlements entirely would drain instantly and look perfect
+
+So a green run now means the trades settled, not just that they were recorded. Expect an extra
+5–15s per run for the drain:
 
 ```
 Waiting for settlement: 43 outbox message(s) still pending...
-Simulation completed with errors 0; outbox drained with no new failed settlements.
+Simulation completed with errors 0; 60 settlement(s) completed, no new failures.
 ```
 
-The count is compared as a **delta**, not against zero: these databases already carry failures
-from earlier work that belong to nobody's current change. If the check fires, the message names
-the before/after counts and points at `/api/outbox/unsettled`, where each stuck settlement can
-be re-driven (once the cause is fixed) or abandoned.
+Failures are compared as a **delta**, not against zero: these databases already carry failures
+from earlier work that belong to nobody's current change. The pre-run drain is part of that —
+a doomed message left over from an earlier run does not fail when it is abandoned but when it
+exhausts its retries, minutes later, and without the drain that lands inside this run's window
+and is charged to it. If either check fires, the message names the counts and points at
+`/api/outbox/unsettled`, where a stuck settlement can be re-driven (once the cause is fixed) or
+abandoned.
 
 ### What a run changes on the database
 

--- a/.claude/skills/run-tallaegg/driver.ps1
+++ b/.claude/skills/run-tallaegg/driver.ps1
@@ -88,6 +88,14 @@ function Get-OrdersConnectionString {
         throw "config/appsettings.global.json is missing, so the settlement check cannot reach the Orders database. Copy config/appsettings.global.example.json to that path (see SKILL.md Prerequisites)."
     }
 
+    # Environment first, matching the precedence every service applies: each layers
+    # AddEnvironmentVariables() over the shared file (the #159 hotfix, d3956d6). Reading only
+    # the file would point this check at a different database than the one the services write
+    # to, and the settlement assertions below would then pass on an empty queue every time.
+    if (-not [string]::IsNullOrWhiteSpace($env:ConnectionStrings__OrdersDb)) {
+        return $env:ConnectionStrings__OrdersDb
+    }
+
     # ReadAllText rather than Get-Content: the file is UTF-8 with a BOM, and in Windows
     # PowerShell 5.1 the BOM survives Get-Content and makes ConvertFrom-Json fail on it.
     $config = [System.IO.File]::ReadAllText($configPath) | ConvertFrom-Json
@@ -285,8 +293,17 @@ switch ($Command) {
         # Counted before the run and compared as a delta afterwards, never as an absolute:
         # these databases already carry failures from earlier work that belong to nobody's
         # current change, and a run that adds none of its own is a pass (issue #175).
+        #
+        # The queue is drained BEFORE the baseline is read, not just after the run. A message
+        # left over from an earlier run that is doomed anyway does not fail the moment it is
+        # abandoned — it fails when it exhausts its retries, which is minutes later, inside the
+        # window this run is measured over. Counting first and draining second charged those
+        # failures to a run that had not started yet. Draining first is also what the simulator's
+        # own DataReset does before it deletes anything, so this costs one query on a clean queue.
         $ordersConnectionString = Get-OrdersConnectionString
+        Wait-OutboxDrained -ConnectionString $ordersConnectionString
         $failedBefore = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 2
+        $completedBefore = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 1
 
         $autoQuoteWas = Get-AutoQuoteEnabled
         Write-Host "Running simulator with args: $simArgs"
@@ -310,11 +327,12 @@ switch ($Command) {
 
         # The Simulator returns 0 whatever happens — it only *logs* its error count — so the
         # summary line is the real result and has to be parsed for it.
-        $summary = Select-String -Path $smokeLog -Pattern 'trades attempted \d+, errors (\d+)' | Select-Object -Last 1
+        $summary = Select-String -Path $smokeLog -Pattern 'trades attempted (\d+), errors (\d+)' | Select-Object -Last 1
         if (-not $summary) {
             throw "Simulator produced no summary line; it did not finish. Full output: $smokeLog"
         }
-        $errorCount = [int]$summary.Matches[0].Groups[1].Value
+        $tradesAttempted = [int]$summary.Matches[0].Groups[1].Value
+        $errorCount = [int]$summary.Matches[0].Groups[2].Value
         if ($errorCount -ne 0) {
             throw "Simulation finished with $errorCount error(s). Full output: $smokeLog"
         }
@@ -330,7 +348,17 @@ switch ($Command) {
             throw "Simulation traded cleanly but $newFailures settlement(s) failed permanently (Failed outbox messages went from $failedBefore to $failedAfter). The trades are recorded but NOT settled and their collateral is still locked. Inspect them at http://localhost:$($ports['orders'])/api/outbox/unsettled. Full output: $smokeLog"
         }
 
-        Write-Host "Simulation completed with errors 0; outbox drained with no new failed settlements."
+        # "Nothing failed" is not "something settled": a regression that stops queueing
+        # settlements at all leaves an empty queue, which drains instantly and adds no failures.
+        # That is the same shape of false green this check exists to remove, so the settlements
+        # have to be counted arriving, not just counted as not-failing.
+        $completedAfter = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 1
+        $settled = $completedAfter - $completedBefore
+        if ($tradesAttempted -gt 0 -and $settled -le 0) {
+            throw "Simulation reported $tradesAttempted trade(s) and no errors, but not one settlement completed (Completed outbox messages stayed at $completedBefore). The trades were recorded and nothing was queued to settle them. Full output: $smokeLog"
+        }
+
+        Write-Host "Simulation completed with errors 0; $settled settlement(s) completed, no new failures."
     }
 
     'stop' {

--- a/.claude/skills/run-tallaegg/driver.ps1
+++ b/.claude/skills/run-tallaegg/driver.ps1
@@ -20,6 +20,12 @@
   menu navigation) through the real IBotHandler and the real Users/Wallet/Orders APIs and
   database — everything except the live Telegram connection, which it fakes.
 
+  "smoke" also waits for settlement before it reports anything. The Simulator's summary line is
+  printed when the trading phase ends, but settlement is queued through the Orders outbox and
+  drains tens of seconds later, so that line alone is not a result (issue #175). After the run
+  the driver polls until no outbox message is Pending, and fails if the number of permanently
+  Failed messages went up.
+
   Two things it changes on the database it runs against:
     * Rows with TelegramId < 0 — created, then wiped by the next run's DataReset phase. A
       real (positive-id) user's data is never touched.
@@ -71,6 +77,67 @@ function Get-ListeningPorts {
         }
     }
     return $busy
+}
+
+function Get-OrdersConnectionString {
+    # OutboxMessages lives in the Orders database. Every service reads one shared config file
+    # (AGENT.md — Configuration) and ConnectionStrings sits at its root, not under a service
+    # section.
+    $configPath = Join-Path $repoRoot 'config/appsettings.global.json'
+    if (-not (Test-Path $configPath)) {
+        throw "config/appsettings.global.json is missing, so the settlement check cannot reach the Orders database. Copy config/appsettings.global.example.json to that path (see SKILL.md Prerequisites)."
+    }
+
+    # ReadAllText rather than Get-Content: the file is UTF-8 with a BOM, and in Windows
+    # PowerShell 5.1 the BOM survives Get-Content and makes ConvertFrom-Json fail on it.
+    $config = [System.IO.File]::ReadAllText($configPath) | ConvertFrom-Json
+    $connectionString = $config.ConnectionStrings.OrdersDb
+    if ([string]::IsNullOrWhiteSpace($connectionString)) {
+        throw "ConnectionStrings:OrdersDb is not set in config/appsettings.global.json."
+    }
+    return $connectionString
+}
+
+function Get-OutboxCount {
+    # Status values are OutboxMessageStatus in src/Order/Orders.Core/OutboxMessage.cs:
+    # 0 Pending, 1 Completed, 2 Failed, 3 Abandoned.
+    param(
+        [Parameter(Mandatory = $true)][string]$ConnectionString,
+        [Parameter(Mandatory = $true)][int]$Status
+    )
+
+    $conn = New-Object System.Data.SqlClient.SqlConnection $ConnectionString
+    try {
+        $conn.Open()
+        $cmd = $conn.CreateCommand()
+        $cmd.CommandText = 'SELECT COUNT(*) FROM OutboxMessages WHERE Status = @status'
+        $null = $cmd.Parameters.AddWithValue('@status', $Status)
+        return [int]$cmd.ExecuteScalar()
+    }
+    finally {
+        $conn.Dispose()
+    }
+}
+
+function Wait-OutboxDrained {
+    # Waits until nothing is queued or mid-dispatch. A message stays Pending for its whole
+    # working life — while an instance holds its lease and the wallet call is in flight, and
+    # while it sits between retries — so zero Pending is the point at which the run really is
+    # over. 300 x 2s = 10 minutes, the same bound DataReset's own wait uses.
+    param([Parameter(Mandatory = $true)][string]$ConnectionString)
+
+    $pending = Get-OutboxCount -ConnectionString $ConnectionString -Status 0
+    for ($i = 0; $i -lt 300 -and $pending -gt 0; $i++) {
+        if ($i % 5 -eq 0) {
+            Write-Host "Waiting for settlement: $pending outbox message(s) still pending..."
+        }
+        Start-Sleep -Seconds 2
+        $pending = Get-OutboxCount -ConnectionString $ConnectionString -Status 0
+    }
+
+    if ($pending -gt 0) {
+        throw "Settlement did not finish: $pending outbox message(s) are still Pending after 10 minutes. Inspect them at http://localhost:$($ports['orders'])/api/outbox/unsettled."
+    }
 }
 
 function Get-AutoQuoteEnabled {
@@ -215,6 +282,12 @@ switch ($Command) {
         New-Item -ItemType Directory -Force -Path $logDir | Out-Null
         $smokeLog = Join-Path $logDir 'smoke.log'
 
+        # Counted before the run and compared as a delta afterwards, never as an absolute:
+        # these databases already carry failures from earlier work that belong to nobody's
+        # current change, and a run that adds none of its own is a pass (issue #175).
+        $ordersConnectionString = Get-OrdersConnectionString
+        $failedBefore = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 2
+
         $autoQuoteWas = Get-AutoQuoteEnabled
         Write-Host "Running simulator with args: $simArgs"
         try {
@@ -245,7 +318,19 @@ switch ($Command) {
         if ($errorCount -ne 0) {
             throw "Simulation finished with $errorCount error(s). Full output: $smokeLog"
         }
-        Write-Host "Simulation completed with errors 0."
+
+        # Everything above only checks the trading phase. Settlement is queued and happens after
+        # the summary line, so without the wait below the driver reports green on a run whose
+        # settlements are still in flight — or already doomed (issue #175). Nearly every
+        # settlement regression is post-summary, which is exactly what this catches.
+        Wait-OutboxDrained -ConnectionString $ordersConnectionString
+        $failedAfter = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 2
+        $newFailures = $failedAfter - $failedBefore
+        if ($newFailures -gt 0) {
+            throw "Simulation traded cleanly but $newFailures settlement(s) failed permanently (Failed outbox messages went from $failedBefore to $failedAfter). The trades are recorded but NOT settled and their collateral is still locked. Inspect them at http://localhost:$($ports['orders'])/api/outbox/unsettled. Full output: $smokeLog"
+        }
+
+        Write-Host "Simulation completed with errors 0; outbox drained with no new failed settlements."
     }
 
     'stop' {

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/DataReset.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/DataReset.cs
@@ -44,8 +44,9 @@ namespace TallaEgg.TelegramBot.Simulator;
 /// processor writing Transactions rows between the two deletes below, which is the second way
 /// this class fails on FK_Transactions_Wallets_WalletId (reproduced on unmodified main), and it
 /// would need ordering against the Trades delete that destroys the link it depends on. Waiting
-/// closes both faults with one condition, and it keeps the completed messages as the record of
-/// what the previous run settled — which is the evidence both issues were diagnosed from.
+/// addresses both faults with one condition — nothing is queued or in flight when the deletes
+/// start — and it keeps the completed messages as the record of what the previous run settled,
+/// which is the evidence both issues were diagnosed from.
 /// </summary>
 public sealed class DataReset(string usersDbConnectionString, string walletDbConnectionString,
     string ordersDbConnectionString, ILogger<DataReset> logger)
@@ -75,8 +76,14 @@ public sealed class DataReset(string usersDbConnectionString, string walletDbCon
 
         if (userIds.Count > 0)
         {
-            await DeleteWalletDataAsync(userIds, cancellationToken);
+            // Orders and Trades go before the wallet rows so that nothing is left able to
+            // produce a settlement while those rows are being deleted. The matching sweep runs
+            // every second and writes a Trade and its outbox message in one transaction, and
+            // the processor dispatching that message writes Transactions rows — which is the
+            // foreign key DeleteWalletDataAsync conflicts on. The wait above clears what is
+            // already queued; this order removes what could still queue more.
             await DeleteOrderDataAsync(userIds, cancellationToken);
+            await DeleteWalletDataAsync(userIds, cancellationToken);
         }
 
         await DeleteUsersAsync(cancellationToken);

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/DataReset.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/DataReset.cs
@@ -27,14 +27,49 @@ namespace TallaEgg.TelegramBot.Simulator;
 /// database (a completed 100-user/1000-trade run) left some Transactions rows behind and the
 /// following Wallets delete then failed on the foreign key. Two independent subqueries with an
 /// explicit cast, one per table, replaced it.
+///
+/// Nothing is deleted until the Orders outbox has drained (issues #184, #175). A run is not
+/// finished when the simulator prints its summary: settlement is queued, and a 60-trade run
+/// outpaces a processor that polls every 5s and takes 20 at a time, so a run reliably ends
+/// with settlements still in the queue. Deleting straight away took the wallets those
+/// settlements needed out from under them — they retried five times, were marked Failed, and
+/// stayed there, 97 of them across three consecutive runs on one machine. Worse, while those
+/// doomed messages were still retrying they were the oldest in the queue, so
+/// <c>ClaimDueMessagesAsync</c>'s OrderBy(CreatedAt) spent every batch on them and the current
+/// run's own settlements never ran at all — a run that exercised no settlement while
+/// reporting itself healthy.
+///
+/// Deleting this run's own outbox rows here instead would be faster, and was considered: the
+/// rows are identifiable, since AggregateId is the trade id. It was not chosen. It leaves the
+/// processor writing Transactions rows between the two deletes below, which is the second way
+/// this class fails on FK_Transactions_Wallets_WalletId (reproduced on unmodified main), and it
+/// would need ordering against the Trades delete that destroys the link it depends on. Waiting
+/// closes both faults with one condition, and it keeps the completed messages as the record of
+/// what the previous run settled — which is the evidence both issues were diagnosed from.
 /// </summary>
 public sealed class DataReset(string usersDbConnectionString, string walletDbConnectionString,
     string ordersDbConnectionString, ILogger<DataReset> logger)
 {
     private const int CommandTimeoutSeconds = 120;
 
+    /// <summary>How often <see cref="WaitForOutboxToDrainAsync"/> re-reads the queue depth.</summary>
+    private static readonly TimeSpan DrainPollInterval = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// How many polls the drain wait makes before giving up — 300 × 2s = 10 minutes.
+    ///
+    /// The bound is counted in polls rather than measured against the clock so the loop's
+    /// give-up behaviour can be tested without waiting for real time to pass. Ten minutes is
+    /// well past both cases that legitimately take a while: a message that can never succeed
+    /// exhausts its five retries in about three minutes of backoff and then stops being
+    /// Pending, and the largest run drains a thousand messages at 20 per 5s in about four.
+    /// </summary>
+    private const int MaxDrainPolls = 300;
+
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        await WaitForOutboxToDrainAsync(cancellationToken);
+
         var userIds = await GetSimulatedUserIdsAsync(cancellationToken);
         logger.LogInformation("Reset: found {Count} previously simulated users.", userIds.Count);
 
@@ -118,6 +153,89 @@ public sealed class DataReset(string usersDbConnectionString, string walletDbCon
             var deleted = await cmd.ExecuteNonQueryAsync(ct);
             logger.LogInformation("Reset: deleted {Count} Orders rows.", deleted);
         }
+    }
+
+    private Task WaitForOutboxToDrainAsync(CancellationToken ct) =>
+        WaitForOutboxToDrainAsync(
+            GetPendingOutboxCountAsync,
+            token => Task.Delay(DrainPollInterval, token),
+            MaxDrainPolls,
+            logger,
+            ct);
+
+    /// <summary>
+    /// Blocks until the Orders outbox holds no Pending message, so the deletes that follow
+    /// cannot take data out from under a settlement that is still queued or in flight.
+    ///
+    /// <para>
+    /// Pending is the right condition to wait on because a message holds that status for its
+    /// whole working life: it is still Pending while an instance holds the lease and the wallet
+    /// call is in flight, and while it sits between retries. It leaves Pending only by
+    /// completing or by exhausting its retries. Zero Pending therefore means nothing is queued
+    /// and nothing is mid-dispatch on any instance — which is also what makes the deletes below
+    /// safe from a concurrent writer.
+    /// </para>
+    ///
+    /// <para>
+    /// The polling and the give-up bound are parameters rather than reads of the clock so this
+    /// loop can be tested directly; the private overload above is what production passes.
+    /// </para>
+    /// </summary>
+    internal static async Task WaitForOutboxToDrainAsync(
+        Func<CancellationToken, Task<int>> getPendingCount,
+        Func<CancellationToken, Task> waitBetweenPolls,
+        int maxPolls,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var pending = await getPendingCount(ct);
+        if (pending == 0)
+        {
+            return;
+        }
+
+        logger.LogInformation(
+            "Reset: {Count} settlement(s) from the previous run are still queued; waiting for the outbox to drain before deleting anything.",
+            pending);
+
+        for (var poll = 0; poll < maxPolls; poll++)
+        {
+            await waitBetweenPolls(ct);
+
+            var remaining = await getPendingCount(ct);
+            if (remaining == 0)
+            {
+                logger.LogInformation("Reset: outbox drained.");
+                return;
+            }
+
+            // Progress matters more than the number here: someone watching a wait that is going
+            // nowhere needs to see that it is going nowhere, not a silent pause.
+            if (remaining != pending)
+            {
+                logger.LogInformation("Reset: {Count} settlement(s) still queued.", remaining);
+                pending = remaining;
+            }
+        }
+
+        throw new TimeoutException(
+            $"The Orders outbox still has {pending} Pending message(s) after waiting for it to drain. " +
+            "Nothing was deleted: resetting now would orphan those settlements. Inspect them at " +
+            "GET /api/outbox/unsettled, then re-drive or abandon them and run again.");
+    }
+
+    private async Task<int> GetPendingOutboxCountAsync(CancellationToken ct)
+    {
+        await using var conn = new SqlConnection(ordersDbConnectionString);
+        await conn.OpenAsync(ct);
+        // Status 0 is OutboxMessageStatus.Pending. Spelled out rather than referenced because
+        // this class deliberately talks to the databases in plain SQL — see the class comment.
+        await using var cmd = new SqlCommand(
+            "SELECT COUNT(*) FROM OutboxMessages WHERE Status = 0", conn)
+        {
+            CommandTimeout = CommandTimeoutSeconds
+        };
+        return (int)(await cmd.ExecuteScalarAsync(ct))!;
     }
 
     private async Task DeleteUsersAsync(CancellationToken ct)

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/TallaEgg.TelegramBot.Simulator.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/TallaEgg.TelegramBot.Simulator.csproj
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- DataReset's outbox drain loop (issues #184, #175) is unit-tested in the solution's
+         single test project; the loop itself is internal because nothing outside this
+         assembly should be calling it. -->
+    <InternalsVisibleTo Include="TallaEgg.AllServices.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />

--- a/tests/TallaEgg.AllServices.Tests/SimulatorOutboxDrainTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SimulatorOutboxDrainTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.TelegramBot.Simulator;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// The simulator's <c>DataReset</c> must not delete anything while the previous run's
+/// settlements are still queued: the wallets it removes are the ones those settlements need,
+/// and they then fail permanently (issues #184, #175).
+///
+/// <para>
+/// These tests drive the drain loop directly rather than a database. The loop takes its queue
+/// depth and its pause as delegates for exactly that reason, so what is asserted here is the
+/// decision it makes — keep waiting, stop waiting, or give up — with no timing in it. The SQL
+/// that produces the real count is one <c>SELECT COUNT(*)</c> and is exercised by running the
+/// simulator.
+/// </para>
+/// </summary>
+public class SimulatorOutboxDrainTests
+{
+    private static Func<CancellationToken, Task<int>> CountsOf(params int[] counts)
+    {
+        var index = 0;
+        return _ => Task.FromResult(counts[Math.Min(index++, counts.Length - 1)]);
+    }
+
+    private static Task Immediately(CancellationToken _) => Task.CompletedTask;
+
+    [Fact]
+    public async Task WaitForOutboxToDrainAsync_QueueAlreadyEmpty_DoesNotPoll()
+    {
+        var polls = 0;
+
+        await DataReset.WaitForOutboxToDrainAsync(
+            _ => Task.FromResult(0),
+            _ => { polls++; return Task.CompletedTask; },
+            maxPolls: 10,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // The common case is a queue that is already empty, and it must cost nothing: the reset
+        // runs at the start of every simulation, including the first one on a clean database.
+        Assert.Equal(0, polls);
+    }
+
+    [Fact]
+    public async Task WaitForOutboxToDrainAsync_QueueDrains_ReturnsOnceEmpty()
+    {
+        await DataReset.WaitForOutboxToDrainAsync(
+            CountsOf(12, 7, 3, 0),
+            Immediately,
+            maxPolls: 10,
+            NullLogger.Instance,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WaitForOutboxToDrainAsync_QueueStopsShrinking_StillWaitsUntilEmpty()
+    {
+        // A queue that sits at the same depth for a while is normal, not stuck: messages that
+        // exhausted an attempt wait out an exponential backoff before the processor sees them
+        // again. Giving up on a count that has not moved would abandon a run that was going to
+        // settle perfectly well a few seconds later.
+        await DataReset.WaitForOutboxToDrainAsync(
+            CountsOf(4, 4, 4, 4, 4, 0),
+            Immediately,
+            maxPolls: 10,
+            NullLogger.Instance,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WaitForOutboxToDrainAsync_QueueNeverDrains_ThrowsAndDeletesNothing()
+    {
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+            DataReset.WaitForOutboxToDrainAsync(
+                CountsOf(5),
+                Immediately,
+                maxPolls: 3,
+                NullLogger.Instance,
+                CancellationToken.None));
+
+        // Throwing is the point: the reset is the first thing a run does, so failing here stops
+        // the run before a single row is deleted. The message has to say where to look, or the
+        // next person sees a simulator that will not start and no reason why.
+        Assert.Contains("5 Pending", exception.Message);
+        Assert.Contains("Nothing was deleted", exception.Message);
+        Assert.Contains("/api/outbox/unsettled", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitForOutboxToDrainAsync_Cancelled_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            DataReset.WaitForOutboxToDrainAsync(
+                CountsOf(3),
+                token => Task.FromCanceled(token),
+                maxPolls: 10,
+                NullLogger.Instance,
+                cts.Token));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj
+++ b/tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj
@@ -38,6 +38,8 @@
     <ProjectReference Include="..\..\src\Order\Orders.Application\Orders.Application.csproj" />
     <!-- برای تست ساخت متن فهرست معاملات (خرید/فروش و تاریخ شمسی). -->
     <ProjectReference Include="..\..\TelegramBot\TallaEgg.TelegramBot.Infrastructure\TallaEgg.TelegramBot.Infrastructure.csproj" />
+    <!-- DataReset's wait for the outbox to drain before it deletes anything (issues #184, #175). -->
+    <ProjectReference Include="..\..\TelegramBot\TallaEgg.TelegramBot.Simulator\TallaEgg.TelegramBot.Simulator.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Branch Name**: `fix/simulator-settlement-drain`
**Linked Issue/Task**: closes #184, closes #175

---

## Description

A simulator run is not over when it says it is. The summary line is printed when the trading
phase ends, but settlement is queued through the Orders outbox and drains tens of seconds later,
so a 60-trade run reliably ends with settlements still in the queue. Both issues are consequences
of that one fact, which is why they are fixed together.

`DataReset` then deleted the wallets those queued settlements needed, so they could never succeed
(#184). And `driver.ps1 smoke` reported green through all of it, because the only thing it checked
was the Simulator's own conversation-level error counter (#175). The second is the worse of the
two: the harness hid its own damage, and once cost a healthy branch a false "regression" verdict.

`DataReset` now waits for the outbox to hold no `Pending` message before it deletes anything, and
`smoke` waits for the same condition around the run and then asserts both halves of what a green
run should mean: no settlement failed, and settlements actually happened.

---

## Type of Change
- [x] Hotfix (urgent bug fix) — test harness, not product code
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

No product code changes. Everything here is in the simulator, the run-tallaegg driver, and tests.

---

## Changes Made

- `DataReset.RunAsync` waits for the Orders outbox to drain before its first delete
  (`WaitForOutboxToDrainAsync`, polling `SELECT COUNT(*) FROM OutboxMessages WHERE Status = 0`
  every 2s, giving up after 10 minutes with a message naming `/api/outbox/unsettled`)
- `DataReset` now deletes `Orders`/`Trades` **before** the wallet rows, so nothing is left able to
  enqueue a settlement while those rows are being deleted
- `driver.ps1 smoke` drains the queue and takes its baseline counts, runs, drains again, then
  asserts two things: no new permanently `Failed` messages, and `Completed` actually grew
- `Get-OrdersConnectionString` / `Get-OutboxCount` / `Wait-OutboxDrained` added to `driver.ps1`;
  the connection string honours `ConnectionStrings__OrdersDb` first and then
  `config/appsettings.global.json` — the same precedence every service applies
- `SimulatorOutboxDrainTests` — 5 tests over the drain loop's decisions
- The test project now references the Simulator, which exposes `InternalsVisibleTo` for it
- `SKILL.md` updated: what a green smoke run now means, and what the reset waits for

---

## Which fix, and why — #184's three options

#184 offered three; #175 asked for the wait plus the smoke assert. **Wait only, no deletion.**

Deleting the run's own outbox rows in `DataReset` is the faster option and it was considered
seriously — `AggregateId` is the trade id, so the rows are identifiable. Three things decided
against it:

1. **It leaves the FK race open.** `DeleteWalletDataAsync` deletes `Transactions` and then
   `Wallets` in two statements, and the outbox processor writes new `Transactions` rows in
   between. That is a crash, not a slow leak, and it reproduced on unmodified `main` during this
   work (run 3 of the "before" table below). Deleting rows does not stop a processor that is
   already mid-dispatch; waiting for it to finish does.
2. **Ordering hazard.** The link the deletion depends on — `OutboxMessages.AggregateId` →
   `Trades.Id` — is destroyed by the `Trades` delete in the same pass, so the outbox delete has
   to come first and stay first. That is a constraint nothing in the code enforces.
3. **It throws away the evidence.** The `Completed` rows are the record of what a run actually
   settled. Both of these issues were diagnosed from exactly those rows.

With the wait in place, deletion buys nothing: every message from the previous run is `Completed`
or `Failed` by the time the reset starts, and neither status is ever claimed again. It costs about
5–15s per run.

The wait alone does not fully close the FK race, which self-review finding 2 below caught: the
previous run's `Orders` outlive it and the matching sweep can still produce a settlement in the
gap. `DataReset` therefore also deletes `Orders`/`Trades` before the wallet rows, so the producer
is gone before the rows the FK protects start disappearing.

## The open question in #175 — does the drain wait still mean anything after #160?

**It does, unchanged, and #160 makes the reasoning cleaner rather than weaker.**

#160 (b1c0f3b) added a per-message lease and a `ServiceLeases` role lease for the two timer-driven
loops. The lease is a *claim*; it is not the message's state. `LeasedBy`/`LeaseExpiresAt` are set
by `ClaimDueMessagesAsync` while `Status` stays `Pending`, and `Status` only leaves `Pending` in
`MarkCompleted()` or in `MarkAttemptFailed()` at max retries. So a message keeps `Pending` for its
whole working life: queued, leased and mid-flight in the wallet call, and sitting between retries.

That means `Pending == 0` reads a shared database column, not per-process memory, and says
"nothing is queued and nothing is mid-dispatch **on any instance**". That was already the
condition before #160; the lease does not weaken it. Two smaller effects both point the same way:

- Before #160, two instances could dispatch the same message and both write wallet
  `Transactions`. The lease narrows that to one, so the FK window the wait closes is narrower
  than it used to be.
- The lease *expires*. A processor killed mid-message used to be able to strand a settlement;
  now the row becomes claimable again, so a dead instance cannot stall the wait indefinitely.

One honest limit, unrelated to #160: `Pending == 0` is a point-in-time reading, not a latch.
Anything that matches a new trade after the check re-opens the window. During a simulator run
nothing does — the simulator is the only client, it has stopped placing orders by then, and
`DataReset` removes the orders a background sweep could match. If some other client were trading
against the same database concurrently, neither this wait nor the assert would be sound, but
neither would `DataReset` itself, which is already built on the simulator owning the negative-id
range.

`ServiceLeases` is deliberately left alone by the reset: those rows are per-role, not per-run, and
the services expire and renew them themselves.

---

## Testing Completed

### Build and unit tests

```
dotnet build TallaEgg.sln     ->  Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test  TallaEgg.sln     ->  Passed!  Failed: 0, Passed: 676, Skipped: 0, Total: 676
```

Both re-run after the review fixes.

`SimulatorOutboxDrainTests` covers the loop's decisions with no timing in them — the queue depth
and the pause are delegates, and the give-up bound is counted in polls rather than measured
against the clock, so the timeout case is deterministic:

- `WaitForOutboxToDrainAsync_QueueAlreadyEmpty_DoesNotPoll`
- `WaitForOutboxToDrainAsync_QueueDrains_ReturnsOnceEmpty`
- `WaitForOutboxToDrainAsync_QueueStopsShrinking_StillWaitsUntilEmpty`
- `WaitForOutboxToDrainAsync_QueueNeverDrains_ThrowsAndDeletesNothing`
- `WaitForOutboxToDrainAsync_Cancelled_Propagates`

### End-to-end, against the running stack

`driver.ps1 smoke --users 20 --quotes 20 --trades 60`, three consecutive runs each way, on a real
local SQL Server. `Failed` is cumulative in the table; the deltas are what matter.

**(a) Before the change — three green runs, and the damage behind them**

| | smoke says | Pending after | Completed | Failed | wallets holding locks |
|---|---|---|---|---|---|
| baseline | — | 0 | 4,963 | 4 | 0 |
| run 1 | `errors 0` ✅ | 37 | 4,963 | 4 | 30 |
| run 2 | `errors 0` ✅ | 97 | 4,963 | 4 | 33 |
| run 3 | `errors 0` ✅ | 157 | 4,963 | 4 | 33 |
| once the queue settled out (+210s) | — | 0 | 5,023 | **101** | 2 |

Three green runs produced **97 permanently failed settlements**. `Completed` did not move at all
across runs 2 and 3 — settlement was completely starved by the previous runs' doomed messages,
which is #184's second mechanism. Only 60 of the 180 trades ever settled. The market maker's
stranded collateral grew from IRT 13,464,325 / MAUA 5.66 to IRT 1,014,238,920 / MAUA 95.01.

An earlier attempt at the same three runs never got to a third: it died on

```
The DELETE statement conflicted with the REFERENCE constraint "FK_Transactions_Wallets_WalletId".
```

which is #175's FK race, reproduced on unmodified `main`.

**(b) After the change — same three runs** (re-run once the review fixes below were in)

| | smoke says | Pending after | Completed | Failed | wallets holding locks |
|---|---|---|---|---|---|
| baseline | — | 0 | 5,323 | 101 | 2 |
| run 1 | `60 settlement(s) completed, no new failures` ✅ | 0 | 5,383 | 101 | 2 |
| run 2 | `60 settlement(s) completed, no new failures` ✅ | 0 | 5,443 | 101 | 2 |
| run 3 | `60 settlement(s) completed, no new failures` ✅ | 0 | 5,503 | 101 | 2 |

`Failed` does not move. `Completed` goes up by exactly 60 per run — every trade settles, and the
driver now says so rather than only reporting the absence of failures. `Pending` is 0 when smoke
returns, so each run really is finished. The two wallets still holding locks and the 101 failures
are residue from the "before" runs above; nothing new is stranded. Cost: ~30s per run against
~12–28s before.

The smallest invocation `SKILL.md` documents (`--users 5 --quotes 1 --trades 1`) still passes:
`1 settlement(s) completed, no new failures`.

**(c) The assert actually fails — and only when it should**

Both directions were driven, using outbox messages injected with fixed ids
(`00000175-...-0001` / `-0002`, type `DeliberateFailure_Issue175Proof`) so they could be removed
again by exact id afterwards. Nothing else in the databases was written or deleted.

*A failure that happens during the run turns it red:*

```
SMOKE VERDICT: RED
  Simulation traded cleanly but 1 settlement(s) failed permanently (Failed outbox messages went
  from 102 to 103). The trades are recorded but NOT settled and their collateral is still locked.
  Inspect them at http://localhost:5140/api/outbox/unsettled.
```

The trading phase reported `errors 0` on that run — the exact green-that-was-not-green from #175 —
and the driver caught it anyway. That run's own 60 trades still settled.

*A failure that was already there does **not**.* With a doomed message sitting in the queue before
smoke starts, the pre-run drain absorbs it (`Failed` 101 to 102) and the baseline is taken after
that, so the run is green with `60 settlement(s) completed`. This is review finding 1 below; before
that fix the same scenario reported RED and blamed a run that had not started yet.

*`DataReset`'s own wait is visible in those runs:*

```
DataReset[0] Reset: 1 settlement(s) from the previous run are still queued;
             waiting for the outbox to drain before deleting anything.
             ... 144s later ...
DataReset[0] Reset: outbox drained.
```

With both injected rows removed, `Failed` was back to 101 and runs were green again.

### Environment
- [x] Tested locally on Windows against a real local SQL Server Express instance
- [ ] Tested on staging environment — no staging environment exists yet
- [ ] Feature flag — n/a

---

## Self-review (`/code-review high 185`)

Five findings, four fixed in f9d5834.

**1. `$failedBefore` was sampled before the simulator's own drain ran — fixed.** A doomed message
left over from an earlier run does not fail when it is abandoned; it fails when it exhausts its
retries, minutes later. Sampling first and draining second put that window inside the run being
measured, so the first clean run on a dirty queue reported RED for damage it had not caused —
the same misattribution the delta exists to prevent, at a different boundary. `smoke` now drains
before taking the baseline. Verified both ways, see (c) above.

**2. The FK race was narrowed, not closed — fixed.** The wait clears what is queued, but the
previous run's `Orders` survived it and were deleted *last*, and `MatchingEngineService` sweeps
every second and writes a `Trade` with its outbox message in one transaction
(`OrderMatchingRepository.cs:208`). A match landing in that window let the processor write
`Transactions` rows between `DELETE FROM Transactions` and `DELETE FROM Wallets`. `DataReset` now
deletes `Orders`/`Trades` first, removing the producer before the wallet rows go. Empirically a
clean run leaves 60 `Completed` orders with `RemainingAmount = 0` and nothing matchable, so the
window is narrow in practice — but an interrupted run does leave resting orders, and the fix is a
reorder of two existing calls. The class comment no longer claims the wait "closes both faults".

**3. The driver ignored `ConnectionStrings__OrdersDb` — fixed.** Every service layers
`AddEnvironmentVariables()` over the shared file (the #159 hotfix, d3956d6), and the simulator does
too. The driver read only the file, so with that variable set it would poll a different database
than the services write to: `Pending` would be 0 instantly and the delta always 0, and both new
assertions would pass silently — exactly the failure mode this PR exists to remove.

**4. The check was purely negative — fixed.** "Nothing failed" is not "something settled". A
regression that stops queueing settlements entirely leaves an empty queue, which drains instantly
and adds no failures, so the negative check alone would have called it green while `SKILL.md`
claimed the trades had settled. `smoke` now also requires `Completed` to have grown when the run
attempted any trades, and reports how many settled.

**5. The waits count every `Pending` row, not only the run's own — no change, and finding 1's fix
removes the consequence.** A message an operator re-drove will make the next `smoke` wait for it.
That wait is correct: resetting while a settlement is in flight is the bug being fixed here, and
"the run's own messages" is not knowable before the run starts. The reported symptom — the next
clean run then going RED — was a real problem, and it is gone: the re-driven message now fails
inside the pre-run drain and lands in the baseline, so the delta stays 0 and the run is green.
What remains is the wait itself, which is intended.

---

## Cleanup that is NOT in this PR

**The ~609 stranded messages from earlier runs need no cleanup, and #175's suggested `DELETE`
would now match zero rows.** All 609 were reviewed and `Abandoned` (`Status = 3`) on 2026-09-01
during the #174 work, with a reason recorded on each one. There are **0** rows at `Status = 2`, so

```sql
DELETE FROM OutboxMessages WHERE Status = 2 AND CreatedAt >= '2026-08-30';   -- 0 rows
```

does nothing. Deleting them at `Status = 3` instead would go against the design: per
`OutboxMessageStatus.Abandoned`, an abandoned message is *"kept (not deleted) so the record
survives for reconciliation and audit"*. Recommendation is to leave them. (The 101 failures this
PR's own before/after runs produced are a separate matter and can be abandoned the same way
whenever it suits.)

**The market maker's accumulated collateral was already released** before this work started —
every one of the 77 wallets read 0 locked at the baseline. It has since reacquired
**IRT 1,014,238,920 and MAUA 95.01** from the "before" runs above, which is the cost of
reproducing the bug. Per #184 that cleanup is separate work and abandoning messages deliberately
does not release collateral, so nothing here touches it.

---

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files — `config/appsettings.global.json` is untracked and read
      at runtime, never committed
- [x] Code compiles without warnings (`TreatWarningsAsErrors` is on)
- [x] The one SQL statement built in PowerShell is parameterized

---

## Code Quality
- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why"
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added
- [x] Scope held to the two issues — #183 has the same root cause and is deliberately untouched

---

## Documentation
- [x] `SKILL.md` for run-tallaegg updated — what a green run now proves, the drain output, the
      reset's wait, and why the check is a delta
- [x] `DataReset`'s class comment records why waiting was chosen over deleting
- [ ] Swagger/API docs — no API change

---

## Breaking Changes?
- [x] No breaking changes

A `smoke` run takes about 5–15s longer, and a queue that will not drain now stops the reset with a
`TimeoutException` instead of silently orphaning it. Both are intended.

---

## Deployment Notes

Nothing to deploy. No product code, no migration, no configuration.

**Rollback**: revert the commit. The harness returns to reporting green on unsettled runs.

---

## Related Issues
- Closes #184 — DataReset orphans the previous run's settlements
- Closes #175 — runs are not independent, and smoke reports green anyway
- Answers #175's open question about #160 (b1c0f3b) — see the section above
- #183 is the production-side form of "settlement fails, collateral stays locked", same root
  cause, deliberately out of scope here
- #39's `/api/outbox/unsettled` and `/redrive` are what the new error messages point at
