### PR TITLE
[Fix] Retry trade settlement after a lost concurrency race, like the other three wallet writes — issue #183

### DIFF
--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -206,9 +206,36 @@ public class WalletRepository : IWalletRepository
     /// wallet are not competing — a deposit and a withdrawal must both land, they simply have to
     /// land one after the other, which is what a retry gives them.
     /// </para>
+    ///
+    /// <para>
+    /// <b>The operation must not leave a transaction open when it throws.</b> The
+    /// <c>ChangeTracker.Clear()</c> above runs between attempts, which is not sound inside an open
+    /// <c>IDbContextTransaction</c>. The three wallet writes below have no transaction of their
+    /// own; <see cref="SettleTradeAsync"/> does, and opens and closes it inside the delegate so
+    /// that by the time an attempt fails there is nothing left open (issue #183).
+    /// </para>
+    /// </summary>
+    private Task<T> WithConcurrencyRetryAsync<T>(
+        Func<Task<T>> operation, string operationName, Guid userId, string asset)
+        => WithConcurrencyRetryAsync(operation, (attempt, spent) => _logger.LogWarning(
+            "Concurrent write to the {Asset} wallet of user {UserId} during {Operation}; " +
+            "retrying from a fresh read (attempt {Attempt}, {Spent}ms of {Budget}ms used).",
+            asset, userId, operationName, attempt,
+            (long)spent.TotalMilliseconds, (long)ConcurrencyRetryBudget.TotalMilliseconds));
+
+    /// <summary>
+    /// The retry loop itself, with the caller supplying its own retry log line.
+    ///
+    /// <para>
+    /// Split out for <see cref="SettleTradeAsync"/>, whose contended row is not "the {Asset} wallet
+    /// of user {UserId}" but four wallets across two users, so the wallet-shaped message above
+    /// would have had to name one of them and mislead about the rest. The budget, the floor, the
+    /// backoff and the clear are shared rather than copied: two places deciding how long a wallet
+    /// write may retry is one place too many.
+    /// </para>
     /// </summary>
     private async Task<T> WithConcurrencyRetryAsync<T>(
-        Func<Task<T>> operation, string operationName, Guid userId, string asset)
+        Func<Task<T>> operation, Action<int, TimeSpan> logRetry)
     {
         var spent = Stopwatch.StartNew();
         var backoff = InitialConcurrencyDelay;
@@ -233,11 +260,7 @@ public class WalletRepository : IWalletRepository
 
                 _context.ChangeTracker.Clear();
 
-                _logger.LogWarning(
-                    "Concurrent write to the {Asset} wallet of user {UserId} during {Operation}; " +
-                    "retrying from a fresh read (attempt {Attempt}, {Spent}ms of {Budget}ms used).",
-                    asset, userId, operationName, attempt,
-                    (long)spent.Elapsed.TotalMilliseconds, (long)ConcurrencyRetryBudget.TotalMilliseconds);
+                logRetry(attempt, spent.Elapsed);
 
                 await Task.Delay(delay);
                 backoff += backoff;
@@ -540,6 +563,75 @@ public class WalletRepository : IWalletRepository
         var buyerReceivesBase = quantity;      // no fee is deducted while fees are disabled
         var sellerReceivesQuote = quoteQuantity;
 
+        // Settlement is the wallet's fourth write, and until #183 the only one that did not retry
+        // after losing an optimistic-concurrency race. It writes four wallet rows, four transaction
+        // rows and the settlement row in one SaveChanges, so its window for losing is the widest of
+        // the four — and the market maker is the counterparty to every quote fill, so those rows are
+        // the whole shop's hot row (the same cause as #174). Measured before this change: 27 losses
+        // in 327 settlement attempts, each costing 14-15s of delay before the outbox redelivered.
+        //
+        // The retry is per *transaction*, not per save: each attempt opens its own transaction,
+        // re-reads the four wallets and rebuilds every row from what it finds. That is what makes
+        // it safe to hand to WithConcurrencyRetryAsync, whose ChangeTracker.Clear() between
+        // attempts would not be sound inside a transaction this method had left open.
+        //
+        // What does NOT change is the guarantee. The TradeSettlements primary key is still what
+        // makes settlement exactly-once, the fast path above is still only an optimisation, and the
+        // duplicate-key branch still *returns* success rather than throwing — so a settlement that
+        // another caller already committed ends the loop instead of becoming a second attempt at
+        // moving the money (issue #42).
+        try
+        {
+            return await WithConcurrencyRetryAsync(
+                () => SettleTradeOnceAsync(
+                    tradeId, buyerUserId, sellerUserId, symbol!, baseAsset, quoteAsset,
+                    quantity, quoteQuantity, buyerReceivesBase, sellerReceivesQuote, referenceId),
+                (attempt, spent) => _logger.LogWarning(
+                    "Concurrent write while settling trade {TradeId} on {Symbol}; " +
+                    "retrying from a fresh read (attempt {Attempt}, {Spent}ms of {Budget}ms used).",
+                    tradeId, symbol, attempt,
+                    (long)spent.TotalMilliseconds, (long)ConcurrencyRetryBudget.TotalMilliseconds));
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Warning, and no stack trace, because nothing is wrong: the trade is recorded, the
+            // collateral is locked, and the outbox redelivers a settlement that reports failure.
+            // This used to fall into the generic handler below and be logged at Error with a full
+            // EF stack trace, which reads as a fault and has cost more than one investigation of a
+            // perfectly healthy trade. The lock path has reported a lost race this way all along.
+            _logger.LogWarning(
+                "Settlement of trade {TradeId} on {Symbol} kept losing the optimistic-concurrency " +
+                "race for its whole {Budget}ms budget; leaving it to the outbox to redeliver.",
+                tradeId, symbol, (long)ConcurrencyRetryBudget.TotalMilliseconds);
+
+            // The message the outbox has always seen for a refused settlement, unchanged.
+            return (false, "Settlement error");
+        }
+    }
+
+    /// <summary>
+    /// One attempt at settling a trade: its own transaction, its own reads, its own rows.
+    ///
+    /// <para>
+    /// Split from <see cref="SettleTradeAsync"/> so the whole attempt can be re-run by
+    /// <c>WithConcurrencyRetryAsync</c>. Every value the attempt derives from the database — the
+    /// four wallets, the <c>BallanceBefore</c> on each of the four transaction rows, the locked
+    /// collateral the guards below check — is read inside this method, so a retry recomputes them
+    /// from the row as the winning writer left it rather than from the stale one it first saw.
+    /// </para>
+    ///
+    /// <para>
+    /// It throws <see cref="DbUpdateConcurrencyException"/> rather than absorbing it, and rolls the
+    /// transaction back before it does, so the caller's retry never runs with a transaction open.
+    /// </para>
+    /// </summary>
+    private async Task<(bool Success, string Message)> SettleTradeOnceAsync(
+        Guid tradeId, Guid buyerUserId, Guid sellerUserId,
+        string symbol, string baseAsset, string quoteAsset,
+        decimal quantity, decimal quoteQuantity,
+        decimal buyerReceivesBase, decimal sellerReceivesQuote,
+        string referenceId)
+    {
         await using var tx = await _context.Database.BeginTransactionAsync();
         try
         {
@@ -645,6 +737,18 @@ public class WalletRepository : IWalletRepository
                 tradeId);
 
             return (true, "Trade already settled.");
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // A different writer changed one of the four wallets between this attempt's read and
+            // its save. Roll back first, so the caller's ChangeTracker.Clear() does not run inside
+            // an open transaction, then let it through to be retried from a fresh read.
+            //
+            // Ordered after the duplicate-key branch deliberately, to leave that branch's
+            // precedence exactly as it was: a save that fails on the TradeSettlements key is
+            // settled, not contended, and must still report success without moving money.
+            await tx.RollbackAsync();
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -592,14 +592,21 @@ public class WalletRepository : IWalletRepository
                     tradeId, symbol, attempt,
                     (long)spent.TotalMilliseconds, (long)ConcurrencyRetryBudget.TotalMilliseconds));
         }
-        catch (DbUpdateConcurrencyException)
+        catch (DbUpdateConcurrencyException ex)
         {
-            // Warning, and no stack trace, because nothing is wrong: the trade is recorded, the
-            // collateral is locked, and the outbox redelivers a settlement that reports failure.
-            // This used to fall into the generic handler below and be logged at Error with a full
-            // EF stack trace, which reads as a fault and has cost more than one investigation of a
-            // perfectly healthy trade. The lock path has reported a lost race this way all along.
-            _logger.LogWarning(
+            // Warning rather than Error: the trade is recorded, the collateral is locked, and the
+            // outbox redelivers a settlement that reports failure, so nothing here is a fault. This
+            // used to fall into the generic handler below and be logged at Error, which reads as
+            // one and has cost more than one investigation of a perfectly healthy trade. The lock
+            // path has reported a lost race at Warning all along.
+            //
+            // The exception is kept even so. DbUpdateConcurrencyException is also what EF raises
+            // when an UPDATE matches no row at all — a wallet deleted out from under a queued
+            // settlement, say — and that fails identically on every attempt and every one of the
+            // outbox's five deliveries. Dropping it would leave the operator reading SETTLEMENT
+            // STUCK with nothing on the wallet side to explain it. Rare enough now (0 in 300
+            // settlements) that its stack trace is not the noise this change set out to remove.
+            _logger.LogWarning(ex,
                 "Settlement of trade {TradeId} on {Symbol} kept losing the optimistic-concurrency " +
                 "race for its whole {Budget}ms budget; leaving it to the outbox to redeliver.",
                 tradeId, symbol, (long)ConcurrencyRetryBudget.TotalMilliseconds);
@@ -632,6 +639,22 @@ public class WalletRepository : IWalletRepository
         decimal buyerReceivesBase, decimal sellerReceivesQuote,
         string referenceId)
     {
+        // The same fast path SettleTradeAsync opens with, repeated here because this method can run
+        // more than once. If a competing caller settled this trade between two attempts, it has
+        // already consumed both sides' locked collateral — so without this check the retry reads
+        // LockedBalance as 0, the guards below fire first, and a settled trade is reported as
+        // "Buyer locked IRT (0) is less than required (1000)": the signature of the lock-after-match
+        // defect (audit C-5), for a trade that is in fact perfectly settled.
+        //
+        // Still an optimisation and still not the guarantee. Two callers can pass it together; the
+        // TradeSettlements primary key below is what decides, and the duplicate-key branch is what
+        // reports the outcome when they do.
+        if (await _context.TradeSettlements.AnyAsync(s => s.TradeId == tradeId))
+        {
+            _logger.LogInformation("Trade {TradeId} already settled; skipping (idempotent).", tradeId);
+            return (true, "Trade already settled.");
+        }
+
         await using var tx = await _context.Database.BeginTransactionAsync();
         try
         {

--- a/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletConcurrencyTests.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Core.Enums.Wallet;
 using Wallet.Core;
@@ -330,6 +331,211 @@ public class WalletConcurrencyTests : IDisposable
         // Nothing was locked: the operation failed whole rather than half-applying.
         await using var check = NewContext();
         Assert.Equal(0m, (await check.Wallets.SingleAsync(w => w.Id == seeded.Id)).LockedBalance);
+    }
+
+    // ── Settlement's retry (issue #183) ─────────────────────────────────────────
+
+    private const string SettlementBase = "MAUA";
+    private const string SettlementQuote = "IRT";
+    private const decimal SettlementQuantity = 2m;
+    private const decimal SettlementQuoteQuantity = 1000m;
+
+    /// <summary>
+    /// The four wallets a settlement touches, with each side's collateral already locked — the
+    /// state <c>LockBalanceAsync</c> leaves behind at order time and settlement's guards require.
+    /// <c>LockedBalance</c> is assigned rather than moved through <c>LockBalance</c> so the seeding
+    /// states the starting position outright, as <c>SettlementSurvivesReferenceIndexTests</c> does.
+    /// </summary>
+    private async Task<(Guid Buyer, Guid Seller)> SeedSettlementWalletsAsync()
+    {
+        var buyer = Guid.NewGuid();
+        var seller = Guid.NewGuid();
+
+        await using var context = NewContext();
+
+        void Seed(Guid userId, string asset, decimal locked)
+        {
+            var wallet = WalletEntity.Create(userId, asset);
+            wallet.LockedBalance = locked;
+            context.Wallets.Add(wallet);
+        }
+
+        Seed(buyer, SettlementQuote, SettlementQuoteQuantity);  // the buyer's collateral
+        Seed(buyer, SettlementBase, 0m);
+        Seed(seller, SettlementBase, SettlementQuantity);       // the seller's collateral
+        Seed(seller, SettlementQuote, 0m);
+
+        await context.SaveChangesAsync();
+        return (buyer, seller);
+    }
+
+    private Task<(bool Success, string Message)> SettleAsync(
+        WalletRepository repository, Guid tradeId, Guid buyer, Guid seller) =>
+        repository.SettleTradeAsync(
+            tradeId, buyer, seller, $"{SettlementBase}/{SettlementQuote}",
+            SettlementQuantity, SettlementQuoteQuantity, 0m, 0m);
+
+    /// <summary>
+    /// Settlement was the one wallet write with no retry: a lost race escaped to the outbox, which
+    /// redelivered it 14-15 seconds later, and five consecutive losses would have stranded a
+    /// recorded trade with its collateral locked. It now retries like the other three.
+    ///
+    /// <para>
+    /// The collision is raised rather than raced. A real competing writer would need a second
+    /// connection, and it could not take a write lock while this attempt's own transaction is open
+    /// — so the deterministic version is also the only one available here, which suits: a test that
+    /// depended on thread timing would be the very flake this line of work is about.
+    /// </para>
+    ///
+    /// <para>
+    /// The leg count is the assertion that matters most. Four transaction rows and one settlement
+    /// row mean the discarded attempt left nothing behind: had the retry rebuilt its rows on top of
+    /// the ones still tracked from the first attempt, this would be eight and a duplicate insert.
+    /// That is what <c>ChangeTracker.Clear()</c> between attempts is for.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task SettleTradeAsync_LosesTheRace_IsRetriedAndSettlesExactlyOnce()
+    {
+        var (buyer, seller) = await SeedSettlementWalletsAsync();
+        var tradeId = Guid.NewGuid();
+        var saves = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            if (++saves == 1)
+                throw new DbUpdateConcurrencyException(
+                    "another writer changed one of the four wallets between the read and the save");
+        };
+
+        var repository = NewRepository(context);
+        var (success, message) = await SettleAsync(repository, tradeId, buyer, seller);
+
+        Assert.True(success, message);
+        Assert.Equal("Trade settled.", message);
+        Assert.Equal(2, saves);  // it lost the first attempt and came back for a second
+
+        await using var check = NewContext();
+
+        Assert.Equal(1, await check.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
+        Assert.Equal(4, await check.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
+
+        // The money moved once, and only once: each side's collateral consumed, each side credited.
+        var buyerQuote = await check.Wallets.SingleAsync(w => w.UserId == buyer && w.Asset == SettlementQuote);
+        var buyerBase = await check.Wallets.SingleAsync(w => w.UserId == buyer && w.Asset == SettlementBase);
+        var sellerBase = await check.Wallets.SingleAsync(w => w.UserId == seller && w.Asset == SettlementBase);
+        var sellerQuote = await check.Wallets.SingleAsync(w => w.UserId == seller && w.Asset == SettlementQuote);
+
+        Assert.Equal(0m, buyerQuote.LockedBalance);
+        Assert.Equal(SettlementQuantity, buyerBase.Balance);
+        Assert.Equal(0m, sellerBase.LockedBalance);
+        Assert.Equal(SettlementQuoteQuantity, sellerQuote.Balance);
+    }
+
+    /// <summary>
+    /// The trap the retry had to be built around (issue #42). Losing the race on the
+    /// <c>TradeSettlements</c> primary key means somebody else already settled this trade, and that
+    /// is reported as success — so adding a retry must not turn it into a second go at moving the
+    /// money. It does not: that branch <b>returns</b> rather than throwing, which ends the loop.
+    ///
+    /// <para>
+    /// <c>saves == 1</c> is the whole point of the test. The balances are asserted alongside it
+    /// because a second attempt that somehow ran would show up there as collateral consumed twice.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task SettleTradeAsync_LosesTheRaceOnTheSettlementKey_ReportsSuccessWithoutRetrying()
+    {
+        var (buyer, seller) = await SeedSettlementWalletsAsync();
+        var tradeId = Guid.NewGuid();
+        var saves = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            saves++;
+
+            // The shape EF raises when the primary key rejects this settlement's insert because
+            // another caller committed the same trade first: the only entity in the failed save is
+            // the TradeSettlement, which is exactly what IsDuplicateSettlement keys off.
+            var settlement = context.ChangeTracker.Entries<TradeSettlement>().Single();
+            throw new DbUpdateException(
+                "duplicate TradeSettlements key", new[] { (EntityEntry)settlement });
+        };
+
+        var repository = NewRepository(context);
+        var (success, message) = await SettleAsync(repository, tradeId, buyer, seller);
+
+        Assert.True(success, message);
+        Assert.Equal("Trade already settled.", message);
+        Assert.Equal(1, saves);
+
+        await using var check = NewContext();
+
+        // This attempt moved nothing: no legs written, and both sides' collateral still locked
+        // exactly as it was, waiting on the settlement that actually won.
+        Assert.Equal(0, await check.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
+        Assert.Equal(SettlementQuoteQuantity,
+            (await check.Wallets.SingleAsync(w => w.UserId == buyer && w.Asset == SettlementQuote)).LockedBalance);
+        Assert.Equal(SettlementQuantity,
+            (await check.Wallets.SingleAsync(w => w.UserId == seller && w.Asset == SettlementBase)).LockedBalance);
+    }
+
+    /// <summary>
+    /// The budget has to end settlement's loop as well as extend it, and what it hands back when it
+    /// does must be the failure the outbox already knows how to handle — not an exception, and not
+    /// a half-applied trade.
+    ///
+    /// <para>
+    /// <c>"Settlement error"</c> is asserted verbatim: the outbox turns a false result into
+    /// <c>Wallet settlement rejected: {message}</c> and reschedules, so this string is the contract
+    /// between the two services rather than an internal detail.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task SettleTradeAsync_NeverWinsTheRace_LeavesTheTradeToTheOutbox()
+    {
+        var (buyer, seller) = await SeedSettlementWalletsAsync();
+        var tradeId = Guid.NewGuid();
+        var attempts = 0;
+
+        await using var context = new CollidingContext(
+            new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options);
+
+        context.BeforeSave = () =>
+        {
+            attempts++;
+            throw new DbUpdateConcurrencyException("a competing writer wins the row every time");
+        };
+
+        var repository = NewRepository(context);
+        var elapsed = Stopwatch.StartNew();
+
+        var (success, message) = await SettleAsync(repository, tradeId, buyer, seller);
+
+        elapsed.Stop();
+
+        Assert.False(success);
+        Assert.Equal("Settlement error", message);
+        Assert.True(attempts > 3, $"the budget bought only {attempts} attempts, no more than the old cap");
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(30),
+            $"the retry loop ran for {elapsed.Elapsed} and is not bounded");
+
+        // The trade is simply unsettled, which is the state the outbox redelivers into: nothing
+        // recorded, nothing moved, and both sides' collateral still locked for the next attempt.
+        await using var check = NewContext();
+
+        Assert.Equal(0, await check.TradeSettlements.CountAsync(s => s.TradeId == tradeId));
+        Assert.Equal(0, await check.Transactions.CountAsync(t => t.ReferenceId == tradeId.ToString()));
+        Assert.Equal(SettlementQuoteQuantity,
+            (await check.Wallets.SingleAsync(w => w.UserId == buyer && w.Asset == SettlementQuote)).LockedBalance);
+        Assert.Equal(SettlementQuantity,
+            (await check.Wallets.SingleAsync(w => w.UserId == seller && w.Asset == SettlementBase)).LockedBalance);
     }
 
     // ── The counter's one weakness ──────────────────────────────────────────────


### PR DESCRIPTION
**Branch Name**: `fix/settlement-concurrency-retry`
**Linked Issue**: closes #183

## Description

`WalletRepository.SettleTradeAsync` was the only wallet write with no concurrency retry.
`LockBalanceAsync`, `UnlockBalanceAsync` and `IncreaseBalanceForTradeAsync` all run inside
`WithConcurrencyRetryAsync`; settlement did not. A lost optimistic-concurrency race therefore
returned `Settlement error` to the outbox, which redelivered the message **14–15 seconds** later
and logged a full EF stack trace at `Error` on the way past. Nothing was ever lost — the outbox is
the safety net and settlement is idempotent on the trade id — but a perfectly healthy trade read as
a fault, and five consecutive losses would have marked the message `Failed` with its collateral
still locked, needing an operator.

The reason it was left out of #182 was real: `WithConcurrencyRetryAsync` calls
`ChangeTracker.Clear()` between attempts, and that is not sound inside the `IDbContextTransaction`
settlement opens. **The transaction is now per attempt rather than per call.** `SettleTradeOnceAsync`
owns it, rolls it back before letting a `DbUpdateConcurrencyException` through, and the next attempt
re-reads the four wallets and rebuilds all nine rows from what it finds.

## Type of Change

- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

## Changes Made

- `WalletRepository.SettleTradeOnceAsync` — the transaction-owning body of `SettleTradeAsync`, split
  out unchanged so the whole attempt can be re-run. It gains one `catch
  (DbUpdateConcurrencyException)` that rolls back and rethrows.
- `WalletRepository.SettleTradeAsync` — its pre-flight validation is unchanged and still runs once;
  it now calls `SettleTradeOnceAsync` through `WithConcurrencyRetryAsync`.
- `WithConcurrencyRetryAsync` split into the loop plus a `logRetry` callback. **The existing 4-argument
  overload keeps its exact signature and its log text**, so the three current callers are untouched
  and `retrying from a fresh read` still greps (the promise #182 made). Settlement supplies its own
  line because its contended row is four wallets across two users, not "the {Asset} wallet of user
  {UserId}".
- A concurrency loss that spends the whole budget is now logged at **Warning** naming the trade and
  the budget, instead of falling into the generic handler as `Error settling trade`. The exception is
  kept on that warning (see the review round below). The generic `Error` handler is unchanged and
  still fires for real faults.
- `WalletConcurrencyTests` — three tests through the existing `CollidingContext`.

## What deliberately did NOT change

This is settlement, so the list of things left alone matters as much as the change:

- **The exactly-once guarantee.** The `TradeSettlements` primary key still decides it. The `AnyAsync`
  check is still only an optimisation and never the guarantee, exactly as issue #42 requires — it now
  also runs per attempt, for the reason the review round below gives.
- **The duplicate-key branch `returns` rather than throws**, so it ends the retry loop instead of
  becoming a second attempt at moving money. This was the specific risk of adding a retry here, and
  it is what `SettleTradeAsync_LosesTheRaceOnTheSettlementKey_ReportsSuccessWithoutRetrying` pins.
- **Every guard, amount, message and ordering.** The collateral guards, the self-trade guard, the
  fee guard, the four legs and their `BallanceBefore`, and both return strings are byte-identical.
  `"Settlement error"` in particular is the contract the outbox reads.
- **The budget itself.** Settlement reuses `ConcurrencyRetryBudget` (2s), `MinimumConcurrencyAttempts`
  and the jittered backoff rather than declaring its own. Two places deciding how long a wallet write
  may retry is one place too many. It fits comfortably inside both bounds around it: the Orders→Wallet
  `HttpClient` has no custom timeout (100s default) and the outbox lease is 2 minutes.

## The two numbers

`driver.ps1 smoke --users 20 --quotes 20 --trades 60`, **five cold runs each way** (`stop` + `start`
before every run), 300 trades per side. The outbox is drained around every run — since #185
`driver.ps1 smoke` does that itself, and without it a run with a backlog does not settle at all
during the run and proves nothing (#183 warns about exactly this).

| | before | after |
|---|---|---|
| settlement conflicts that **escaped** to the outbox | **27** | **0** |
| conflicts absorbed in process instead | 0 | 8 |
| settlement attempts for 300 trades | 327 | **300** (one each) |
| outbox messages retried at least once (from the DB) | 38 | **0** |
| `Error settling trade` + EF stack trace | 27 | **0** |
| permanently `Failed` / `SETTLEMENT STUCK` | 0 | 0 |
| trades settled | 300 / 300 | 300 / 300 |
| lock-path collisions | 18 | 19 |

Per run, before: 6, 6, 5, 5, 5 conflicts. After: 0, 0, 0, 0, 0, with 1, 0, 2, 3, 2 absorbed instead.

**Lock-path collisions went up, not down (18 → 19)**, which is the fingerprint that matters: the
machine was not quieter during the "after" runs, so the settlement conflicts did not disappear
because contention did. The `327 → 300` attempt count is the same fact from the other side — before,
27 of those attempts were redeliveries of a settlement that had already done the work once and
thrown it away.

The measured cost of a single loss, from the wallet log of a "before" run, matching each
`Error settling trade` to the `Settled trade` for the same trade id:

```
21172d8c  conflict 13:52:10 -> settled 13:52:25  (+15s)
7c8dc140  conflict 13:52:10 -> settled 13:52:25  (+15s)
41f14c57  conflict 13:52:11 -> settled 13:52:25  (+14s)
8bb95da7  conflict 13:52:11 -> settled 13:52:26  (+15s)
ecbdbc16  conflict 13:52:12 -> settled 13:52:26  (+14s)
```

14–15s, not the 10s `BaseRetryDelay` alone: the backoff is followed by the next 5s poll tick.

## Testing Completed

### Unit Tests

```
dotnet build TallaEgg.sln --configuration Release  -> Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test  TallaEgg.sln --configuration Release  -> Passed! Failed: 0, Passed: 679, Skipped: 0
```

All three new tests drive `CollidingContext`, so the collisions are deterministic. A real competing
writer is not available here anyway: it would need a second connection, and it could not take a
write lock while the attempt's own transaction is open.

| test | covers | fails without this change? |
|---|---|---|
| `SettleTradeAsync_LosesTheRace_IsRetriedAndSettlesExactlyOnce` | the retry, and that the discarded attempt leaves nothing behind — **4 transaction legs and 1 settlement row, not 8 and a duplicate** | **yes** — old code returns `(false, "Settlement error")` |
| `SettleTradeAsync_NeverWinsTheRace_LeavesTheTradeToTheOutbox` | the budget ends the loop, hands back `"Settlement error"`, and leaves the trade unsettled with collateral intact | **yes** — old code makes 1 attempt, not >3 |
| `SettleTradeAsync_LosesTheRaceOnTheSettlementKey_ReportsSuccessWithoutRetrying` | issue #42: the duplicate-key path still reports success, moves no money, and **does not retry** | **no, by design** — it is a guard on behaviour this change must not break, not a regression test |

Verified by stashing the `WalletRepository` change and re-running: 2 failed, 1 passed, as above.

### Integration

Driven end to end through `driver.ps1` (real handlers, real APIs, real SQL Server), 60 fills per
run, 10 runs total. Database afterwards, scoped to the measurement window:

| check | before | after |
|---|---|---|
| outbox messages in window, all `Completed` | 360 | 300 |
| permanently `Failed` in window | 0 | 0 |
| outbox rows with `RetryCount > 0` | 38 | **0** |
| trades in window with no completed settlement | 0 | 0 |
| duplicate `TradeSettlements.TradeId` | 0 | 0 |
| negative `LockedBalance` | 0 | 0 |
| balance vs latest transaction's `BallanceAfter` | 39 wallets, 0 mismatched | 39 wallets, 0 mismatched |
| legs per settlement, last run | 60 × 4 | 60 × 4 |
| market maker's locked collateral | IRT 1,014,238,920 / MAUA 95.01 | **identical** |

The market maker's `LockedBalance` being byte-identical across ten runs is the collateral-leak check:
these runs stranded none. The figure itself is old residue from work that predates this branch — that
account has a positive `TelegramId`, so `DataReset` never clears it.

Two measurement notes, both harness artifacts rather than findings:

- Settlements from **earlier** runs show 2 transaction legs instead of 4. `DataReset` deletes the
  `Transactions` of `TelegramId < 0` wallets while `TradeSettlements` is never deleted, so only the
  two market-maker legs survive. Leg count is therefore only meaningful for the most recent run.
- The measurement script's own `SmokeFailed` column reads `True` on every row. `driver.ps1` prints its
  success line with `Write-Host`, which is not on the output stream the script captured. All ten runs
  were green; the driver's own output says
  `Simulation completed with errors 0; 60 settlement(s) completed, no new failures.` ten times.

### Environment

- [x] Tested locally on Windows
- [ ] Tested on staging environment (no staging exists yet — `STANDARDS.md` §7)

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] Code compiles without warnings (`TreatWarningsAsErrors` is on)

## Code Quality

- [x] Follows `STANDARDS.md`; new tests use `Method_Scenario_ExpectedResult`
- [x] Comments in English, explaining the "why"
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added

## Breaking Changes?

- [x] No breaking changes

No API, schema, configuration or customer-facing text changes. The only behaviour change is that a
settlement that loses a race retries in process for up to 2s before handing back the same failure it
handed back immediately before.

## Deployment Notes

No migration, no configuration, no feature flag.

**Rollback**: revert the commit. Settlement stops retrying and lost races go back to costing 14–15s
and an `Error` trace each.

## Review round (`/code-review high`, commit `d84b1cb`)

Two findings, both accepted and fixed.

**1. A retry re-ran the collateral guards without re-checking `TradeSettlements`.**
If a competing caller settled the same trade between two attempts, it had already consumed both
sides' locked collateral — so the retry read `LockedBalance` as `0`, the guards fired *before* the
duplicate-key branch could be reached, and a settled trade was reported as
`Buyer locked IRT (0) is less than required (1000)`. That is the signature of the lock-after-match
defect (audit C-5), for a trade that is in fact perfectly settled. The outbox still recovered on its
next delivery through the outer fast path, so no money was at risk, but the message was misleading
and the delay unnecessary. This is a window the retry itself opened, so it belongs to this change.

`SettleTradeOnceAsync` now opens with the same check `SettleTradeAsync` does. It stays an
optimisation and not the guarantee — two callers can pass it together, the primary key decides, and
the duplicate-key branch reports the outcome when they do.

**2. The exhausted-budget warning dropped its exception.**
`DbUpdateConcurrencyException` also covers an UPDATE that matched no row at all — a wallet deleted
out from under a queued settlement, say — which fails identically on every attempt and on every one
of the outbox's five deliveries, and would have reached an operator as `SETTLEMENT STUCK` with
nothing on the wallet side to explain it. The level stays `Warning`, so the false alarm this PR
removes stays removed; only the diagnostic comes back.

### Re-measured after the fixes

The 5-run table above was measured on `21066e9`. Three further cold runs on `d84b1cb`, same
conditions, 180 trades:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| settlement conflicts escaping to the outbox | 0 | 0 | 0 |
| conflicts absorbed in process | 3 | 4 | 4 |
| settlement attempts (60 trades each) | 60 | 60 | 60 |
| `Error settling trade` | 0 | 0 | 0 |
| trades settled | 60 | 60 | 60 |

Database over those three runs: 180 outbox messages, **all `Completed`**, 0 `Failed`, **0 with
`RetryCount > 0`**, 0 trades without a completed settlement, 0 duplicate `TradeSettlements.TradeId`,
0 negative `LockedBalance`, 39 wallets with 0 balance/`BallanceAfter` mismatches, the 60 most recent
settlements all carrying exactly 4 legs, and the market maker's locked collateral still
IRT 1,014,238,920 / MAUA 95.01 — unchanged across all thirteen runs in this PR.

### One thing not covered by a test

The re-check in finding 1 has **no dedicated test**. Reproducing the interleaving needs a second
writer committing between two attempts, and a second connection cannot take a write lock while the
attempt's own transaction is open — the same constraint noted above. Every alternative was either
timing-dependent (the flake this whole line of work is about) or required moving these tests off
`DataSource=:memory:` onto WAL-mode file SQLite, which is more new test machinery than the eight
lines it would pin. What *is* covered is that the re-check does not disturb the normal or
duplicate paths: all 679 tests pass, including the three above.

## Related Issues

- Closes #183
- Same root cause as #174 / #182 (the market maker is the counterparty to every quote fill, so its
  wallet rows are the whole shop's hot row). #182 raised the settlement-side conflict rate on purpose;
  this closes the gap on the side that absorbed it.
- Preserves the guarantee added by #42 (`TradeSettlements` primary key)
- Measurement method depends on the outbox drain from #185 (#184, #175)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
