### PR TITLE
[Fix] ASPNETCORE_URLS, --urls and the bot's command line now reach the host — issue #181

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -75,6 +75,12 @@ public class Program
 
                 configBuilder.AddInMemoryCollection(flattened);
                 configBuilder.AddEnvironmentVariables();
+
+                // Host.CreateDefaultBuilder(args) registers a command-line provider among its
+                // defaults, which run before this callback — so the shared file outranked
+                // --Key=value, the same defect #159 fixed in the five APIs. Re-registered here
+                // beside the environment, which was already in the right place (issue #181).
+                configBuilder.AddCommandLine(args);
             })
             .ConfigureServices((context, services) =>
             {

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -50,8 +50,12 @@ builder.Configuration.AddCommandLine(args);
 // نمادهای معاملاتی از appsettings.global.json (بخش Symbols) — نه پیش‌فرض‌های کامپایل‌شده.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
+// UseUrls writes through UseSetting, which bypasses the configuration providers entirely, so
+// calling it unconditionally let the file's address beat ASPNETCORE_URLS and --urls however the
+// providers were ordered — the one override #159 could not reach. The file now supplies the
+// listen address only when the host has not already named one (issue #181).
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
-if (urls is { Length: > 0 })
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]) && urls is { Length: > 0 })
 {
     builder.WebHost.UseUrls(urls);
 }

--- a/src/Affiliate/Affiliate.Api/Properties/launchSettings.json
+++ b/src/Affiliate/Affiliate.Api/Properties/launchSettings.json
@@ -5,8 +5,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:60811;http://localhost:60812"
+      }
     }
   }
 }

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -66,8 +66,12 @@ builder.Configuration.AddCommandLine(args);
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
+// UseUrls writes through UseSetting, which bypasses the configuration providers entirely, so
+// calling it unconditionally let the file's address beat ASPNETCORE_URLS and --urls however the
+// providers were ordered — the one override #159 could not reach. The file now supplies the
+// listen address only when the host has not already named one (issue #181).
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
-if (urls is { Length: > 0 })
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]) && urls is { Length: > 0 })
 {
     builder.WebHost.UseUrls(urls);
 }

--- a/src/Order/Orders.Api/Properties/launchSettings.json
+++ b/src/Order/Orders.Api/Properties/launchSettings.json
@@ -5,7 +5,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5140",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +13,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7140;http://localhost:5140",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -54,8 +54,12 @@ builder.Configuration.AddCommandLine(args);
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
+// UseUrls writes through UseSetting, which bypasses the configuration providers entirely, so
+// calling it unconditionally let the file's address beat ASPNETCORE_URLS and --urls however the
+// providers were ordered — the one override #159 could not reach. The file now supplies the
+// listen address only when the host has not already named one (issue #181).
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
-if (urls is { Length: > 0 })
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]) && urls is { Length: > 0 })
 {
     builder.WebHost.UseUrls(urls);
 }

--- a/src/TallaEgg/TallaEgg.Api/Properties/launchSettings.json
+++ b/src/TallaEgg/TallaEgg.Api/Properties/launchSettings.json
@@ -12,7 +12,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7296;http://localhost:5135",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -65,8 +65,12 @@ builder.Configuration.AddCommandLine(args);
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
+// UseUrls writes through UseSetting, which bypasses the configuration providers entirely, so
+// calling it unconditionally let the file's address beat ASPNETCORE_URLS and --urls however the
+// providers were ordered — the one override #159 could not reach. The file now supplies the
+// listen address only when the host has not already named one (issue #181).
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
-if (urls is { Length: > 0 })
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]) && urls is { Length: > 0 })
 {
     builder.WebHost.UseUrls(urls);
 }

--- a/src/User/Users.Api/Properties/launchSettings.json
+++ b/src/User/Users.Api/Properties/launchSettings.json
@@ -5,8 +5,7 @@
       "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:5136"
+      }
     }
   }
 }

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -61,8 +61,12 @@ builder.Configuration.AddCommandLine(args);
 // Trading symbols come from appsettings.global.json (Symbols section), not compiled-in defaults.
 TallaEgg.Core.CurrenciesConstant.Configure(builder.Configuration);
 
+// UseUrls writes through UseSetting, which bypasses the configuration providers entirely, so
+// calling it unconditionally let the file's address beat ASPNETCORE_URLS and --urls however the
+// providers were ordered — the one override #159 could not reach. The file now supplies the
+// listen address only when the host has not already named one (issue #181).
 var urls = serviceSection.GetSection("Urls").Get<string[]>();
-if (urls is { Length: > 0 })
+if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]) && urls is { Length: > 0 })
 {
     builder.WebHost.UseUrls(urls);
 }

--- a/src/Wallet/Wallet.Api/Properties/launchSettings.json
+++ b/src/Wallet/Wallet.Api/Properties/launchSettings.json
@@ -5,8 +5,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:60932;http://localhost:60933"
+      }
     }
   }
 }

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -23,6 +26,17 @@ namespace TallaEgg.AllServices.Tests;
 /// <see cref="EveryHost_RegistersTheEnvironment_AfterTheSharedFile"/> is what makes the reordering
 /// fail, by reading the host files themselves. Neither half is worth much without the other.
 /// </para>
+///
+/// <para>
+/// <b>The two places provider order could not reach (#181).</b> An API host called
+/// <c>UseUrls</c> with the file's value unconditionally, and <c>UseUrls</c> writes through
+/// <c>UseSetting</c>, which bypasses the provider chain — so the file beat <c>ASPNETCORE_URLS</c>
+/// and <c>--urls</c> however the providers were ordered, and a service came up somewhere other
+/// than where the host had told it to, without saying so. The bot, meanwhile, had the environment
+/// in the right place but not the command line, which <c>Host.CreateDefaultBuilder(args)</c>
+/// registers among the defaults, before the shared file. Both are covered below, in the same two
+/// halves.
+/// </para>
 /// </summary>
 public class ConfigurationPrecedenceTests
 {
@@ -40,6 +54,23 @@ public class ConfigurationPrecedenceTests
         "src/TallaEgg/TallaEgg.Api/Program.cs",
         "src/Affiliate/Affiliate.Api/Program.cs",
     };
+
+    /// <summary>
+    /// The hosts whose configuration a command-line provider feeds: the five APIs, and the bot
+    /// since #181.
+    ///
+    /// <para>
+    /// The simulator is deliberately absent. It builds a bare <c>ConfigurationBuilder</c> and
+    /// parses its own <c>--users</c>/<c>--trades</c> switches in <c>SimulationOptions.FromArgs</c>,
+    /// which a command-line configuration provider has no part in.
+    /// </para>
+    /// </summary>
+    public static TheoryData<string> CommandLineHosts()
+    {
+        var hosts = ApiHosts();
+        hosts.Add("TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs");
+        return hosts;
+    }
 
     /// <summary>
     /// Every host that reads the shared file, including the bot and the simulator — which had the
@@ -128,6 +159,68 @@ public class ConfigurationPrecedenceTests
     }
 
     /// <summary>
+    /// The first half of #181. <c>ASPNETCORE_URLS</c> is the spelling a deployment script, a
+    /// service definition or a container image reaches for, and it did nothing at all: the file's
+    /// address was applied unconditionally through <c>UseUrls</c>, so the service started,
+    /// reported healthy, and listened somewhere other than where it had been told.
+    /// </summary>
+    [Fact]
+    public void AspNetCoreUrls_OutranksTheConfiguredUrls()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var hostAddress = new EnvironmentVariable("ASPNETCORE_URLS", "http://localhost:61001");
+
+        Assert.Equal("http://localhost:61001", ResolveListenAddressLikeAnApiHost(sharedFile));
+    }
+
+    /// <summary>
+    /// The same through the switch. It reaches the host by a different provider than the
+    /// environment does, and both land on <see cref="WebHostDefaults.ServerUrlsKey"/>, which is
+    /// what the guard reads.
+    /// </summary>
+    [Fact]
+    public void UrlsSwitch_OutranksTheConfiguredUrls()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var noHostAddress = new EnvironmentVariable("ASPNETCORE_URLS", null);
+
+        var listenAddress = ResolveListenAddressLikeAnApiHost(
+            sharedFile, args: new[] { "--urls", "http://localhost:61002" });
+
+        Assert.Equal("http://localhost:61002", listenAddress);
+    }
+
+    /// <summary>
+    /// The half that is easy to break while fixing the other one, and the regression this change
+    /// actually risks: with no address named by the host — every host in this system today — the
+    /// file still decides where the service listens.
+    /// </summary>
+    [Fact]
+    public void ConfiguredUrls_StillApply_WhenTheHostNamedNoAddress()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var noHostAddress = new EnvironmentVariable("ASPNETCORE_URLS", null);
+
+        Assert.Equal("http://localhost:60933", ResolveListenAddressLikeAnApiHost(sharedFile));
+    }
+
+    /// <summary>
+    /// The negative control for the three above. Applying the file's address unconditionally, as
+    /// the hosts did before #181, and the address the host named is gone — which is the whole bug,
+    /// and what rules out the three passing for a reason unrelated to the guard.
+    /// </summary>
+    [Fact]
+    public void UnconditionalUseUrls_OutranksTheAddressTheHostNamed()
+    {
+        using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
+        using var hostAddress = new EnvironmentVariable("ASPNETCORE_URLS", "http://localhost:61003");
+
+        var listenAddress = ResolveListenAddressLikeAnApiHost(sharedFile, guardTheAddressTheHostNamed: false);
+
+        Assert.Equal("http://localhost:60933", listenAddress);
+    }
+
+    /// <summary>
     /// The regression guard: the environment provider has to be registered after the shared file
     /// <i>and</i> after the section flattened out of it, in the host files themselves. The
     /// flattening is the easy one to miss — it copies the file's values onto the root keys the
@@ -145,20 +238,19 @@ public class ConfigurationPrecedenceTests
     }
 
     /// <summary>
-    /// The command line, for the five APIs only.
+    /// The command line, for the five APIs and — since #181 — the bot.
     ///
     /// <para>
-    /// The bot and the simulator are deliberately absent. The simulator builds a bare
-    /// <c>ConfigurationBuilder</c> and parses its own <c>--users</c>/<c>--trades</c> switches in
-    /// <c>SimulationOptions.FromArgs</c>, which a command-line configuration provider has no part
-    /// in. The bot's <c>Host.CreateDefaultBuilder(args)</c> does register one, but early enough
-    /// that the shared file still outranks it — a real if smaller gap, left alone because #159 is
-    /// about the environment and nothing in the bot reads a setting from <c>args</c> today.
+    /// The bot's <c>Host.CreateDefaultBuilder(args)</c> registers a command-line provider among
+    /// the defaults, which run before <c>ConfigureAppConfiguration</c> adds the shared file, so
+    /// the file outranked <c>--Key=value</c> there. #159 was about the environment, which the bot
+    /// already had in the right place, so the gap outlived it. Nothing in the bot reads a setting
+    /// from <c>args</c> today — the inconsistency is what is being fixed, before something does.
     /// </para>
     /// </summary>
     [Theory]
-    [MemberData(nameof(ApiHosts))]
-    public void EveryApiHost_RegistersTheCommandLine_AfterTheSharedFile(string hostProgram)
+    [MemberData(nameof(CommandLineHosts))]
+    public void EveryHostThatParsesTheCommandLine_RegistersIt_AfterTheSharedFile(string hostProgram)
     {
         var code = ReadHostProgram(hostProgram);
 
@@ -182,6 +274,79 @@ public class ConfigurationPrecedenceTests
 
         AssertRegisteredLast(code, hostProgram, "GetSection(\"Urls\")", "AddEnvironmentVariables");
         AssertRegisteredLast(code, hostProgram, "UseUrls", "AddEnvironmentVariables");
+    }
+
+    /// <summary>
+    /// The source half of the <c>UseUrls</c> fix (#181): the file's address may only be applied
+    /// when the host named none. The behavioural tests above build that condition themselves, so
+    /// on their own they would stay green after a host went back to calling <c>UseUrls</c>
+    /// unconditionally — and because that call bypasses the provider chain, no other test in this
+    /// file would notice either.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ApiHosts))]
+    public void EveryApiHost_AppliesTheConfiguredUrls_OnlyWhenTheHostNamedNoAddress(string hostProgram)
+    {
+        var code = ReadHostProgram(hostProgram);
+
+        var guard = code.LastIndexOf("WebHostDefaults.ServerUrlsKey", StringComparison.Ordinal);
+        var useUrls = code.LastIndexOf("UseUrls", StringComparison.Ordinal);
+
+        Assert.True(guard >= 0,
+            $"{hostProgram} must read WebHostDefaults.ServerUrlsKey before applying the configured Urls, " +
+            "or ASPNETCORE_URLS and --urls are silently ignored again (#181).");
+        Assert.True(useUrls > guard,
+            $"{hostProgram} reaches UseUrls before it checks WebHostDefaults.ServerUrlsKey. UseUrls writes " +
+            "through UseSetting, which bypasses the configuration providers, so an unguarded call makes the " +
+            "file's address beat the host's whatever the provider order is (#181).");
+    }
+
+    /// <summary>
+    /// Boots configuration the way an API host does, and returns the address that host would
+    /// listen on.
+    ///
+    /// <para>
+    /// A real <see cref="WebApplicationBuilder"/> rather than a hand-built chain, because the
+    /// question is entirely about providers <c>WebApplication.CreateBuilder</c> registers — the
+    /// <c>ASPNETCORE_</c>-prefixed environment and the command line, both of which land on
+    /// <see cref="WebHostDefaults.ServerUrlsKey"/> — and about <c>UseUrls</c> writing back to that
+    /// same key through <c>UseSetting</c>. A model of that chain could model it wrong and still
+    /// pass.
+    /// </para>
+    /// </summary>
+    /// <param name="guardTheAddressTheHostNamed">
+    /// <c>false</c> reproduces the unconditional call the hosts made before #181, for the negative
+    /// control.
+    /// </param>
+    private static string? ResolveListenAddressLikeAnApiHost(
+        SharedConfigFile sharedFile,
+        string[]? args = null,
+        bool guardTheAddressTheHostNamed = true)
+    {
+        args ??= Array.Empty<string>();
+
+        // Content root is the throwaway file's own directory, so that no appsettings.json sitting
+        // beside the test assembly can take part in the answer.
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            Args = args,
+            EnvironmentName = Environments.Production,
+            ContentRootPath = sharedFile.Directory,
+        });
+
+        AddSharedFileAndItsFlattenedSection(builder.Configuration, sharedFile.Path);
+        builder.Configuration.AddEnvironmentVariables();
+        builder.Configuration.AddCommandLine(args);
+
+        var serviceSection = builder.Configuration.GetSection($"Services:{ApplicationName}");
+        var urls = serviceSection.GetSection("Urls").Get<string[]>();
+        if ((!guardTheAddressTheHostNamed || string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKey]))
+            && urls is { Length: > 0 })
+        {
+            builder.WebHost.UseUrls(urls);
+        }
+
+        return builder.Configuration[WebHostDefaults.ServerUrlsKey];
     }
 
     /// <summary>
@@ -277,7 +442,9 @@ public class ConfigurationPrecedenceTests
     {
         public SharedConfigFile(string walletDb)
         {
-            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"tallaegg-{Guid.NewGuid():N}.json");
+            Directory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"tallaegg-{Guid.NewGuid():N}");
+            System.IO.Directory.CreateDirectory(Directory);
+            Path = System.IO.Path.Combine(Directory, "appsettings.global.json");
             File.WriteAllText(Path, $$"""
                 {
                   "Services": {
@@ -293,20 +460,32 @@ public class ConfigurationPrecedenceTests
 
         public string Path { get; }
 
-        public void Dispose() => File.Delete(Path);
+        /// <summary>
+        /// The file's own directory, which the tests hand a host as its content root: a directory
+        /// with nothing else in it cannot contribute an <c>appsettings.json</c> of its own.
+        /// </summary>
+        public string Directory { get; }
+
+        public void Dispose() => System.IO.Directory.Delete(Directory, recursive: true);
     }
 
     /// <summary>
     /// Sets a process environment variable for the length of a test and puts back whatever was
     /// there. Nothing else in this suite reads the environment, but a test that leaks one fails
     /// somewhere else entirely, and those are expensive to find.
+    ///
+    /// <para>
+    /// A null <c>value</c> removes the variable instead of setting it, which is how the tests that
+    /// assert the file still supplies the listen address make sure the machine running them has
+    /// not named one (#181).
+    /// </para>
     /// </summary>
     private sealed class EnvironmentVariable : IDisposable
     {
         private readonly string _name;
         private readonly string? _original;
 
-        public EnvironmentVariable(string name, string value)
+        public EnvironmentVariable(string name, string? value)
         {
             _name = name;
             _original = Environment.GetEnvironmentVariable(name);

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using System.Text.Json;
 
 namespace TallaEgg.AllServices.Tests;
 
@@ -53,6 +54,19 @@ public class ConfigurationPrecedenceTests
         "src/Wallet/Wallet.Api/Program.cs",
         "src/TallaEgg/TallaEgg.Api/Program.cs",
         "src/Affiliate/Affiliate.Api/Program.cs",
+    };
+
+    /// <summary>
+    /// The launch profiles of the five APIs, whose <c>applicationUrl</c> would otherwise name a
+    /// listen address behind the shared file's back. Repo-relative, forward-slashed.
+    /// </summary>
+    public static TheoryData<string> ApiLaunchSettings() => new()
+    {
+        "src/Order/Orders.Api/Properties/launchSettings.json",
+        "src/User/Users.Api/Properties/launchSettings.json",
+        "src/Wallet/Wallet.Api/Properties/launchSettings.json",
+        "src/TallaEgg/TallaEgg.Api/Properties/launchSettings.json",
+        "src/Affiliate/Affiliate.Api/Properties/launchSettings.json",
     };
 
     /// <summary>
@@ -182,7 +196,7 @@ public class ConfigurationPrecedenceTests
     public void UrlsSwitch_OutranksTheConfiguredUrls()
     {
         using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
-        using var noHostAddress = new EnvironmentVariable("ASPNETCORE_URLS", null);
+        using var noHostAddress = new NoAddressInTheEnvironment();
 
         var listenAddress = ResolveListenAddressLikeAnApiHost(
             sharedFile, args: new[] { "--urls", "http://localhost:61002" });
@@ -199,7 +213,7 @@ public class ConfigurationPrecedenceTests
     public void ConfiguredUrls_StillApply_WhenTheHostNamedNoAddress()
     {
         using var sharedFile = new SharedConfigFile(walletDb: "Server=from-the-file;Database=Wallet;");
-        using var noHostAddress = new EnvironmentVariable("ASPNETCORE_URLS", null);
+        using var noHostAddress = new NoAddressInTheEnvironment();
 
         Assert.Equal("http://localhost:60933", ResolveListenAddressLikeAnApiHost(sharedFile));
     }
@@ -299,6 +313,46 @@ public class ConfigurationPrecedenceTests
             $"{hostProgram} reaches UseUrls before it checks WebHostDefaults.ServerUrlsKey. UseUrls writes " +
             "through UseSetting, which bypasses the configuration providers, so an unguarded call makes the " +
             "file's address beat the host's whatever the provider order is (#181).");
+    }
+
+    /// <summary>
+    /// A launch profile must not name a listen address either (#181).
+    ///
+    /// <para>
+    /// <c>dotnet run</c> hands a profile's <c>applicationUrl</c> to the process as
+    /// <c>ASPNETCORE_URLS</c>, which is indistinguishable from a deployment setting it. While
+    /// <c>UseUrls</c> was unconditional that made no difference — nothing a profile said could
+    /// reach the server. Now that a host's address is honoured, a profile would quietly outrank
+    /// <c>config/appsettings.global.json</c>, and the https endpoints three of these profiles used
+    /// to name would have to be bound wherever the stack runs — including a CI runner with no
+    /// development certificate, where Kestrel refuses to start at all. The shared file is the
+    /// source of truth for where a service listens (<c>AGENT.md</c>); a profile repeating it is a
+    /// second one, free to drift.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ApiLaunchSettings))]
+    public void NoApiLaunchProfile_NamesAListenAddress(string launchSettings)
+    {
+        var path = Path.Combine(FindRepositoryRoot(), launchSettings.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"Launch settings not found: {launchSettings}");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+        // iisSettings has an applicationUrl of its own, which IIS Express reads and `dotnet run`
+        // never sees — only the profiles are in question here.
+        if (!document.RootElement.TryGetProperty("profiles", out var profiles))
+        {
+            return;
+        }
+
+        foreach (var profile in profiles.EnumerateObject())
+        {
+            Assert.False(profile.Value.TryGetProperty("applicationUrl", out _),
+                $"{launchSettings}: profile '{profile.Name}' names an applicationUrl. dotnet run passes it as " +
+                "ASPNETCORE_URLS, which now outranks the shared file — the port a developer or CI reads from " +
+                "config/appsettings.global.json would stop being the port the service listens on (#181).");
+        }
     }
 
     /// <summary>
@@ -493,5 +547,31 @@ public class ConfigurationPrecedenceTests
         }
 
         public void Dispose() => Environment.SetEnvironmentVariable(_name, _original);
+    }
+
+    /// <summary>
+    /// Clears every environment variable that can name a listen address, for the tests that assert
+    /// the file supplies one when nothing else does. A host reads three spellings — the
+    /// <c>ASPNETCORE_</c> and <c>DOTNET_</c> prefixed environments both strip their prefix onto the
+    /// same <c>urls</c> key, and the unprefixed provider the services re-register reaches a bare
+    /// <c>URLS</c> — so a machine that happens to have any one of them set would fail those tests
+    /// with a message about the shared file.
+    /// </summary>
+    private sealed class NoAddressInTheEnvironment : IDisposable
+    {
+        private readonly EnvironmentVariable[] _cleared =
+        {
+            new("ASPNETCORE_URLS", null),
+            new("DOTNET_URLS", null),
+            new("URLS", null),
+        };
+
+        public void Dispose()
+        {
+            foreach (var variable in _cleared)
+            {
+                variable.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
**Branch Name**: `fix/host-urls-precedence-181`
**Linked Issue/Task**: Closes #181

---

## Description

Two places where the shared file still beat the host, both left standing by #159 / PR #180.

`UseUrls` writes through `UseSetting`, which bypasses the configuration provider chain
entirely, so the five API hosts applied `config/appsettings.global.json`'s `Urls` over
`ASPNETCORE_URLS` and `--urls` no matter how the providers were ordered. The service
started, reported healthy, and listened somewhere other than where it had been told —
silently, which is the part that matters. Each host now falls back to the file only when
the host named no address of its own.

The bot's `Host.CreateDefaultBuilder(args)` registers a command-line provider among the
defaults, which run before `ConfigureAppConfiguration` adds the shared file, so the file
outranked `--Key=value` there. `AddCommandLine(args)` is now registered beside the
`AddEnvironmentVariables()` call that was already in the right place.

A third change follows from the first and is not optional: the five `launchSettings.json`
files no longer name an `applicationUrl`. See Decisions — without it this PR would have
broken `manual-test-run`.

---

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

Marked hotfix only in the sense that it is a defect fix; nothing is on fire, because
everything still runs on one machine. It stops being theoretical at the first deployment,
same as #159.

---

## Changes Made

- `src/{Order/Orders.Api, User/Users.Api, Wallet/Wallet.Api, TallaEgg/TallaEgg.Api, Affiliate/Affiliate.Api}/Program.cs`:
  apply the configured `Urls` only when `builder.Configuration[WebHostDefaults.ServerUrlsKey]`
  is empty — i.e. only when neither `ASPNETCORE_URLS` nor `--urls` named an address.
- `TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs`: `configBuilder.AddCommandLine(args)`
  after `AddInMemoryCollection(flattened)` and `AddEnvironmentVariables()`.
- `src/*/Properties/launchSettings.json` (the same five): `applicationUrl` removed from every
  profile. Nothing else in those files changes — `ASPNETCORE_ENVIRONMENT=Development`, which
  is what the driver and the CI workflow actually need from them, stays.
- `tests/TallaEgg.AllServices.Tests/ConfigurationPrecedenceTests.cs`: 15 new cases
  (4 behavioural, 5 + 5 source-guard theory cases, and the bot added to the command-line guard).

---

## Verified before writing, not assumed

The pre-fix behaviour was reproduced on `main` rather than taken from the issue text, so
that "after" has something to be measured against. Both held exactly:

| On `main`, `Wallet.Api` | Result |
|---|---|
| `ASPNETCORE_URLS=http://localhost:61935`, run the built exe | `Now listening on: http://localhost:60933` — port 61935 never opened |
| Bot, `-- --OrderApiUrl=http://localhost:5140/api/proof-of-181` | `Order API URL: http://localhost:5140/api` — the file's value; the switch ignored |

---

## Decisions this change had to make

**Launch profiles had to stop naming an address, or this PR breaks CI.** `dotnet run` hands
a profile's `applicationUrl` to the process as `ASPNETCORE_URLS` — indistinguishable, by
construction, from a deployment setting it. While `UseUrls` was unconditional that made no
difference: nothing a profile said could reach the server. The moment a host's own address
is honoured, the profile silently outranks the shared file, and three of the five profiles
name an https endpoint that would then have to be bound wherever the stack runs.
`.github/workflows/manual-test-run.yml` starts these services with plain `dotnet run` on
`ubuntu-latest` with no `dotnet dev-certs` step, so `Wallet.Api` would have failed to start
there and taken the job with it. First seen on this machine as a behaviour change:

```
Wallet.Api, dotnet run, before -> http://localhost:60933
Wallet.Api, dotnet run, with the guard but the profile still naming an address
                               -> https://localhost:60932   (from launchSettings)
                                  http://localhost:60933
```

Removing `applicationUrl` is the smaller of the two available repairs — the other being
`--no-launch-profile` plus an explicit `ASPNETCORE_ENVIRONMENT` in the workflow, in
`driver.ps1` and in the skill's documentation, which would also leave the trap live for
anyone typing `dotnet run` by hand. It leaves the shared file as the single source of truth
for where a service listens, which is what `AGENT.md` already says it is, and it keeps
`dotnet run` binding exactly what it binds today (evidence below). A new test keeps
`applicationUrl` out, with the reason in its own docs, since a `.json` file has nowhere to
put a comment.

**The guard reads configuration, not the web host.** `builder.Configuration[WebHostDefaults.ServerUrlsKey]`
sees both spellings, because `WebApplication.CreateBuilder` registers the
`ASPNETCORE_`-prefixed environment provider and the command-line provider, and both land on
the same `urls` key. The file cannot collide with it: the section's `Urls` is an array, so
flattening produces `Urls:0`, never a value at `Urls` itself.

**`Affiliate.Api` included, although the affiliate feature is dormant and outside the
audit's scope.** Same reason as #180: the change is mechanical, the service had the same
defect, and leaving it out would leave one service choosing its listen address by a
different rule from the other four — the inconsistency the acceptance criteria warn about.
It boots clean and honours both overrides (table below).

**The simulator was left alone.** It binds no address and parses its own
`--users`/`--trades` switches in `SimulationOptions.FromArgs`, which a command-line
configuration provider has no part in. The bot's own `launchSettings.json` keeps its
`applicationUrl` for the same reason: it is a generic host with no Kestrel, so the value has
never reached anything, and this PR does not change that.

**`ResolveSharedConfigPath` is still copy-pasted into all seven `Program.cs` files**, and it
is still why a configuration fix costs five or six edits instead of one. Untouched here for
the same reason #180 left it: this issue is about the boot path's precedence, and widening
it into a startup refactor across every service is what `STANDARDS.md` says not to do.

---

## Flagged, not fixed

- **`ASPNETCORE_HTTP_PORTS` / `ASPNETCORE_HTTPS_PORTS` are still silently overridden.** The
  guard reads only `urls`, and `urls` outranks `HTTP_PORTS` in Kestrel's binder, so a host
  that names its port the other way still gets the file's address instead — the same
  listen-somewhere-else shape #181 is about, in a spelling the issue does not mention. It
  matters because the official `mcr.microsoft.com/dotnet/aspnet` images set `HTTP_PORTS` by
  default, so a containerised deployment would hit it first. Extending the same condition to
  those two keys is a few characters per host; raised here rather than done, the way #180
  raised this issue.
- **`Orders.Api` now has two launch profiles, `http` and `https`, that do the same thing.**
  Its `https` profile existed only to name an address, and it never bound one. Deleting it
  is tidy-up outside this issue.

---

## Testing Completed

### Unit Tests
- [x] New unit tests written
- [x] All unit tests pass (`dotnet test`)

```
dotnet build TallaEgg.sln --no-incremental
-> Build succeeded. 0 Warning(s) 0 Error(s)     (TreatWarningsAsErrors is on)

dotnet test TallaEgg.sln
-> Passed! Failed: 0, Passed: 694, Skipped: 0, Total: 694
```

The suite's existing two-halves shape is kept, because either half alone would be worth
little here:

- **Behavioural** (4 new) — through a real `WebApplicationBuilder`, not a hand-built
  provider chain, since the whole question is about providers `WebApplication.CreateBuilder`
  registers and about `UseUrls` writing back to the same key. `ASPNETCORE_URLS` wins,
  `--urls` wins, and — the one that matters most — with neither set the file still supplies
  the address. A negative control reproduces the old unconditional call and asserts the file
  wins, so the other three cannot pass for a reason unrelated to the guard.
- **Source guards** (11 new theory cases) — the five hosts must reach
  `WebHostDefaults.ServerUrlsKey` before `UseUrls`; no API launch profile may name an
  `applicationUrl`; and the bot joins the existing command-line ordering theory. Comment
  lines are stripped before matching, as before, so a comment naming a provider can neither
  satisfy nor defeat an assertion.

Each new guard was confirmed non-vacuous by reverting exactly one file and watching exactly
its own case go red:

```
Failed …EveryApiHost_AppliesTheConfiguredUrls_OnlyWhenTheHostNamedNoAddress(hostProgram: "src/Wallet/Wallet.Api/Program.cs")
Failed …EveryHostThatParsesTheCommandLine_RegistersIt_AfterTheSharedFile(hostProgram: "TelegramBot/…/Program.cs")
Failed …NoApiLaunchProfile_NamesAListenAddress(launchSettings: "src/Wallet/Wallet.Api/Properties/launchSettings.json")
```

### The risk here is boot, not tests

This is the path where a mistake takes all five services down at once and no unit test shows
it, so every service was actually run — each built executable, three ways: with
`ASPNETCORE_URLS`, with `--urls`, and with neither.

```
Users.Api      env     listening=http://localhost:61936   filePort(5136)=False  overridePort=True   errors=0
Users.Api      switch  listening=http://localhost:61936   filePort(5136)=False  overridePort=True   errors=0
Users.Api      none    listening=http://localhost:5136    filePort(5136)=True   overridePort=False  errors=0
Wallet.Api     env     listening=http://localhost:61935   filePort(60933)=False overridePort=True   errors=0
Wallet.Api     switch  listening=http://localhost:61935   filePort(60933)=False overridePort=True   errors=0
Wallet.Api     none    listening=http://localhost:60933   filePort(60933)=True  overridePort=False  errors=0
Orders.Api     env     listening=http://localhost:61937   filePort(5140)=False  overridePort=True   errors=0
Orders.Api     switch  listening=http://localhost:61937   filePort(5140)=False  overridePort=True   errors=0
Orders.Api     none    listening=http://localhost:5140    filePort(5140)=True   overridePort=False  errors=0
TallaEgg.Api   env     listening=http://localhost:61938   filePort(5135)=False  overridePort=True   errors=0
TallaEgg.Api   switch  listening=http://localhost:61938   filePort(5135)=False  overridePort=True   errors=0
TallaEgg.Api   none    listening=http://localhost:5135    filePort(5135)=True   overridePort=False  errors=0
Affiliate.Api  env     listening=http://localhost:61939   filePort(60812)=False overridePort=True   errors=0
Affiliate.Api  switch  listening=http://localhost:61939   filePort(60812)=False overridePort=True   errors=0
Affiliate.Api  none    listening=http://localhost:60812   filePort(60812)=True  overridePort=False  errors=0
```

The third row of each group is the acceptance criterion this change most risked breaking: no
host address anywhere, and the file still decides. `filePort` and `overridePort` are read
from `Get-NetTCPConnection`, not from the log, so a service that printed one address and
bound another would show up.

**All five services and the bot start together, on the same ports as before this PR, and the
bot reaches its polling loop** (`driver.ps1 start` plus `dotnet run` for the other two and
the bot, i.e. through the launch profiles):

```
users:     [INF] Now listening on: http://localhost:5136
wallet:    [INF] Now listening on: http://localhost:60933
orders:    [INF] Now listening on: http://localhost:5140
tallaegg:  [INF] Now listening on: http://localhost:5135
affiliate: [INF] Now listening on: http://localhost:60812
bot:       [INF] Bot is now running and listening for messages...
-> 0 [ERR]/[FTL] lines across all six logs
-> https ports 60932 / 7296 / 60811 / 57545: not listening, as before this PR
```

**End to end through the real handlers and APIs**, with all six hosts up
(`driver.ps1 smoke`, 5 users / 5 quotes / 10 trades):

```
=== Done in 00:00:10.4. Registered 5 (4 approved), trades attempted 10, errors 0 ===
Simulation completed with errors 0; 10 settlement(s) completed, no new failures.
Restored auto-quote for MAUA/IRT to IsEnabled=True.
```

Settlement is included, not just the trading phase — the driver drains the outbox and
requires `Completed` to have grown and `Failed` not to have (#175 / #184).

**The bot's half, at runtime:**

```
bot -- --OrderApiUrl=http://localhost:5140/api/proof-of-181
[INF] Order API URL: http://localhost:5140/api/proof-of-181     <- the switch
[INF] Users API URL: http://localhost:5136/api                  <- still the file
```

The second line is the half that is easy to break while fixing the first: everything the
command line did not name still comes from the shared file. On `main`, the same switch
produced the file's value on both lines.

### Environment
- [x] Tested locally on Windows
- [ ] Tested on staging environment (no staging exists yet — see `STANDARDS.md` §7)

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files (config, .env, secrets)
- [x] Code compiles without warnings (`TreatWarningsAsErrors` is on; 0 warnings)

`config/appsettings.global.json` is untouched and uncommitted. The only values from it that
appear anywhere in this PR are the five service ports, which are already in
`config/appsettings.global.example.json` and `AGENT.md`. The tests generate their own
throwaway config file in a temp directory with invented values and delete it afterwards — CI
has no shared config file and this suite still must not need one.

The direction of travel is the same as #159's: a deployment can now move a listen address
with the standard `ASPNETCORE_URLS`, instead of hand-editing the one file that holds live
credentials on the server.

---

## Code Quality

- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why", not the "what"
- [x] No large blocks of commented-out code
- [x] Consistent indentation and formatting
- [x] No unnecessary dependencies added

---

## Documentation

- [x] Code comments are clear and in English
- [ ] Updated relevant `.md` files in `docs/` — none needed. `AGENT.md`'s Configuration
      section already describes the shared file as the source of truth for what a host does
      not override, which is now true of the listen address as well. Its note that the
      services "also listen on an HTTPS port, which nothing in the system uses" describes
      the launch profiles, and was already untrue of what the services bound; it is now
      untrue in the same way and for the same reason, so it is left for whoever revises that
      list.

---

## Breaking Changes?

- [x] No breaking changes

Nothing changes for a host that names no address — the deployed shape today, every row of
the `none` group above, and every service in the full-stack run. Two things are worth
knowing about:

1. **A pre-existing `ASPNETCORE_URLS`, `DOTNET_URLS` or bare `URLS` in an environment now
   wins** where it previously lost. That is the intended behaviour and there is nothing of
   the sort on this machine or in CI, but it is the shape of surprise this change makes
   possible.
2. **Visual Studio / Rider no longer read a browse address out of the launch profile.** They
   run the project the same way and the service binds the same port; only the "open a
   browser at this URL" hint is gone.

---

## Deployment Notes

**Pre-Deployment**: nothing. No migrations, no new environment variables, no feature flag.

**Post-Deployment Verification**:
- [x] Application starts successfully
- [x] Smoke tests pass
- [x] Logs show no errors

**How to use it.** The bespoke spelling #180 documented still works, and the standard one
now works too:

```
ASPNETCORE_URLS=http://0.0.0.0:60933                 # or --urls http://0.0.0.0:60933
Services__Wallet.Api__Urls__0=http://0.0.0.0:60933   # still honoured
```

If both are set, `ASPNETCORE_URLS` wins — the host's own spelling is the one a deployment
script reaches for, and the nested key is the file's shape.

**Rollback Plan**: revert the two commits and restart. There is no state to undo — the
change is one condition per service, one provider registration in the bot, and one key
removed from five launch profiles.

---

## Related Issues

- Closes #181
- #159 / PR #180 — provider registration order; this is the part that order could not reach
- #105 — production checklist; this belongs on it for the same reason #159 did
- #33 — why `config/appsettings.global.json` is untracked, and why editing it on a server is
  the thing worth avoiding
