### PR TITLE
[Feat] Simulator trades every symbol in the catalogue, at each one's own precision — issue #147

### DIFF
--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -97,13 +97,17 @@ quantity round-tripped unchanged. The symbol cycles per trade, so any run with a
 trades as there are symbols touches all of them, and the run prints a per-symbol breakdown:
 
 ```
-Settled trades by symbol:
-  BTC/IRT: 4 settled
-  MAUA/IRT: 3 settled
-  SEKE_BAHAR/IRT: 3 settled
+Filled trades by symbol:
+  BTC/IRT: 4 filled
+  MAUA/IRT: 3 filled
+  SEKE_BAHAR/IRT: 3 filled
 ```
 
-A symbol showing `0 settled` means the run did not exercise it. Override any subset of the
+A symbol showing `0 filled` means the run did not exercise it. *Filled*, not *settled*: a fill is a
+matched trade with its settlement queued, and settlement is what the driver asserts after the
+outbox drains (below).
+
+Override any subset of the
 knobs after `smoke` — the ones you don't name keep the small defaults above (the driver merges
 them; passing them straight through would drop to the Simulator's own compiled defaults of 100
 users / 120 quotes / **1000 trades**, so `smoke --seed 7` alone would be a hundred-fold bigger

--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -86,7 +86,24 @@ seconds pass. On timeout it prints the last 40 lines of *both* logs per service 
 `/start` + contact-share flow, promotes one to admin, has admin approve/reject the rest, funds
 wallets, publishes quotes through the real `18500000-18550000`-style text command, fills trades
 by quote acceptance, and clicks through the help/history/balance menu buttons — end to end,
-through the real handler and API code, against the real database. Override any subset of the
+through the real handler and API code, against the real database.
+
+**It trades every symbol in the pair catalogue, not just gold** (issue #147). Each symbol gets its
+own quotes, its own wallet funding (base asset *and* `CREDIT_` ledger), and quantities at its own
+precision — eight decimal places on `BTC/IRT`, two on `MAUA/IRT`. That difference is the point: the
+simulator ran a thousand clean MAUA trades on top of #146, where `Orders.Amount` was
+`decimal(18, 2)`, because MAUA's precision is exactly the two places the column held and every gold
+quantity round-tripped unchanged. The symbol cycles per trade, so any run with at least as many
+trades as there are symbols touches all of them, and the run prints a per-symbol breakdown:
+
+```
+Settled trades by symbol:
+  BTC/IRT: 4 settled
+  MAUA/IRT: 3 settled
+  SEKE_BAHAR/IRT: 3 settled
+```
+
+A symbol showing `0 settled` means the run did not exercise it. Override any subset of the
 knobs after `smoke` — the ones you don't name keep the small defaults above (the driver merges
 them; passing them straight through would drop to the Simulator's own compiled defaults of 100
 users / 120 quotes / **1000 trades**, so `smoke --seed 7` alone would be a hundred-fold bigger
@@ -155,12 +172,13 @@ abandoned.
   ```
 
   It gives up after 10 minutes rather than waiting forever, and says where to look when it does.
-- **The auto-quote flag for `MAUA/IRT`.** The Simulator turns it off in Phase 2 — a background
-  publisher replacing the run's quotes breaks quote-fill trades — and never turns it back on.
-  That is per-symbol Orders-DB state, not `TelegramId`-scoped, so `DataReset` does not restore
-  it. **`driver.ps1 smoke` reads the flag before the run and puts it back afterwards**, including
-  when the run fails part-way. If the restore itself fails the driver says so; turn it back on
-  from the bot with the admin command `اتومات روشن`, or:
+- **The auto-quote flag for every symbol the run trades.** The Simulator turns each one off in
+  Phase 2 — a background publisher replacing the run's quotes breaks quote-fill trades — and never
+  turns any back on. That is per-symbol Orders-DB state, not `TelegramId`-scoped, so `DataReset`
+  does not restore it. **`driver.ps1 smoke` snapshots every symbol's flag from the
+  `AutoQuoteSettings` table before the run and puts them back afterwards**, including when the run
+  fails part-way. If a restore itself fails the driver says so; turn it back on from the bot with
+  the admin command `اتومات روشن`, or:
 
   ```powershell
   Invoke-RestMethod -Method Post -ContentType 'application/json' `

--- a/.claude/skills/run-tallaegg/driver.ps1
+++ b/.claude/skills/run-tallaegg/driver.ps1
@@ -29,11 +29,11 @@
   Two things it changes on the database it runs against:
     * Rows with TelegramId < 0 — created, then wiped by the next run's DataReset phase. A
       real (positive-id) user's data is never touched.
-    * The auto-quote enabled flag for MAUA/IRT — the Simulator turns it off in its Phase 2 and
-      never turns it back on, because a background publisher replacing the run's quotes breaks
-      quote-fill trades. That is per-symbol Orders-DB state, not TelegramId-scoped, so
-      DataReset does not restore it. This script reads the flag before the run and puts it
-      back afterwards; see Restore-AutoQuote below.
+    * The auto-quote enabled flag for every symbol the run trades — the Simulator turns each
+      one off in its Phase 2 and never turns any back on, because a background publisher
+      replacing the run's quotes breaks quote-fill trades. That is per-symbol Orders-DB state,
+      not TelegramId-scoped, so DataReset does not restore it. This script snapshots every
+      symbol's flag before the run and puts them back afterwards; see Restore-AutoQuote below.
 #>
 param(
     [Parameter(Mandatory = $true, Position = 0)]
@@ -55,9 +55,6 @@ $projects = @{
 }
 $logDir = Join-Path $repoRoot 'run-logs'
 $pidFile = Join-Path $logDir 'launcher.pids'
-
-# The symbol the Simulator trades, and whose auto-quote flag it turns off (Simulation.cs).
-$smokeSymbol = 'MAUA/IRT'
 
 function Test-ServicesUp {
     foreach ($name in $ports.Keys) {
@@ -148,30 +145,47 @@ function Wait-OutboxDrained {
     }
 }
 
-function Get-AutoQuoteEnabled {
-    # Returns $true/$false, or $null if the setting could not be read (caller then skips restore
-    # rather than guessing — writing the wrong value back is worse than leaving it alone).
+function Get-AutoQuoteFlags {
+    # Every symbol's flag, as a hashtable keyed by symbol.
+    #
+    # Read from the table rather than through GET /api/autoquote-settings/{symbol}, for two
+    # reasons. That endpoint is GetOrCreate, so asking about a symbol that has never been
+    # auto-quoted creates its row as a side effect of the question. And there is no endpoint that
+    # enumerates: the Simulator now turns auto-quote off for every symbol it trades (issue #147),
+    # and which symbols those are comes from the pair catalogue, which this script cannot read.
+    param([Parameter(Mandatory = $true)][string]$ConnectionString)
+
+    $flags = @{}
+    $conn = New-Object System.Data.SqlClient.SqlConnection $ConnectionString
     try {
-        $r = Invoke-RestMethod -TimeoutSec 10 -Uri "http://localhost:$($ports['orders'])/api/autoquote-settings/$smokeSymbol"
-        return [bool]$r.Data.IsEnabled
-    } catch {
-        Write-Warning "Could not read auto-quote setting for ${smokeSymbol}: $($_.Exception.Message)"
-        return $null
+        $conn.Open()
+        $cmd = $conn.CreateCommand()
+        $cmd.CommandText = 'SELECT Symbol, IsEnabled FROM AutoQuoteSettings'
+        $reader = $cmd.ExecuteReader()
+        while ($reader.Read()) { $flags[[string]$reader['Symbol']] = [bool]$reader['IsEnabled'] }
+        $reader.Close()
     }
+    finally {
+        $conn.Dispose()
+    }
+    return $flags
 }
 
 function Restore-AutoQuote {
-    param([bool]$Enabled)
+    param(
+        [Parameter(Mandatory = $true)][string]$Symbol,
+        [Parameter(Mandatory = $true)][bool]$Enabled
+    )
 
     try {
         # Guid.Empty as the updater: this is a dev-tooling restore, not an admin action, and
         # AutoQuoteSettings.CreateDefault already uses Guid.Empty as its no-real-user sentinel.
         $body = @{ IsEnabled = $Enabled; UpdatedByUserId = [guid]::Empty.ToString() } | ConvertTo-Json
         Invoke-RestMethod -Method Post -TimeoutSec 10 -ContentType 'application/json' -Body $body `
-            -Uri "http://localhost:$($ports['orders'])/api/autoquote-settings/$smokeSymbol/enabled" | Out-Null
-        Write-Host "Restored auto-quote for $smokeSymbol to IsEnabled=$Enabled."
+            -Uri "http://localhost:$($ports['orders'])/api/autoquote-settings/$Symbol/enabled" | Out-Null
+        Write-Host "Restored auto-quote for $Symbol to IsEnabled=$Enabled."
     } catch {
-        Write-Warning "Failed to restore auto-quote for ${smokeSymbol} to IsEnabled=${Enabled}: $($_.Exception.Message)"
+        Write-Warning "Failed to restore auto-quote for ${Symbol} to IsEnabled=${Enabled}: $($_.Exception.Message)"
         Write-Warning "Turn it back on from the bot with the admin command 'اتومات روشن' if it was on before."
     }
 }
@@ -305,7 +319,7 @@ switch ($Command) {
         $failedBefore = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 2
         $completedBefore = Get-OutboxCount -ConnectionString $ordersConnectionString -Status 1
 
-        $autoQuoteWas = Get-AutoQuoteEnabled
+        $autoQuoteWas = Get-AutoQuoteFlags -ConnectionString $ordersConnectionString
         Write-Host "Running simulator with args: $simArgs"
         try {
             dotnet run --no-build --configuration Release `
@@ -314,10 +328,15 @@ switch ($Command) {
             $simExit = $LASTEXITCODE
         }
         finally {
-            # The Simulator disables auto-quote for the symbol and never re-enables it; put the
-            # flag back however we found it, including when the run threw part-way through.
-            if ($null -ne $autoQuoteWas -and $autoQuoteWas) {
-                Restore-AutoQuote -Enabled $true
+            # The Simulator disables auto-quote for every symbol it trades and never re-enables
+            # any of them; put each flag back however we found it, including when the run threw
+            # part-way through. Restoring unconditionally rather than re-reading first: the POST
+            # is idempotent, and a second query here would be one more thing to fail inside a
+            # cleanup block.
+            foreach ($symbol in @($autoQuoteWas.Keys)) {
+                if ($autoQuoteWas[$symbol]) {
+                    Restore-AutoQuote -Symbol $symbol -Enabled $true
+                }
             }
         }
 

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
@@ -50,6 +50,12 @@ configBuilder.AddEnvironmentVariables();
 var configuration = configBuilder.Build();
 serviceSection = configuration.GetSection($"Services:{BotApplicationName}");
 
+// The same call every service and the real bot make at startup. It matters here now that the run
+// reads its symbols from CurrenciesConstant.AllTradingPairs (issue #147): without it the simulator
+// would trade the compiled defaults while the APIs it drives were serving whatever the shared
+// file's "Symbols" section adds on top of them.
+TallaEgg.Core.CurrenciesConstant.Configure(configuration);
+
 var services = new ServiceCollection();
 services.AddLogging(b => b.AddSimpleConsole(o =>
 {

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using TallaEgg.Core;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.Enums.User;
 using TallaEgg.Core.Requests.Wallet;
@@ -27,7 +28,50 @@ public sealed class Simulation(
     DataReset dataReset,
     ILogger<Simulation> logger)
 {
-    private const string Symbol = "MAUA/IRT";
+    /// <summary>
+    /// How much of the symbol's own spread the published buy and sell legs sit either side of the
+    /// walking mid. A fraction rather than an amount, so it means the same thing on a gram of gold
+    /// and on a Bitcoin.
+    /// </summary>
+    private const decimal QuoteSpreadFraction = 0.002m;
+
+    /// <summary>
+    /// How far one published quote may move from the one before it, as a fraction of the price.
+    ///
+    /// Deliberately far inside the ±5% plausibility band: a quote outside it is held for an admin
+    /// to confirm rather than published (issue #158), and a held quote is not a published one — so
+    /// a run that walked too far would leave a symbol with no quote and every trade on it failing.
+    /// </summary>
+    private const double QuoteWalkFraction = 0.0025;
+
+    /// <summary>
+    /// How many maximum-size trades each user is funded for, per symbol. Every base asset, its
+    /// credit ledger and the shared quote currency are all sized from this one number, so no
+    /// symbol runs its wallets dry earlier than another.
+    /// </summary>
+    private const int FundedTradesPerUser = 40;
+
+    /// <summary>
+    /// A plausible price per base unit, in the quote currency, for each symbol the platform ships
+    /// with — per gram for gold, not the per-mesghal figure an admin types.
+    ///
+    /// <para>
+    /// Only consulted for a symbol that has no published quote to anchor on. Whatever this run
+    /// publishes becomes the price the next quote is measured against, and one more than ±5% away
+    /// is held for approval instead of published (issue #158) — so an invented figure here would
+    /// lock the live price feed out of its own market. These are the levels the feed itself was
+    /// publishing on 2026-09-01: melted gold ≈ 22.1M toman per gram, a full Bahar Azadi coin at
+    /// ≈ 1.24x the mesghal price of melted gold, Bitcoin ≈ 16.6 billion toman.
+    /// </para>
+    /// </summary>
+    private static readonly Dictionary<string, decimal> ReferenceUnitPrices =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [CurrenciesConstant.Maua] = 22_100_000m,
+            [CurrenciesConstant.SekeBahar] = 118_900_000m,
+            [CurrenciesConstant.Btc] = 16_620_000_000m,
+        };
+
     private static readonly string[] FirstNames = ["Ali", "Sara", "Reza", "Mina", "Hamid", "Neda", "Omid", "Yalda", "Kian", "Roya"];
     private static readonly string[] LastNames = ["Ahmadi", "Karimi", "Hosseini", "Moradi", "Jafari", "Rahimi", "Ghasemi", "Sadeghi"];
 
@@ -45,6 +89,19 @@ public sealed class Simulation(
         logger.LogInformation("-- Phase 0: reset previously simulated data --");
         await dataReset.RunAsync();
 
+        // Every symbol the platform trades, not one of them. A run that touches a single symbol
+        // proves that symbol works and reads as if it proved the platform works — which is how
+        // 1000 clean MAUA trades sat on top of #146 for as long as Bitcoin had been tradable.
+        var plans = await BuildSymbolPlansAsync();
+        logger.LogInformation("Trading {Count} symbol(s) this run:", plans.Count);
+        foreach (var plan in plans)
+        {
+            logger.LogInformation(
+                "  {Symbol}: quantities {Min} to {Max} at {Decimals} decimal place(s), around {Price} {Quote} per {Unit}",
+                plan.Symbol, plan.MinTradeQuantity, plan.MaxTradeQuantity, plan.Pair.BaseDecimalPlaces,
+                plan.ReferenceUnitPrice, plan.Pair.QuoteAsset, plan.Pair.BaseUnit);
+        }
+
         logger.LogInformation("-- Phase 1: register {Count} virtual users via /start + phone share --", options.UserCount);
         var users = await RegisterUsersAsync(options.UserCount, random);
 
@@ -57,8 +114,11 @@ public sealed class Simulation(
         // whichever quote this run just published with one from a different market maker —
         // discovered by trades starting to fail ~600 in with "wallet not found" for a user
         // this run never touched. Every quote-accept trade needs a single, known market
-        // maker throughout the run, so auto-quote is turned off for the run's symbol first.
-        await orderApi.SetAutoQuoteEnabledAsync(Symbol, isEnabled: false, admin.UserId!.Value);
+        // maker throughout the run, so auto-quote is turned off for every symbol it trades.
+        foreach (var plan in plans)
+        {
+            await orderApi.SetAutoQuoteEnabledAsync(plan.Symbol, isEnabled: false, admin.UserId!.Value);
+        }
 
         logger.LogInformation("-- Phase 3: admin approves/rejects the remaining {Count} registrations --", users.Count - 1);
         await ApproveOrRejectUsersAsync(admin, users.Skip(1).ToList(), random);
@@ -71,7 +131,7 @@ public sealed class Simulation(
         var customers = approved.Where(u => u.TelegramId != admin.TelegramId).ToList();
 
         logger.LogInformation("-- Phase 4: fund every approved wallet so trades can clear --");
-        await FundWalletsAsync(customers);
+        await FundWalletsAsync(customers, plans);
 
         // Admin is the counterparty to every quote fill in the market, not just its own
         // trades — its reserve depletes across the whole run, not per-user, so it needs an
@@ -79,16 +139,27 @@ public sealed class Simulation(
         // pass at 100 users / 1000 trades ran out of admin MAUA around trade #656 and every
         // fill failed after that with "در حال حاضر امکان انجام این معامله نیست." — the
         // customer-sized funding below was the bug, not the product.
-        await FundWalletsAsync([admin], multiplier: 50m);
+        //
+        // Trading several symbols does not make that reserve run out sooner: the funding above is
+        // per symbol, so the same budget is not divided between them — a symbol added to the run
+        // brings its own base asset and its own credit ledger with it.
+        await FundWalletsAsync([admin], plans, multiplier: 50m);
 
         logger.LogInformation("-- Phase 5: admin charge/discharge sample --");
         await ChargeAndDischargeSampleAsync(admin, customers, random);
 
-        logger.LogInformation("-- Phase 6: admin publishes {Count}+ quotes --", options.QuoteCount);
-        await PublishQuotesAsync(admin, options.QuoteCount, random);
+        logger.LogInformation("-- Phase 6: admin publishes {Count}+ quotes across {Symbols} symbol(s) --",
+            options.QuoteCount, plans.Count);
+        await PublishQuotesAsync(admin, plans, options.QuoteCount, random);
+
+        // A quote too far from the one already published is held for an admin to confirm rather
+        // than published (issue #158), and a symbol with no active quote refuses every fill. Left
+        // unchecked that is a symbol quietly contributing nothing to a run that still reports
+        // itself green — the exact shape of gap this simulator exists to close.
+        var tradable = await FilterToQuotedSymbolsAsync(plans);
 
         logger.LogInformation("-- Phase 7: {Count}+ trades via quote acceptance --", options.TradeCount);
-        var tradesDone = await GenerateTradesAsync(customers, options.TradeCount, random);
+        var (tradesDone, tradesBySymbol) = await GenerateTradesAsync(customers, tradable, options.TradeCount, random);
 
         logger.LogInformation("-- Phase 8: scattered user navigation (help, history, balance, active orders) --");
         await ScatterUserBehaviorAsync(approved, random);
@@ -97,6 +168,15 @@ public sealed class Simulation(
         logger.LogInformation(
             "=== Done in {Elapsed}. Registered {Users} ({Approved} approved), trades attempted {Trades}, errors {Errors} ===",
             stopwatch.Elapsed, users.Count, approved.Count, tradesDone, _errors.Count);
+
+        // Reported per symbol because the total says nothing about coverage: a symbol with zero
+        // settled trades is a symbol this run did not exercise, however green the total looks.
+        logger.LogInformation("Settled trades by symbol:");
+        foreach (var plan in plans)
+        {
+            logger.LogInformation("  {Symbol}: {Count} settled", plan.Symbol,
+                tradesBySymbol.TryGetValue(plan.Symbol, out var settled) ? settled : 0);
+        }
 
         if (_errors.Count > 0)
         {
@@ -109,6 +189,93 @@ public sealed class Simulation(
 
         logger.LogInformation(
             "Every logged error above corresponds to a TraceId entry in logs/*.log under the relevant API service (issue #88).");
+    }
+
+    // ── The run's symbols, and the sizes and prices each one gets ─────────────────────────
+
+    /// <summary>
+    /// Builds one <see cref="SymbolPlan"/> per trading pair the platform knows about, read from
+    /// <see cref="CurrenciesConstant.AllTradingPairs"/> rather than named here — a pair added by
+    /// configuration alone is then traded by the next run with no change to this file.
+    /// </summary>
+    private async Task<List<SymbolPlan>> BuildSymbolPlansAsync()
+    {
+        var plans = new List<SymbolPlan>();
+
+        // Ordered by symbol so a run is reproducible from its seed alone: the pair catalogue is a
+        // dictionary, and the order configuration happens to merge into it would otherwise decide
+        // which symbol each round-robin trade lands on.
+        foreach (var pair in CurrenciesConstant.AllTradingPairs.OrderBy(p => p.Symbol, StringComparer.Ordinal))
+        {
+            plans.Add(SymbolPlan.For(pair, await ResolveReferenceUnitPriceAsync(pair)));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    /// The price this run will publish quotes around, per base unit in the quote currency.
+    ///
+    /// <para>
+    /// Anchored on whatever is already published, because a quote more than ±5% from the current
+    /// one is held for approval instead of published (issue #158): a run that ignored the live
+    /// price would publish nothing for the symbol, and every trade on it would then fail for want
+    /// of a quote. <see cref="DataReset"/> deliberately leaves quotes behind, so this is normally
+    /// the price the last run or the price feed left.
+    /// </para>
+    /// </summary>
+    private async Task<decimal> ResolveReferenceUnitPriceAsync(TradingPairInfo pair)
+    {
+        try
+        {
+            var quote = await orderApi.GetActiveQuoteAsync(pair.Symbol);
+            if (quote is not null && quote.BuyPrice > 0 && quote.SellPrice > 0)
+                return (quote.BuyPrice + quote.SellPrice) / 2m;
+        }
+        catch (Exception ex)
+        {
+            RecordError($"read the active quote for {pair.Symbol}", ex);
+        }
+
+        if (ReferenceUnitPrices.TryGetValue(pair.BaseAsset, out var reference))
+            return reference;
+
+        // A pair nobody has listed above and that has never been quoted: the price at which its
+        // own smallest tradable quantity is worth its own smallest tradable value. Not a market
+        // price, but the right order of magnitude — which is all the run needs to size trades and
+        // fund wallets, and the only figure available without inventing one.
+        return pair.MinQuantity > 0 ? pair.MinNotional / pair.MinQuantity : 1m;
+    }
+
+    /// <summary>
+    /// Drops any symbol that ended Phase 6 without an active quote, and records an error for it so
+    /// the run cannot report itself clean while silently covering fewer symbols than it claims.
+    /// </summary>
+    private async Task<List<SymbolPlan>> FilterToQuotedSymbolsAsync(List<SymbolPlan> plans)
+    {
+        var quoted = new List<SymbolPlan>();
+
+        foreach (var plan in plans)
+        {
+            try
+            {
+                if (await orderApi.GetActiveQuoteAsync(plan.Symbol) is not null)
+                {
+                    quoted.Add(plan);
+                    continue;
+                }
+
+                RecordError($"publish a quote for {plan.Symbol}", new InvalidOperationException(
+                    "No active quote after the quote phase — it was probably held for approval as " +
+                    "implausible; no trade on this symbol can be filled."));
+            }
+            catch (Exception ex)
+            {
+                RecordError($"check the active quote for {plan.Symbol}", ex);
+            }
+        }
+
+        return quoted;
     }
 
     // ── Phase 1: registration, through the real conversation ──────────────────────────────
@@ -210,24 +377,69 @@ public sealed class Simulation(
 
     // ── Phase 4: wallet funding (direct API — not a "behavior" worth replaying per user) ──
 
-    private async Task FundWalletsAsync(List<VirtualUser> users, decimal multiplier = 1m)
+    /// <summary>
+    /// Funds every wallet a run needs: each quote currency, then each traded symbol's base asset
+    /// and that asset's credit ledger.
+    ///
+    /// <para>
+    /// It used to deposit Toman and MAUA and nothing else, which is why registration's three
+    /// default wallets were all anyone ever had. A symbol is only exercised if the customers can
+    /// pay for it in both directions — a buy is settled from the quote currency, a sell from the
+    /// base asset — so the funding follows whatever is being traded rather than naming an asset.
+    /// </para>
+    /// </summary>
+    private async Task FundWalletsAsync(List<VirtualUser> users, IReadOnlyList<SymbolPlan> plans, decimal multiplier = 1m)
     {
+        // A quote currency has to cover a buy on every symbol priced in it, so it is funded for
+        // that whole group; each base asset only has to cover its own symbol's sells. Grouped
+        // rather than assuming toman — every pair is quoted in IRT today, but the funding follows
+        // the pair here exactly as it does on the base side.
+        var quoteFunding = plans
+            .GroupBy(p => p.Pair.QuoteAsset, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => CurrenciesConstant.RoundToCurrencyPrecision(
+                    group.Sum(p => p.MaxTradeQuantity * p.ReferenceUnitPrice) * FundedTradesPerUser * multiplier,
+                    group.Key),
+                StringComparer.OrdinalIgnoreCase);
+
         foreach (var user in users)
         {
             try
             {
-                await walletApi.DepositeAsync(new WalletRequest
+                foreach (var (asset, amount) in quoteFunding)
                 {
-                    UserId = user.UserId!.Value,
-                    Asset = TallaEgg.Core.CurrenciesConstant.Toman,
-                    Amount = 500_000_000m * multiplier,
-                });
-                await walletApi.DepositeAsync(new WalletRequest
+                    await walletApi.DepositeAsync(new WalletRequest
+                    {
+                        UserId = user.UserId!.Value,
+                        Asset = asset,
+                        Amount = amount,
+                    });
+                }
+
+                foreach (var plan in plans)
                 {
-                    UserId = user.UserId!.Value,
-                    Asset = TallaEgg.Core.CurrenciesConstant.Maua,
-                    Amount = 500m * multiplier,
-                });
+                    var baseFunding = CurrenciesConstant.RoundToCurrencyPrecision(
+                        plan.MaxTradeQuantity * FundedTradesPerUser * multiplier, plan.BaseAsset);
+
+                    await walletApi.DepositeAsync(new WalletRequest
+                    {
+                        UserId = user.UserId!.Value,
+                        Asset = plan.BaseAsset,
+                        Amount = baseFunding,
+                    });
+
+                    // Credit as well as balance: credit is what the trade path actually checks
+                    // (ValidateCreditAndBalanceAsync), and it is cross-asset — a customer's
+                    // CREDIT_MAUA legitimately backs an IRT position — so a symbol funded with
+                    // balance alone is a symbol whose credit ledger this run never touches.
+                    await walletApi.DepositeAsync(new WalletRequest
+                    {
+                        UserId = user.UserId!.Value,
+                        Asset = plan.CreditAsset,
+                        Amount = baseFunding,
+                    });
+                }
             }
             catch (Exception ex)
             {
@@ -262,63 +474,123 @@ public sealed class Simulation(
 
     // ── Phase 6: quote publishing, through the real "buyPrice-sellPrice" text command ─────
 
-    private async Task PublishQuotesAsync(VirtualUser admin, int count, Random random)
+    private async Task PublishQuotesAsync(VirtualUser admin, IReadOnlyList<SymbolPlan> plans, int count, Random random)
     {
-        // A basis around a plausible gold price, walking randomly so quotes actually vary
-        // instead of the matching engine seeing the same price a hundred times in a row.
-        var basePrice = 18_500_000m;
-
-        for (var i = 0; i < count; i++)
+        if (plans.Count == 0)
         {
-            basePrice += random.Next(-50_000, 50_001);
-            var spread = basePrice * 0.002m;
-            var buy = Math.Round(basePrice - spread / 2, 0);
-            var sell = Math.Round(basePrice + spread / 2, 0);
+            RecordError("publish quotes", new InvalidOperationException("No trading pairs to quote."));
+            return;
+        }
+
+        // Each symbol's mid walks on its own, from the price already published for it. A shared
+        // absolute step is what a single-symbol run could get away with: ±50,000 toman is a
+        // plausible move on a mesghal of gold and is lost in the rounding of a Bitcoin price.
+        var mids = plans.ToDictionary(p => p.Symbol, p => p.ReferenceUnitPrice);
+
+        // At least one quote per symbol whatever the caller asked for: a symbol without one
+        // refuses every fill, so a small run would otherwise trade fewer symbols than it planned.
+        var total = Math.Max(count, plans.Count);
+
+        for (var i = 0; i < total; i++)
+        {
+            var plan = plans[i % plans.Count];
+
+            var mid = mids[plan.Symbol] * (1m + (decimal)((random.NextDouble() - 0.5) * 2 * QuoteWalkFraction));
+            mids[plan.Symbol] = mid;
+
+            // Prices are typed the way an admin types them — per mesghal for gold, per traded
+            // unit for everything else — and the bot converts. The command only accepts whole
+            // numbers, which every symbol this platform quotes is comfortably above.
+            var typed = ToTypedPrice(plan.Symbol, mid);
+            var spread = typed * QuoteSpreadFraction;
+            var buy = (long)Math.Round(typed - spread / 2, 0);
+            var sell = (long)Math.Round(typed + spread / 2, 0);
 
             try
             {
-                await botHandler.HandleMessageAsync(NewMessage(admin, $"{(long)buy}-{(long)sell}"));
+                if (plan.QuoteKeyword is { } keyword)
+                {
+                    var command = keyword.Length == 0 ? $"{buy}-{sell}" : $"{buy}-{sell} {keyword}";
+                    await botHandler.HandleMessageAsync(NewMessage(admin, command));
+                }
+                else
+                {
+                    // No keyword can name this pair, so no admin could quote it from the bot
+                    // either. Publishing it directly keeps the run's coverage complete and leaves
+                    // the gap visible in the log rather than as a symbol with no trades.
+                    logger.LogWarning(
+                        "{Symbol} has no alias, so it cannot be quoted through the admin command; publishing it directly.",
+                        plan.Symbol);
+
+                    await orderApi.PublishQuoteAsync(plan.Symbol, buy, sell, admin.UserId!.Value);
+                }
             }
             catch (Exception ex)
             {
-                RecordError($"publish quote #{i}", ex);
+                RecordError($"publish quote #{i} for {plan.Symbol}", ex);
             }
         }
     }
 
+    /// <summary>
+    /// The price an admin types for a symbol, given the price the system stores for it. Gold is
+    /// the one symbol with two units — typed per mesghal and stored per gram, converted by
+    /// <c>QuoteMessage.Prepare</c> — so anchoring on a published quote has to undo that.
+    /// </summary>
+    private static decimal ToTypedPrice(string symbol, decimal unitPrice) =>
+        symbol == CurrenciesConstant.MAUA_IRT ? unitPrice * CurrenciesConstant.GramsPerMesghal : unitPrice;
+
     // ── Phase 7: trade volume via quote acceptance (direct API — see class remarks) ───────
 
-    private async Task<int> GenerateTradesAsync(List<VirtualUser> users, int targetCount, Random random)
+    private async Task<(int Attempted, Dictionary<string, int> SettledBySymbol)> GenerateTradesAsync(
+        List<VirtualUser> users, IReadOnlyList<SymbolPlan> plans, int targetCount, Random random)
     {
+        var settledBySymbol = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
         if (users.Count == 0)
         {
             RecordError("generate trades", new InvalidOperationException("No approved users to trade with."));
-            return 0;
+            return (0, settledBySymbol);
+        }
+
+        if (plans.Count == 0)
+        {
+            RecordError("generate trades", new InvalidOperationException("No quoted symbols to trade."));
+            return (0, settledBySymbol);
         }
 
         var done = 0;
         for (var i = 0; i < targetCount; i++)
         {
+            // The symbol cycles rather than being drawn at random, so coverage is a property of
+            // the run instead of a probability: any run of at least as many trades as there are
+            // symbols touches every one of them, down to the driver's ten-trade smoke default.
+            var plan = plans[i % plans.Count];
+
             var user = users[random.Next(users.Count)];
             var side = random.Next(2) == 0 ? OrderSide.Buy : OrderSide.Sell;
-            var quantity = Math.Round((decimal)(random.NextDouble() * 2.9 + 0.1), 2);
+            var quantity = plan.RandomQuantity(random);
 
             try
             {
-                var (success, message) = await orderApi.AcceptQuoteAsync(user.UserId!.Value, Symbol, side, quantity);
-                if (!success)
+                var (success, message) = await orderApi.AcceptQuoteAsync(user.UserId!.Value, plan.Symbol, side, quantity);
+                if (success)
                 {
-                    RecordError($"trade #{i} for {user.TelegramId}", new InvalidOperationException(message));
+                    settledBySymbol[plan.Symbol] = settledBySymbol.GetValueOrDefault(plan.Symbol) + 1;
+                }
+                else
+                {
+                    RecordError($"trade #{i} ({plan.Symbol}) for {user.TelegramId}", new InvalidOperationException(message));
                 }
                 done++;
             }
             catch (Exception ex)
             {
-                RecordError($"trade #{i} for {user.TelegramId}", ex);
+                RecordError($"trade #{i} ({plan.Symbol}) for {user.TelegramId}", ex);
             }
         }
 
-        return done;
+        return (done, settledBySymbol);
     }
 
     // ── Phase 8: the behaviors named explicitly — help, history, balance, active orders ───

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Simulation.cs
@@ -150,13 +150,18 @@ public sealed class Simulation(
 
         logger.LogInformation("-- Phase 6: admin publishes {Count}+ quotes across {Symbols} symbol(s) --",
             options.QuoteCount, plans.Count);
+
+        // Marked before publishing, and used below to tell this run's quotes from the ones a
+        // previous run left active.
+        var quotePhaseStartedAt = DateTime.UtcNow;
         await PublishQuotesAsync(admin, plans, options.QuoteCount, random);
 
         // A quote too far from the one already published is held for an admin to confirm rather
-        // than published (issue #158), and a symbol with no active quote refuses every fill. Left
-        // unchecked that is a symbol quietly contributing nothing to a run that still reports
-        // itself green — the exact shape of gap this simulator exists to close.
-        var tradable = await FilterToQuotedSymbolsAsync(plans);
+        // than published (issue #158), and a symbol with no quote of this run's own refuses every
+        // fill or fills against a deleted market maker. Left unchecked that is a symbol quietly
+        // contributing nothing to a run that still reports itself green — the exact shape of gap
+        // this simulator exists to close.
+        var tradable = await FilterToQuotedSymbolsAsync(plans, quotePhaseStartedAt);
 
         logger.LogInformation("-- Phase 7: {Count}+ trades via quote acceptance --", options.TradeCount);
         var (tradesDone, tradesBySymbol) = await GenerateTradesAsync(customers, tradable, options.TradeCount, random);
@@ -170,12 +175,17 @@ public sealed class Simulation(
             stopwatch.Elapsed, users.Count, approved.Count, tradesDone, _errors.Count);
 
         // Reported per symbol because the total says nothing about coverage: a symbol with zero
-        // settled trades is a symbol this run did not exercise, however green the total looks.
-        logger.LogInformation("Settled trades by symbol:");
+        // fills is a symbol this run did not exercise, however green the total looks.
+        //
+        // "Filled", not "settled". A fill is a matched trade with its settlement queued on the
+        // outbox; settlement happens tens of seconds later and is what driver.ps1 asserts after
+        // the queue drains (issues #184, #175). Calling these settled here would be this run
+        // claiming more than it has seen, which is the habit this whole change is against.
+        logger.LogInformation("Filled trades by symbol:");
         foreach (var plan in plans)
         {
-            logger.LogInformation("  {Symbol}: {Count} settled", plan.Symbol,
-                tradesBySymbol.TryGetValue(plan.Symbol, out var settled) ? settled : 0);
+            logger.LogInformation("  {Symbol}: {Count} filled", plan.Symbol,
+                tradesBySymbol.TryGetValue(plan.Symbol, out var filled) ? filled : 0);
         }
 
         if (_errors.Count > 0)
@@ -207,7 +217,18 @@ public sealed class Simulation(
         // which symbol each round-robin trade lands on.
         foreach (var pair in CurrenciesConstant.AllTradingPairs.OrderBy(p => p.Symbol, StringComparer.Ordinal))
         {
-            plans.Add(SymbolPlan.For(pair, await ResolveReferenceUnitPriceAsync(pair)));
+            var plan = SymbolPlan.For(pair, await ResolveReferenceUnitPriceAsync(pair));
+
+            if (!plan.HasTradableBand)
+            {
+                RecordError($"size trades for {pair.Symbol}", new InvalidOperationException(
+                    $"MaxQuantity {pair.MaxQuantity} is below the {plan.MinTradeQuantity} that " +
+                    $"MinQuantity and MinNotional require at {plan.ReferenceUnitPrice} per unit, " +
+                    "so no quantity this pair accepts exists; the symbol is excluded from the run."));
+                continue;
+            }
+
+            plans.Add(plan);
         }
 
         return plans;
@@ -223,19 +244,21 @@ public sealed class Simulation(
     /// of a quote. <see cref="DataReset"/> deliberately leaves quotes behind, so this is normally
     /// the price the last run or the price feed left.
     /// </para>
+    ///
+    /// <para>
+    /// <c>GetActiveQuoteAsync</c> returns null for a symbol that has never been quoted and for an
+    /// Orders API that could not be reached, and nothing here can tell those apart — so a blip
+    /// falls back to a reference price that may be outside the band, and every quote for that
+    /// symbol is then held rather than published. That is not caught here but by
+    /// <see cref="FilterToQuotedSymbolsAsync"/>, which checks the outcome instead of guessing at
+    /// the cause.
+    /// </para>
     /// </summary>
     private async Task<decimal> ResolveReferenceUnitPriceAsync(TradingPairInfo pair)
     {
-        try
-        {
-            var quote = await orderApi.GetActiveQuoteAsync(pair.Symbol);
-            if (quote is not null && quote.BuyPrice > 0 && quote.SellPrice > 0)
-                return (quote.BuyPrice + quote.SellPrice) / 2m;
-        }
-        catch (Exception ex)
-        {
-            RecordError($"read the active quote for {pair.Symbol}", ex);
-        }
+        var quote = await orderApi.GetActiveQuoteAsync(pair.Symbol);
+        if (quote is not null && quote.BuyPrice > 0 && quote.SellPrice > 0)
+            return (quote.BuyPrice + quote.SellPrice) / 2m;
 
         if (ReferenceUnitPrices.TryGetValue(pair.BaseAsset, out var reference))
             return reference;
@@ -248,31 +271,39 @@ public sealed class Simulation(
     }
 
     /// <summary>
-    /// Drops any symbol that ended Phase 6 without an active quote, and records an error for it so
-    /// the run cannot report itself clean while silently covering fewer symbols than it claims.
+    /// Drops any symbol whose active quote is not one this run published, and records an error for
+    /// it, so the run cannot report itself clean while silently covering fewer symbols than it
+    /// claims.
+    ///
+    /// <para>
+    /// "A quote exists" is not enough, which is why this compares the publication time against the
+    /// moment Phase 6 began. A quote held for approval as implausible (issue #158) is not
+    /// published, and the previous run's quote stays active in its place — published by a market
+    /// maker <see cref="DataReset"/> has just deleted. Trading against that fills every order
+    /// against an account that no longer exists, which is a far more confusing failure than the
+    /// missing quote it grew out of.
+    /// </para>
     /// </summary>
-    private async Task<List<SymbolPlan>> FilterToQuotedSymbolsAsync(List<SymbolPlan> plans)
+    private async Task<List<SymbolPlan>> FilterToQuotedSymbolsAsync(List<SymbolPlan> plans, DateTime publishedAfter)
     {
         var quoted = new List<SymbolPlan>();
 
         foreach (var plan in plans)
         {
-            try
-            {
-                if (await orderApi.GetActiveQuoteAsync(plan.Symbol) is not null)
-                {
-                    quoted.Add(plan);
-                    continue;
-                }
+            var quote = await orderApi.GetActiveQuoteAsync(plan.Symbol);
 
-                RecordError($"publish a quote for {plan.Symbol}", new InvalidOperationException(
-                    "No active quote after the quote phase — it was probably held for approval as " +
-                    "implausible; no trade on this symbol can be filled."));
-            }
-            catch (Exception ex)
+            if (quote is not null && quote.PublishedAt >= publishedAfter)
             {
-                RecordError($"check the active quote for {plan.Symbol}", ex);
+                quoted.Add(plan);
+                continue;
             }
+
+            RecordError($"publish a quote for {plan.Symbol}", new InvalidOperationException(
+                quote is null
+                    ? "No active quote after the quote phase, so no trade on this symbol can be filled."
+                    : $"The active quote for this symbol was published at {quote.PublishedAt:O}, before this " +
+                      "run's quote phase — this run's own quote was held for approval as implausible, and " +
+                      "the quote left standing belongs to a market maker the reset has deleted."));
         }
 
         return quoted;
@@ -405,46 +436,49 @@ public sealed class Simulation(
 
         foreach (var user in users)
         {
-            try
+            foreach (var (asset, amount) in quoteFunding)
             {
-                foreach (var (asset, amount) in quoteFunding)
-                {
-                    await walletApi.DepositeAsync(new WalletRequest
-                    {
-                        UserId = user.UserId!.Value,
-                        Asset = asset,
-                        Amount = amount,
-                    });
-                }
-
-                foreach (var plan in plans)
-                {
-                    var baseFunding = CurrenciesConstant.RoundToCurrencyPrecision(
-                        plan.MaxTradeQuantity * FundedTradesPerUser * multiplier, plan.BaseAsset);
-
-                    await walletApi.DepositeAsync(new WalletRequest
-                    {
-                        UserId = user.UserId!.Value,
-                        Asset = plan.BaseAsset,
-                        Amount = baseFunding,
-                    });
-
-                    // Credit as well as balance: credit is what the trade path actually checks
-                    // (ValidateCreditAndBalanceAsync), and it is cross-asset — a customer's
-                    // CREDIT_MAUA legitimately backs an IRT position — so a symbol funded with
-                    // balance alone is a symbol whose credit ledger this run never touches.
-                    await walletApi.DepositeAsync(new WalletRequest
-                    {
-                        UserId = user.UserId!.Value,
-                        Asset = plan.CreditAsset,
-                        Amount = baseFunding,
-                    });
-                }
+                await DepositAsync(user, asset, amount);
             }
-            catch (Exception ex)
+
+            foreach (var plan in plans)
             {
-                RecordError($"fund wallet for {user.TelegramId}", ex);
+                var baseFunding = CurrenciesConstant.RoundToCurrencyPrecision(
+                    plan.MaxTradeQuantity * FundedTradesPerUser * multiplier, plan.BaseAsset);
+
+                await DepositAsync(user, plan.BaseAsset, baseFunding);
+
+                // Credit as well as balance: credit is what the trade path actually checks
+                // (ValidateCreditAndBalanceAsync), and it is cross-asset — a customer's
+                // CREDIT_MAUA legitimately backs an IRT position — so a symbol funded with
+                // balance alone is a symbol whose credit ledger this run never touches.
+                await DepositAsync(user, plan.CreditAsset, baseFunding);
             }
+        }
+    }
+
+    /// <summary>
+    /// One funding deposit, with its own error handling.
+    ///
+    /// Per deposit rather than per user on purpose: a user is funded in seven assets now, and one
+    /// try/catch around all of them turns a single failed deposit into a user left funded for some
+    /// symbols and not others. That surfaces much later as trades on one symbol failing for
+    /// insufficient balance, which reads as a problem with that symbol rather than with funding.
+    /// </summary>
+    private async Task DepositAsync(VirtualUser user, string asset, decimal amount)
+    {
+        try
+        {
+            await walletApi.DepositeAsync(new WalletRequest
+            {
+                UserId = user.UserId!.Value,
+                Asset = asset,
+                Amount = amount,
+            });
+        }
+        catch (Exception ex)
+        {
+            RecordError($"fund {asset} wallet for {user.TelegramId}", ex);
         }
     }
 
@@ -522,7 +556,19 @@ public sealed class Simulation(
                         "{Symbol} has no alias, so it cannot be quoted through the admin command; publishing it directly.",
                         plan.Symbol);
 
-                    await orderApi.PublishQuoteAsync(plan.Symbol, buy, sell, admin.UserId!.Value);
+                    // Unlike the conversation path, this one returns its outcome rather than
+                    // sending it to a chat, so it has to be read: a refusal, or a quote the
+                    // plausibility band is holding, is not a published quote.
+                    var (published, message, pending) =
+                        await orderApi.PublishQuoteAsync(plan.Symbol, buy, sell, admin.UserId!.Value);
+
+                    if (!published || pending is not null)
+                    {
+                        RecordError($"publish quote #{i} for {plan.Symbol}", new InvalidOperationException(
+                            pending is not null
+                                ? $"Held for approval: {pending.DeviationPercent}% from the previous mid."
+                                : message));
+                    }
                 }
             }
             catch (Exception ex)
@@ -542,21 +588,21 @@ public sealed class Simulation(
 
     // ── Phase 7: trade volume via quote acceptance (direct API — see class remarks) ───────
 
-    private async Task<(int Attempted, Dictionary<string, int> SettledBySymbol)> GenerateTradesAsync(
+    private async Task<(int Attempted, Dictionary<string, int> FilledBySymbol)> GenerateTradesAsync(
         List<VirtualUser> users, IReadOnlyList<SymbolPlan> plans, int targetCount, Random random)
     {
-        var settledBySymbol = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var filledBySymbol = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         if (users.Count == 0)
         {
             RecordError("generate trades", new InvalidOperationException("No approved users to trade with."));
-            return (0, settledBySymbol);
+            return (0, filledBySymbol);
         }
 
         if (plans.Count == 0)
         {
             RecordError("generate trades", new InvalidOperationException("No quoted symbols to trade."));
-            return (0, settledBySymbol);
+            return (0, filledBySymbol);
         }
 
         var done = 0;
@@ -576,7 +622,7 @@ public sealed class Simulation(
                 var (success, message) = await orderApi.AcceptQuoteAsync(user.UserId!.Value, plan.Symbol, side, quantity);
                 if (success)
                 {
-                    settledBySymbol[plan.Symbol] = settledBySymbol.GetValueOrDefault(plan.Symbol) + 1;
+                    filledBySymbol[plan.Symbol] = filledBySymbol.GetValueOrDefault(plan.Symbol) + 1;
                 }
                 else
                 {
@@ -590,7 +636,7 @@ public sealed class Simulation(
             }
         }
 
-        return (done, settledBySymbol);
+        return (done, filledBySymbol);
     }
 
     // ── Phase 8: the behaviors named explicitly — help, history, balance, active orders ───

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/SymbolPlan.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/SymbolPlan.cs
@@ -1,0 +1,109 @@
+using TallaEgg.Core;
+
+namespace TallaEgg.TelegramBot.Simulator;
+
+/// <summary>
+/// One trading pair as a run will trade it: the pair's own configuration, the price its quotes
+/// walk around, and the quantity band derived from the two.
+///
+/// <para>
+/// It exists because a single shared trade size across every symbol is exactly what hid #146. The
+/// simulator only traded MAUA/IRT, whose precision is two decimal places — the same two the
+/// <c>Orders.Amount</c> column held — so every quantity round-tripped unchanged and a thousand
+/// clean trades proved nothing about a symbol needing eight. Sizes are therefore derived per
+/// symbol, from that symbol's own <see cref="TradingPairInfo.MinQuantity"/>,
+/// <see cref="TradingPairInfo.MinNotional"/> and <see cref="TradingPairInfo.BaseDecimalPlaces"/>,
+/// so one pass produces 0.00000001-scale quantities on Bitcoin and 0.1-scale on gold (#147).
+/// </para>
+/// </summary>
+internal sealed record SymbolPlan(
+    TradingPairInfo Pair,
+    decimal ReferenceUnitPrice,
+    decimal MinTradeQuantity,
+    decimal MaxTradeQuantity)
+{
+    /// <summary>
+    /// How many times the symbol's smallest tradable size the largest simulated trade may be.
+    ///
+    /// A multiple rather than a per-symbol number: because each symbol's own minimum is already
+    /// scaled to its price, thirty of them lands every symbol's trades within the same order of
+    /// magnitude in toman — which is what lets one wallet-funding formula serve prices five
+    /// orders of magnitude apart.
+    /// </summary>
+    internal const int TradeSizeSpread = 30;
+
+    public string Symbol => Pair.Symbol;
+
+    public string BaseAsset => Pair.BaseAsset;
+
+    /// <summary>The credit ledger backing this symbol's base asset, e.g. <c>CREDIT_BTC</c>.</summary>
+    public string CreditAsset => CurrenciesConstant.CreditAssetFor(Pair.BaseAsset);
+
+    /// <summary>
+    /// Builds the plan for a pair, given the price its quotes will be published around
+    /// (per base unit, in the quote currency — per gram for gold, not per mesghal).
+    /// </summary>
+    public static SymbolPlan For(TradingPairInfo pair, decimal referenceUnitPrice)
+    {
+        // Both configured floors bind, and the larger one wins: a quantity above MinQuantity can
+        // still be worth less than MinNotional, and OrderService.ValidateTradingLimits refuses
+        // either. Deriving the second from the price means a symbol whose market has moved since
+        // its limits were written still produces sizes the product accepts.
+        var notionalFloor = referenceUnitPrice > 0 ? pair.MinNotional / referenceUnitPrice : 0m;
+
+        // Rounded up, never down: rounding the floor down at the asset's precision would put it
+        // back under the minimum it was computed from.
+        var minQuantity = CurrenciesConstant.CeilingToCurrencyPrecision(
+            Math.Max(pair.MinQuantity, notionalFloor), pair.BaseAsset);
+
+        var maxQuantity = CurrenciesConstant.RoundToCurrencyPrecision(
+            minQuantity * TradeSizeSpread, pair.BaseAsset);
+
+        if (pair.MaxQuantity > 0 && maxQuantity > pair.MaxQuantity)
+            maxQuantity = pair.MaxQuantity;
+
+        // A symbol whose configured maximum is below the floor above can still be traded, at
+        // exactly one size, rather than producing an empty range the caller has to special-case.
+        if (maxQuantity < minQuantity)
+            maxQuantity = minQuantity;
+
+        return new SymbolPlan(pair, referenceUnitPrice, minQuantity, maxQuantity);
+    }
+
+    /// <summary>
+    /// A trade size for this symbol, at this symbol's own precision — the whole point of the
+    /// plan. Eight decimal places on Bitcoin, two on gold, from the same call.
+    /// </summary>
+    public decimal RandomQuantity(Random random)
+    {
+        var raw = MinTradeQuantity + (decimal)random.NextDouble() * (MaxTradeQuantity - MinTradeQuantity);
+        var quantity = CurrenciesConstant.RoundToCurrencyPrecision(raw, BaseAsset);
+
+        // Only reachable when the pair's own minimum carries more decimal places than the asset
+        // does, which no symbol configured today does — but rounding a draw down through the
+        // floor would produce an order the product rejects, and that is a confusing way to find
+        // out about a mis-configured pair.
+        return quantity < MinTradeQuantity
+            ? CurrenciesConstant.CeilingToCurrencyPrecision(MinTradeQuantity, BaseAsset)
+            : quantity;
+    }
+
+    /// <summary>
+    /// The keyword the admin's <c>buyPrice-sellPrice</c> command needs to mean this symbol: the
+    /// pair's first configured alias, or the empty string for the symbol an absent keyword
+    /// already means. Null when neither applies — a pair added purely by configuration with no
+    /// <see cref="TradingPairInfo.Aliases"/> entry cannot be quoted from the bot at all, and the
+    /// caller publishes it through the API client instead.
+    /// </summary>
+    public string? QuoteKeyword
+    {
+        get
+        {
+            var alias = Pair.Aliases.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a));
+            if (alias is not null)
+                return alias;
+
+            return CurrenciesConstant.ResolveSymbolByAlias(null) == Symbol ? string.Empty : null;
+        }
+    }
+}

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/SymbolPlan.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/SymbolPlan.cs
@@ -62,13 +62,22 @@ internal sealed record SymbolPlan(
         if (pair.MaxQuantity > 0 && maxQuantity > pair.MaxQuantity)
             maxQuantity = pair.MaxQuantity;
 
-        // A symbol whose configured maximum is below the floor above can still be traded, at
-        // exactly one size, rather than producing an empty range the caller has to special-case.
-        if (maxQuantity < minQuantity)
-            maxQuantity = minQuantity;
-
         return new SymbolPlan(pair, referenceUnitPrice, minQuantity, maxQuantity);
     }
+
+    /// <summary>
+    /// Whether any quantity satisfies this pair's limits at this price.
+    ///
+    /// <para>
+    /// It is false only for a pair whose <see cref="TradingPairInfo.MaxQuantity"/> sits below the
+    /// floor its own <see cref="TradingPairInfo.MinNotional"/> implies — a mis-configured pair, or
+    /// one whose price has moved far enough that its limits no longer describe a tradable size.
+    /// Squeezing a size out of that range anyway would produce orders
+    /// <c>OrderService.ValidateTradingLimits</c> refuses, one per trade, which reads as a broken
+    /// simulator rather than a broken symbol. The caller drops the symbol and says why.
+    /// </para>
+    /// </summary>
+    public bool HasTradableBand => MaxTradeQuantity >= MinTradeQuantity;
 
     /// <summary>
     /// A trade size for this symbol, at this symbol's own precision — the whole point of the

--- a/tests/TallaEgg.AllServices.Tests/SymbolPlanTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SymbolPlanTests.cs
@@ -115,6 +115,28 @@ public class SymbolPlanTests
     }
 
     [Fact]
+    public void For_EverySymbolAtItsRealPrice_HasATradableBand()
+    {
+        Assert.All(
+            new[] { CurrenciesConstant.MAUA_IRT, CurrenciesConstant.SEKE_BAHAR_IRT, CurrenciesConstant.BTC_IRT },
+            symbol => Assert.True(PlanFor(symbol).HasTradableBand, $"{symbol} has no tradable band."));
+    }
+
+    [Fact]
+    public void For_MaxQuantityBelowTheNotionalFloor_ReportsNoTradableBand()
+    {
+        var pair = Pair(CurrenciesConstant.SEKE_BAHAR_IRT);
+
+        // A price so low that even MaxQuantity coins are worth less than MinNotional: no quantity
+        // this pair accepts exists. Reported rather than repaired — squeezing a size out of that
+        // range produces orders ValidateTradingLimits refuses, one per trade, which reads as a
+        // broken simulator rather than a broken symbol.
+        var plan = SymbolPlan.For(pair, pair.MinNotional / (pair.MaxQuantity * 2m));
+
+        Assert.False(plan.HasTradableBand);
+    }
+
+    [Fact]
     public void QuoteKeyword_SymbolWithAnAlias_IsThatAlias()
     {
         Assert.Equal("سکه", PlanFor(CurrenciesConstant.SEKE_BAHAR_IRT).QuoteKeyword);

--- a/tests/TallaEgg.AllServices.Tests/SymbolPlanTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SymbolPlanTests.cs
@@ -1,0 +1,159 @@
+using TallaEgg.Core;
+using TallaEgg.TelegramBot.Simulator;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// The simulator's per-symbol trade sizing (issue #147).
+///
+/// <para>
+/// What these tests are really pinning is that two symbols do <b>not</b> get the same trade size.
+/// The simulator traded only MAUA/IRT, whose precision is two decimal places — exactly what the
+/// <c>Orders.Amount</c> column held — so 1009 clean simulated trades sat on top of #146, which one
+/// manual Bitcoin trade then found in minutes. A shared step, or a shared minimum, would flatten
+/// that difference again and the run would be back to proving one symbol works.
+/// </para>
+///
+/// <para>
+/// Read from <see cref="CurrenciesConstant"/>'s compiled defaults, never through
+/// <c>Configure</c>: that method mutates static state every other test class in this process
+/// reads, and xUnit runs classes in parallel.
+/// </para>
+/// </summary>
+public class SymbolPlanTests
+{
+    private static TradingPairInfo Pair(string symbol) =>
+        CurrenciesConstant.GetTradingPairInfo(symbol)
+            ?? throw new InvalidOperationException($"{symbol} is not a compiled-in trading pair.");
+
+    /// <summary>Reference prices close to the levels the live feed publishes, so the sizes are the real ones.</summary>
+    private static SymbolPlan PlanFor(string symbol) => symbol switch
+    {
+        CurrenciesConstant.MAUA_IRT => SymbolPlan.For(Pair(symbol), 22_100_000m),
+        CurrenciesConstant.SEKE_BAHAR_IRT => SymbolPlan.For(Pair(symbol), 118_900_000m),
+        CurrenciesConstant.BTC_IRT => SymbolPlan.For(Pair(symbol), 16_620_000_000m),
+        _ => throw new ArgumentOutOfRangeException(nameof(symbol), symbol, "No reference price for this symbol.")
+    };
+
+    private static List<decimal> Draw(SymbolPlan plan, int count = 200)
+    {
+        var random = new Random(1);
+        return Enumerable.Range(0, count).Select(_ => plan.RandomQuantity(random)).ToList();
+    }
+
+    private static int DecimalPlaces(decimal value) => (decimal.GetBits(value)[3] >> 16) & 0xFF;
+
+    [Fact]
+    public void RandomQuantity_Bitcoin_UsesMoreThanTwoDecimalPlaces()
+    {
+        var quantities = Draw(PlanFor(CurrenciesConstant.BTC_IRT));
+
+        // The whole point of the change: a Bitcoin quantity that survives a decimal(18,2) column
+        // unchanged is a Bitcoin quantity that could not have caught #146.
+        Assert.Contains(quantities, q => q != decimal.Round(q, 2));
+        Assert.All(quantities, q => Assert.Equal(q, decimal.Round(q, 8)));
+    }
+
+    [Fact]
+    public void RandomQuantity_Gold_StaysAtTheAssetsOwnTwoDecimalPlaces()
+    {
+        var quantities = Draw(PlanFor(CurrenciesConstant.MAUA_IRT));
+
+        Assert.All(quantities, q => Assert.True(DecimalPlaces(q) <= 2, $"{q} has more than two decimal places."));
+    }
+
+    [Theory]
+    [InlineData(CurrenciesConstant.MAUA_IRT)]
+    [InlineData(CurrenciesConstant.SEKE_BAHAR_IRT)]
+    [InlineData(CurrenciesConstant.BTC_IRT)]
+    public void RandomQuantity_EverySymbol_RespectsThatSymbolsTradingLimits(string symbol)
+    {
+        var plan = PlanFor(symbol);
+
+        // OrderService.ValidateTradingLimits refuses any of the three, and a refused order is a
+        // trade the run never makes — which would read as a symbol quietly contributing nothing.
+        Assert.All(Draw(plan), q =>
+        {
+            Assert.True(q >= plan.Pair.MinQuantity, $"{q} is below {symbol}'s MinQuantity.");
+            Assert.True(q <= plan.Pair.MaxQuantity, $"{q} is above {symbol}'s MaxQuantity.");
+            Assert.True(q * plan.ReferenceUnitPrice >= plan.Pair.MinNotional, $"{q} is worth less than {symbol}'s MinNotional.");
+        });
+    }
+
+    [Fact]
+    public void RandomQuantity_BitcoinAndGold_ProduceQuantitiesOrdersOfMagnitudeApart()
+    {
+        var bitcoin = Draw(PlanFor(CurrenciesConstant.BTC_IRT)).Max();
+        var gold = Draw(PlanFor(CurrenciesConstant.MAUA_IRT)).Max();
+
+        Assert.True(gold > bitcoin * 100m,
+            $"Gold's largest simulated quantity ({gold}) and Bitcoin's ({bitcoin}) are on the same scale, " +
+            "so the run is no longer exercising both.");
+    }
+
+    [Fact]
+    public void For_PriceTooLowForTheNotionalMinimum_RaisesTheFloorAboveMinQuantity()
+    {
+        // MinQuantity alone would allow 0.0001 BTC, worth 100,000 toman at this price — under the
+        // pair's own 1,000,000 MinNotional, which the order path rejects.
+        var plan = SymbolPlan.For(Pair(CurrenciesConstant.BTC_IRT), 1_000_000_000m);
+
+        Assert.True(plan.MinTradeQuantity > Pair(CurrenciesConstant.BTC_IRT).MinQuantity);
+        Assert.True(plan.MinTradeQuantity * plan.ReferenceUnitPrice >= Pair(CurrenciesConstant.BTC_IRT).MinNotional);
+    }
+
+    [Fact]
+    public void For_MinimumTimesTheSpreadAboveMaxQuantity_ClampsToTheConfiguredMaximum()
+    {
+        var pair = Pair(CurrenciesConstant.SEKE_BAHAR_IRT);
+
+        // A price low enough that thirty times the notional floor would run past MaxQuantity.
+        var plan = SymbolPlan.For(pair, pair.MinNotional / (pair.MaxQuantity / 2m));
+
+        Assert.Equal(pair.MaxQuantity, plan.MaxTradeQuantity);
+        Assert.True(plan.MaxTradeQuantity >= plan.MinTradeQuantity);
+    }
+
+    [Fact]
+    public void QuoteKeyword_SymbolWithAnAlias_IsThatAlias()
+    {
+        Assert.Equal("سکه", PlanFor(CurrenciesConstant.SEKE_BAHAR_IRT).QuoteKeyword);
+        Assert.Equal("بیت", PlanFor(CurrenciesConstant.BTC_IRT).QuoteKeyword);
+    }
+
+    [Fact]
+    public void QuoteKeyword_TheSymbolAnAbsentKeywordMeans_IsEmptyRatherThanNull()
+    {
+        // MAUA/IRT has no alias and needs none: the admin's quote command already defaults to it.
+        Assert.Equal(string.Empty, PlanFor(CurrenciesConstant.MAUA_IRT).QuoteKeyword);
+    }
+
+    [Fact]
+    public void QuoteKeyword_PairWithNoAliasAndNotTheDefault_IsNull()
+    {
+        // A pair added by configuration with no Aliases entry cannot be named in the admin's quote
+        // command at all, so the simulator publishes it through the API client instead.
+        var orphan = new TradingPairInfo
+        {
+            Symbol = "ETH/IRT",
+            BaseAsset = "ETH",
+            QuoteAsset = CurrenciesConstant.Toman,
+            MinQuantity = 0.01m,
+            MaxQuantity = 100m,
+            MinNotional = 1_000_000m,
+            BaseDecimalPlaces = 8
+        };
+
+        Assert.Null(SymbolPlan.For(orphan, 200_000_000m).QuoteKeyword);
+    }
+
+    [Fact]
+    public void CreditAsset_EverySymbol_IsThatSymbolsOwnCreditLedger()
+    {
+        // Credit is per-asset in storage: funding CREDIT_MAUA does not let a customer trade
+        // Bitcoin, so a run that funds one ledger has funded one symbol.
+        Assert.Equal("CREDIT_MAUA", PlanFor(CurrenciesConstant.MAUA_IRT).CreditAsset);
+        Assert.Equal("CREDIT_BTC", PlanFor(CurrenciesConstant.BTC_IRT).CreditAsset);
+        Assert.Equal("CREDIT_SEKE_BAHAR", PlanFor(CurrenciesConstant.SEKE_BAHAR_IRT).CreditAsset);
+    }
+}


### PR DESCRIPTION
**Branch Name**: `feat/simulator-trades-every-symbol`
**Linked Issue**: Closes #147

---

## Description

The simulator hard-coded one symbol, so a full run — 100 users, 120 quotes, 1000 trades — was
entirely gold. It now reads its symbols from `CurrenciesConstant.AllTradingPairs` and gives each
one its own quotes, its own wallet funding and its own trade sizes, at that symbol's own
precision.

That precision is the point. On 2026-08-27 a run reported `trades attempted 1000, errors 0` with a
verifiably clean database, and **a single manual BTC trade immediately afterwards found #146** —
`Orders.Amount` was `decimal(18, 2)` while wallets and trades were `(28, 8)`, so `2.111` was stored
as `2.11` and the collateral difference stayed locked with no order holding it. The simulator could
not have found it: MAUA's precision is 2, exactly what the column held, so every gold quantity
round-tripped unchanged. A run that touches one symbol proves that symbol works and reads as if it
proved the platform works.

---

## Type of Change
- [x] Feature (new capability) — dev tooling only; no product code is touched.

---

## Changes Made

- **`SymbolPlan.cs` (new)** — one trading pair as a run will trade it. Derives the trade-size band
  from that pair's own `MinQuantity`, `MinNotional` and `BaseDecimalPlaces` (largest trade =
  30× the smallest tradable size, clamped to `MaxQuantity`), and resolves the pair's quote-command
  keyword and `CREDIT_` ledger.
- **Phase 2** turns auto-quote off for every symbol the run trades, not just `MAUA/IRT`.
- **Phase 4** funds each quote currency, each traded symbol's base asset, and each base asset's
  `CREDIT_` ledger — sized from the same band Phase 7 draws from, so no symbol's reserve runs out
  earlier than another's. It previously deposited Toman and MAUA and nothing else, which is why
  registration's three default wallets were all anyone ever had.
- **Phase 6** publishes per symbol through the real `buyPrice-sellPrice` admin command, using each
  pair's own alias (`سکه`, `بیت`; none for `MAUA/IRT`, which the command already defaults to). The
  mid **anchors on the symbol's currently published quote** and walks by a fraction rather than a
  fixed toman step — an absolute step that varies gold plausibly is lost in the rounding of a
  Bitcoin price, and a quote more than ±5% from the current one is *held for approval*, not
  published (#158). At least one quote per symbol is published regardless of `--quotes`.
- **A symbol with no active quote after Phase 6 is now a recorded error** and is dropped from the
  trading phase. Previously that would have been a symbol quietly contributing nothing to a run
  that still reported itself green — the same shape of gap this issue is about.
- **Phase 7** cycles the symbol per trade, so coverage is a property of the run rather than a
  probability: any run with at least as many trades as there are symbols touches all of them, down
  to the driver's 10-trade default. The summary now reports settled trades per symbol.
- **`Program.cs`** calls `CurrenciesConstant.Configure`, as every service and the real bot already
  do, so the run's catalogue matches what the APIs it drives are serving.
- **`driver.ps1`** snapshots every symbol's auto-quote flag from the `AutoQuoteSettings` table
  before the run and restores them afterwards, instead of only `MAUA/IRT`. Read from the table
  rather than the REST endpoint because that endpoint is `GetOrCreate` — probing a symbol would
  create its row — and because nothing enumerates them.
- **`SKILL.md`** documents the multi-symbol behaviour and the per-symbol breakdown.

### Reference prices

Only consulted when a symbol has no published quote to anchor on. Whatever the run publishes
becomes the price the next quote is measured against, so an invented figure would lock the live
feed out of its own market (±5% band). These are the levels the feed itself was publishing on
2026-09-01: melted gold ≈ 22.1M toman/gram, a full Bahar Azadi coin ≈ 1.24× the mesghal price of
melted gold, Bitcoin ≈ 16.6 billion toman. A pair listed in neither the table nor the quote history
falls back to `MinNotional / MinQuantity` — not a market price, but the right order of magnitude.

---

## Testing Completed

### Unit Tests

New `SymbolPlanTests` (10 tests) pin the thing that matters: that two symbols do **not** get the
same trade size.

```
dotnet build TallaEgg.sln --no-incremental   →  Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test TallaEgg.sln                     →  Passed! Failed: 0, Passed: 706, Skipped: 0
```

- `RandomQuantity_Bitcoin_UsesMoreThanTwoDecimalPlaces` — a BTC quantity that survives a
  `decimal(18,2)` column unchanged is one that could not have caught #146.
- `RandomQuantity_Gold_StaysAtTheAssetsOwnTwoDecimalPlaces`
- `RandomQuantity_EverySymbol_RespectsThatSymbolsTradingLimits` — `MinQuantity`, `MaxQuantity` and
  `MinNotional`, all three of which `OrderService.ValidateTradingLimits` refuses.
- `RandomQuantity_BitcoinAndGold_ProduceQuantitiesOrdersOfMagnitudeApart`
- plus the notional floor, the `MaxQuantity` clamp, quote-keyword resolution and the per-asset
  credit ledger.

### Full run — `/run-tallaegg`, 100 users / 120 quotes / 1000 trades, seed 42

```
Trading 3 symbol(s) this run:
  BTC/IRT:        quantities 0.0001 to 0.0030 at 8 decimal place(s), around 16,427,413,700 IRT per بیت‌کوین
  MAUA/IRT:       quantities 0.1    to 3.0    at 2 decimal place(s), around     22,127,983.75 IRT per گرم
  SEKE_BAHAR/IRT: quantities 0.01   to 0.30   at 2 decimal place(s), around    118,900,000 IRT per سکه

=== Done in 00:03:39. Registered 100 (89 approved), trades attempted 1000, errors 0 ===
Settled trades by symbol:
  BTC/IRT: 334 settled
  MAUA/IRT: 333 settled
  SEKE_BAHAR/IRT: 333 settled

Restored auto-quote for BTC/IRT to IsEnabled=True.
Restored auto-quote for MAUA/IRT to IsEnabled=True.
Simulation completed with errors 0; 1000 settlement(s) completed, no new failures.
```

**(a) Every pair in `AllTradingPairs` was touched** — trades recorded per symbol:

| Symbol | Trades | Min quantity | Max quantity |
| --- | ---: | --- | --- |
| `BTC/IRT` | 334 | 0.00012780 | 0.00299938 |
| `MAUA/IRT` | 333 | 0.12 | 2.97 |
| `SEKE_BAHAR/IRT` | 333 | 0.01 | 0.30 |

**(b) Quantities really use each symbol's own precision.** Order amounts with more than two decimal
places, per symbol:

| Symbol | Orders | Amounts beyond 2 dp |
| --- | ---: | ---: |
| `BTC/IRT` | 668 | **668** |
| `MAUA/IRT` | 666 | 0 |
| `SEKE_BAHAR/IRT` | 666 | 0 |

Real rows from the `Trades` table:

```
Symbol    Quantity                 Price            QuoteQuantity
BTC/IRT   0.00077100   16463148769.00000000       12693087.00000000
BTC/IRT   0.00294146   16430255365.00000000       48328938.00000000
BTC/IRT   0.00046362   16430255365.00000000        7617394.00000000
BTC/IRT   0.00027373   16430255365.00000000        4497453.00000000
MAUA/IRT  0.64000000      22182702.34000000
MAUA/IRT  2.43000000      22182702.34000000
SEKE_BAHAR/IRT 0.19000000 118121859.00000000
SEKE_BAHAR/IRT 0.13000000 118121859.00000000
```

Every BTC quantity carries eight decimal places. On the old code they were all two.

**(c) Database clean after the run** (queries scoped to `Users.TelegramId < 0`, this run's rows):

| Check | Result |
| --- | --- |
| Trades settled more than once | **0** |
| Settlement transactions per trade | **4 for all 1000** (buyer/quote, buyer/base, seller/base, seller/quote) |
| Orders left in a non-terminal status | **0** — all 2000 `Completed` |
| Wallets with collateral still locked | **0** — `SUM(LockedBalance) = 0` on all 7 assets |
| Wallets disagreeing with their transaction history | **0** (`Balance` vs `SUM(BallanceAfter - BallanceBefore)`) |
| This run's outbox messages not `Completed` | **0** |
| New `Failed` outbox messages | **0** — the driver's delta check; the 101 in the table are pre-existing, newest 9½ hours before the run |

Wallets created, confirming the funding follows the symbol:

```
Asset               Wallets   TotalLocked
BTC                      89    0.00000000
CREDIT_BTC               89    0.00000000
CREDIT_MAUA             100    0.00000000
CREDIT_SEKE_BAHAR        89    0.00000000
IRT                     100    0.00000000
MAUA                    100    0.00000000
SEKE_BAHAR               89    0.00000000
```

(100 for the three assets registration seeds by default, 89 for everything the run funded: the 88
approved customers plus the admin.)

### The known trap, and what happened to it

The comment at `Simulation.cs:79` records that a first pass at 100 users / 1000 trades exhausted
the admin's MAUA around trade #656, fixed by funding the admin at 50×. Several symbols do **not**
make that arrive sooner: the funding is computed per symbol, so the same budget is not divided
between them — a symbol added to the run brings its own base asset and its own credit ledger with
it. At this run's sizes the market maker held 6000 g, 600 coins and 6 BTC against an expected
one-sided draw of roughly 260 g, 26 coins and 0.26 BTC. Nothing ran dry; 1000/1000 trades settled.

### Note for whoever runs these checks next

`DataReset` deletes `Trades` and `Transactions` but not `TradeSettlements`, so the wallet database
carries settlement rows for trades from earlier runs whose transactions are gone. An unscoped
"settlements without exactly four transactions" query lights up with hundreds of those. They are
residue, not faults — scoped to this run's own trades the count is 4 for every one of the 1000.

---

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `config/appsettings.global.json` untouched and uncommitted
- [x] Code compiles without warnings (`TreatWarningsAsErrors`)

## Code Quality
- [x] Comments in English, explaining why
- [x] `MethodName_Scenario_ExpectedResult` naming on the new tests
- [x] No product code changed — the diff is the Simulator, its test, and the run-tallaegg skill
- [x] No new dependencies

## Breaking Changes?
- [x] No breaking changes — a local dev tool, never referenced by a service's `Program.cs`.

## Deployment Notes

Not deployed. No migrations, no configuration changes, no feature flags. A run funds more wallets
than before (7 deposits per user rather than 2) and leaves per-symbol wallets behind, all inside
the `TelegramId < 0` range the next run's `DataReset` wipes.

## Related Issues

- Closes #147
- #146 — the defect this would have caught, and the reason the sizing is per symbol
- #101 — the simulator itself
- #158 — the plausibility band the quote anchoring exists to stay inside
- #184, #175 — the settlement guarantees this builds on; both still hold with several symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)
