### PR TITLE
[Hotfix][Critical] BOT_DIRECT_CONNECTION=1 now actually bypasses the proxy — issue #199

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
@@ -11,34 +11,35 @@ configured port.)
 
 | Condition | What you get | Timeout |
 |---|---|---|
-| `BOT_DIRECT_CONNECTION=1` | `HttpClient` with the **default** handler | 120 s |
+| `BOT_DIRECT_CONNECTION=1` | `HttpClient` on a handler with `UseProxy = false` | 120 s |
 | A system proxy applies | `HttpClient` with `Proxy` set explicitly from `WebRequest.GetSystemWebProxy()` | 120 s |
-| No system proxy applies | `HttpClient` with the default handler | 120 s |
-| Anything above throws | Bare `TelegramBotClient(token)`, no `HttpClient` supplied | **100 s** |
+| No system proxy applies | `HttpClient` on the stock handler | 120 s |
+| Anything above throws | `HttpClient` on the stock handler | 120 s |
 
 The 120 s matters because `getUpdates` is a long poll and the .NET default of 100 s is too tight
-for it. Note the last row: the exception fallback drops to that 100 s default, and
-`TelegramBotHostedService` derives its polling-recovery gap from `_botClient.Timeout`, so a
-silent fall onto that path shifts the down-alert threshold too.
+for it. Every row gets it now, the exception fallback included: that row used to supply no
+`HttpClient` at all and silently take the 100 s default, which moved the down-alert threshold
+with it, because `TelegramBotHostedService` derives its polling-recovery gap from
+`_botClient.Timeout` (#199).
 
-### Two things the console output will not tell you
+### Reading the console output
 
-**`🔧 Using proxy: …` is printed unconditionally**, on line 29, *before* the check on line 31
-that decides whether a proxy is actually in play. When no proxy applies, `GetProxy` returns the
-destination itself and you get `🔧 Using proxy: https://api.telegram.org/` — which means *no
-proxy*. Do not read that line as evidence of one.
+One line is printed, and it means what it says. Until #199 two of the three did not, so output
+from a build older than that fix cannot be read this way.
 
-**`BOT_DIRECT_CONNECTION=1` does not disable proxying.** It prints
-`🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)` and constructs
-`new HttpClient { Timeout = … }` — the default `HttpClientHandler`, which on Windows has
-`UseProxy = true` and `Proxy = null`, so it falls through to `HttpClient.DefaultProxy` and reads
-the same WinInet settings. Nothing sets `UseProxy = false`.
-
-What the flag really changes is *how* the proxy is resolved — `DefaultProxy` instead of an
-explicit `WebRequest.GetSystemWebProxy()` handler — which is sometimes enough to shake off a
-misbehaving handler, and sometimes not. **Treat it as worth trying, not as a guaranteed bypass.**
-A real bypass needs `new HttpClient(new HttpClientHandler { UseProxy = false })`; that gap is
-tracked as an issue, not fixed here.
+- **`🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)`** — the handler has
+  `UseProxy = false`, so nothing the bot sends is proxied: not the system proxy, not one
+  configured elsewhere in .NET. Before #199 this line printed over a stock handler, which on
+  Windows leaves `UseProxy = true` with a null `Proxy` and so falls through to
+  `HttpClient.DefaultProxy` — the same WinInet settings the proxy path reads. It proxied, and
+  said it did not.
+- **`🔧 Using proxy: <uri>`** — a system proxy applies to `api.telegram.org` and the client is
+  bound to it. Printed only in that case; it used to be printed unconditionally, *before* the
+  check that decides whether a proxy is in play.
+- **`🔧 No system proxy applies to api.telegram.org`** — `GetProxy` answered with the destination
+  itself, or with null. Both mean no proxy. The first used to surface as
+  `🔧 Using proxy: https://api.telegram.org/`, which says *no proxy* and reads as its opposite;
+  the second took the proxy branch outright and printed `🔧 Using proxy: ` with nothing after it.
 
 ## The failure this file exists for
 
@@ -62,8 +63,15 @@ The build is not optional — `dotnet run --no-build` against a stale `bin` runs
 already changed, which here would mean running a binary that predates the flag and concluding it
 does not work.
 
-If the drops continue, the proxy is still in the path — see the note above — and the next step is
-to clear it machine-wide or disconnect the VPN.
+Two outcomes, and they mean different things:
+
+- **The drops continue.** The proxy is not what was dropping them — with the flag set the bot's
+  client does not use one. Look at the VPN and the direct route instead. Note that the flag covers
+  the bot's Telegram client only; the startup diagnostics build their own `HttpClient`, and
+  everything else on the machine still follows the system proxy.
+- **The bot stops connecting entirely**, with `No connection could be made because the target machine
+  actively refused it. (api.telegram.org:443)` or a timeout. The machine cannot reach Telegram
+  directly after all, so the proxy was doing real work. Unset the flag; the fix is elsewhere.
 
 ## When nothing connects at all
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
@@ -6,6 +6,16 @@ namespace TallaEgg.TelegramBot
 {
     public class ProxyBotClient
     {
+        private static readonly Uri TelegramApiRoot = new("https://api.telegram.org");
+
+        // getUpdates is a long poll, so the .NET default of 100 s is too tight. Every path below
+        // reaches this through CreateHttpClient, the exception fallback included: that fallback
+        // used to hand TelegramBotClient no HttpClient at all and silently take the 100 s
+        // default, and TelegramBotHostedService derives its polling-recovery gap from
+        // ITelegramBotClient.Timeout, so landing there moved the down-alert threshold too
+        // (issue #199).
+        internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(120);
+
         public static ITelegramBotClient CreateWithProxy(string token)
         {
             // Local override: when the machine can reach Telegram directly (e.g. a TUN-mode VPN),
@@ -13,49 +23,76 @@ namespace TallaEgg.TelegramBot
             // connection ("response ended prematurely"). Set BOT_DIRECT_CONNECTION=1 to bypass the
             // proxy and connect directly. Unset (the default) keeps the original proxy behaviour,
             // which the server deployment relies on.
+            //
+            // Deliberately outside the try below: if resolving the system proxy threw, the catch
+            // would fall back to the default handler, which proxies — the one thing this flag is
+            // set to avoid.
             if (Environment.GetEnvironmentVariable("BOT_DIRECT_CONNECTION") == "1")
             {
-                Console.WriteLine("🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)");
-                var directClient = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
-                return new TelegramBotClient(token, directClient);
+                var (directHandler, directMessage) = ChooseConnection(bypassProxy: true, systemProxy: null);
+                Console.WriteLine(directMessage);
+                return new TelegramBotClient(token, CreateHttpClient(directHandler));
             }
 
             try
             {
-                // Get system proxy
-                var proxy = WebRequest.GetSystemWebProxy();
-                var proxyUri = proxy.GetProxy(new Uri("https://api.telegram.org"));
-                
-                Console.WriteLine($"🔧 Using proxy: {proxyUri}");
-                
-                if (proxyUri != new Uri("https://api.telegram.org"))
-                {
-                    // Create bot client with proxy
-                    var handler = new HttpClientHandler
-                    {
-                        Proxy = proxy,
-                        UseProxy = true
-                    };
-                    
-                    var httpClient = new HttpClient(handler);
-                    httpClient.Timeout = TimeSpan.FromSeconds(120); // افزایش timeout به 2 دقیقه
-                    
-                    return new TelegramBotClient(token, httpClient);
-                }
-                else
-                {
-                    // No proxy needed - create with extended timeout
-                    var httpClient = new HttpClient();
-                    httpClient.Timeout = TimeSpan.FromSeconds(120); // افزایش timeout به 2 دقیقه
-                    return new TelegramBotClient(token, httpClient);
-                }
+                var (handler, message) = ChooseConnection(bypassProxy: false, WebRequest.GetSystemWebProxy());
+                Console.WriteLine(message);
+                return new TelegramBotClient(token, CreateHttpClient(handler));
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"⚠️ Error configuring proxy: {ex.Message}");
-                Console.WriteLine("Falling back to direct connection...");
-                return new TelegramBotClient(token);
+                Console.WriteLine("Falling back to the default handler, which may still use the system proxy...");
+                return new TelegramBotClient(token, CreateHttpClient(null));
             }
         }
+
+        /// <summary>
+        /// Chooses the handler the bot's <see cref="HttpClient"/> is built on, and the one line
+        /// that describes the choice. A <see langword="null"/> handler means the stock one is
+        /// right and nothing needs configuring.
+        /// </summary>
+        /// <remarks>
+        /// Split out of <see cref="CreateWithProxy"/> so the choice can be asserted: the
+        /// <see cref="ITelegramBotClient"/> that method returns exposes neither its handler nor
+        /// its proxy settings, which is why the bug in issue #199 — a bypass flag that did not
+        /// bypass — survived behind a message claiming otherwise.
+        /// </remarks>
+        internal static (HttpClientHandler? Handler, string Message) ChooseConnection(
+            bool bypassProxy,
+            IWebProxy? systemProxy)
+        {
+            if (bypassProxy)
+            {
+                // UseProxy = false is what makes this a bypass. The stock handler leaves it true
+                // with a null Proxy, which on Windows resolves through HttpClient.DefaultProxy —
+                // the same WinInet settings GetSystemWebProxy reads — so it proxies just like the
+                // branch below (issue #199).
+                return (new HttpClientHandler { UseProxy = false },
+                    "🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)");
+            }
+
+            // GetProxy answers with the destination itself when no proxy applies to it, and can
+            // answer null. Neither means "send this through a proxy", and reporting either as one
+            // is how "🔧 Using proxy: https://api.telegram.org/" — which means the opposite — used
+            // to get printed.
+            var proxyUri = systemProxy?.GetProxy(TelegramApiRoot);
+            if (proxyUri is null || proxyUri == TelegramApiRoot)
+            {
+                return (null, $"🔧 No system proxy applies to {TelegramApiRoot.Host}");
+            }
+
+            return (new HttpClientHandler { Proxy = systemProxy, UseProxy = true },
+                $"🔧 Using proxy: {proxyUri}");
+        }
+
+        /// <summary>
+        /// Builds the bot's <see cref="HttpClient"/> on <paramref name="handler"/>, or on the
+        /// stock handler when it is <see langword="null"/>. The single place the long-poll
+        /// timeout is applied, so no path can quietly do without it.
+        /// </summary>
+        internal static HttpClient CreateHttpClient(HttpClientHandler? handler) =>
+            new(handler ?? new HttpClientHandler()) { Timeout = RequestTimeout };
     }
 }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
@@ -11,6 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- ProxyBotClient.ChooseConnection and CreateHttpClient are internal so the connection
+         choice can be asserted directly; the ITelegramBotClient they end up inside exposes
+         neither its handler nor its timeout source (issue #199). -->
+    <InternalsVisibleTo Include="TallaEgg.AllServices.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Telegram.Bot" Version="22.6.0" />

--- a/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using TallaEgg.TelegramBot;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Pins what <see cref="ProxyBotClient"/> actually does, because it said one thing and did
+/// another: <c>BOT_DIRECT_CONNECTION=1</c> printed "proxy bypassed" and then proxied anyway,
+/// since <c>new HttpClient()</c> takes the stock handler — <c>UseProxy = true</c>,
+/// <c>Proxy = null</c> — which on Windows resolves through <c>HttpClient.DefaultProxy</c> and
+/// reads the same WinInet settings the proxy branch reads. An operator who trusted that message
+/// struck a working workaround off the list on false evidence (issue #199).
+///
+/// <para>
+/// The message was never checkable from outside: <c>CreateWithProxy</c> returns an
+/// <c>ITelegramBotClient</c>, which exposes neither its handler nor its proxy settings. That is
+/// why the choice now comes out of <c>ChooseConnection</c> as a value — a claim about proxying
+/// should fail a test when it stops being true, not wait for someone to read the source.
+/// </para>
+/// </summary>
+public class ProxyBotClientTests
+{
+    private static readonly Uri TelegramApiRoot = new("https://api.telegram.org");
+
+    [Fact]
+    public void ChooseConnection_BypassRequested_TurnsProxyingOff()
+    {
+        var (handler, _) = ProxyBotClient.ChooseConnection(bypassProxy: true, systemProxy: null);
+
+        using var configured = Assert.IsType<HttpClientHandler>(handler);
+        Assert.False(configured.UseProxy);
+    }
+
+    [Fact]
+    public void StockHandler_LeftAlone_WouldStillProxy()
+    {
+        // The defaults the bug rode on. If .NET ever flipped these, the test above would keep
+        // passing while meaning much less, so record what it is guarding against.
+        using var stock = new HttpClientHandler();
+
+        Assert.True(stock.UseProxy);
+        Assert.Null(stock.Proxy);
+    }
+
+    [Fact]
+    public void ChooseConnection_BypassRequested_NeverConsultsTheSystemProxy()
+    {
+        // A bypass that asked the system for its proxy first would fail exactly when it is needed
+        // most — on a machine whose proxy configuration is the problem.
+        var (handler, _) = ProxyBotClient.ChooseConnection(bypassProxy: true, new ThrowingProxy());
+
+        handler?.Dispose();
+    }
+
+    [Fact]
+    public void ChooseConnection_BypassRequested_SaysSo()
+    {
+        var (handler, message) = ProxyBotClient.ChooseConnection(bypassProxy: true, systemProxy: null);
+        handler?.Dispose();
+
+        Assert.Contains("BOT_DIRECT_CONNECTION=1", message);
+        Assert.DoesNotContain("Using proxy", message);
+    }
+
+    [Fact]
+    public void ChooseConnection_ProxyApplies_UsesItAndNamesIt()
+    {
+        var systemProxy = new StubProxy(new Uri("http://proxy.invalid:8080"));
+
+        var (handler, message) = ProxyBotClient.ChooseConnection(bypassProxy: false, systemProxy);
+
+        using var configured = Assert.IsType<HttpClientHandler>(handler);
+        Assert.True(configured.UseProxy);
+        Assert.Same(systemProxy, configured.Proxy);
+        Assert.Contains("http://proxy.invalid:8080", message);
+    }
+
+    [Fact]
+    public void ChooseConnection_GetProxyReturnsTheDestination_ReportsNoProxy()
+    {
+        // What GetSystemWebProxy answers when no proxy applies to the destination. Printed
+        // unconditionally, it used to read "Using proxy: https://api.telegram.org/" — which means
+        // *no* proxy, and reads as the opposite.
+        var (handler, message) = ProxyBotClient.ChooseConnection(
+            bypassProxy: false, new StubProxy(TelegramApiRoot));
+
+        Assert.Null(handler);
+        Assert.DoesNotContain("Using proxy", message);
+    }
+
+    [Fact]
+    public void ChooseConnection_GetProxyReturnsNull_ReportsNoProxy()
+    {
+        // null is not equal to the destination, so this used to take the proxy branch and print
+        // "Using proxy: " with nothing after it.
+        var (handler, message) = ProxyBotClient.ChooseConnection(bypassProxy: false, new StubProxy(null));
+
+        Assert.Null(handler);
+        Assert.DoesNotContain("Using proxy", message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateHttpClient_WithOrWithoutAHandler_KeepsTheLongPollTimeout(bool withHandler)
+    {
+        // The exception fallback supplies no handler. It must still get 120 s: getUpdates is a
+        // long poll, and TelegramBotHostedService derives its down-alert threshold from this.
+        using var client = ProxyBotClient.CreateHttpClient(
+            withHandler ? new HttpClientHandler { UseProxy = false } : null);
+
+        Assert.Equal(TimeSpan.FromSeconds(120), client.Timeout);
+    }
+
+    [Fact]
+    public async Task ChooseConnection_BypassRequested_SendsNoTrafficToAConfiguredProxy()
+    {
+        // The assertions above describe the handler; this one watches the socket. A proxy is
+        // attached to the bypass handler and must still be ignored, so anything arriving at the
+        // listener means UseProxy = false did not take effect. Loopback only — no outbound
+        // traffic and no state shared with other tests.
+        using var proxy = new RecordingProxy();
+        var destination = new Uri($"http://127.0.0.1:{ClosedPort()}/");
+
+        var (bypassHandler, _) = ProxyBotClient.ChooseConnection(bypassProxy: true, systemProxy: null);
+        Assert.NotNull(bypassHandler);
+        bypassHandler.Proxy = proxy.AsWebProxy();
+
+        using (var direct = ProxyBotClient.CreateHttpClient(bypassHandler))
+        {
+            await Assert.ThrowsAsync<HttpRequestException>(() => direct.GetStringAsync(destination));
+        }
+
+        Assert.Equal(0, proxy.RequestCount);
+
+        // Control: the same request through a handler that does proxy lands on the listener, so a
+        // count of zero above is evidence rather than a listener that never worked.
+        using var proxyingHandler = new HttpClientHandler { Proxy = proxy.AsWebProxy(), UseProxy = true };
+        using var proxied = ProxyBotClient.CreateHttpClient(proxyingHandler);
+        Assert.Equal(RecordingProxy.ResponseBody, await proxied.GetStringAsync(destination));
+        Assert.Equal(1, proxy.RequestCount);
+        Assert.Equal($"GET {destination} HTTP/1.1", proxy.LastRequestLine);
+    }
+
+    /// <summary>A port nothing listens on, so a direct attempt is refused rather than left hanging.</summary>
+    private static int ClosedPort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    private sealed class StubProxy : IWebProxy
+    {
+        private readonly Uri? _result;
+
+        public StubProxy(Uri? result) => _result = result;
+
+        public ICredentials? Credentials { get; set; }
+
+        public Uri? GetProxy(Uri destination) => _result;
+
+        public bool IsBypassed(Uri host) => _result is null;
+    }
+
+    private sealed class ThrowingProxy : IWebProxy
+    {
+        public ICredentials? Credentials { get; set; }
+
+        public Uri GetProxy(Uri destination) => throw new InvalidOperationException(NotHere);
+
+        public bool IsBypassed(Uri host) => throw new InvalidOperationException(NotHere);
+
+        private const string NotHere = "The system proxy must not be consulted on the bypass path.";
+    }
+
+    /// <summary>
+    /// A loopback HTTP proxy that counts what reaches it and answers everything the same way.
+    /// Enough to tell "the client proxied" from "the client did not".
+    /// </summary>
+    private sealed class RecordingProxy : IDisposable
+    {
+        internal const string ResponseBody = "proxied";
+
+        private static readonly byte[] Response = Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: " +
+            ResponseBody.Length + "\r\nConnection: close\r\n\r\n" + ResponseBody);
+
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _accepting;
+        private int _requestCount;
+        private string? _lastRequestLine;
+
+        public RecordingProxy()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            _accepting = AcceptAsync(_cts.Token);
+        }
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        public string? LastRequestLine => Volatile.Read(ref _lastRequestLine);
+
+        public IWebProxy AsWebProxy() =>
+            new WebProxy($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}");
+
+        private async Task AcceptAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                }
+                catch (Exception ex) when (ex is OperationCanceledException or SocketException or ObjectDisposedException)
+                {
+                    return;
+                }
+
+                using (client)
+                {
+                    Interlocked.Increment(ref _requestCount);
+                    var stream = client.GetStream();
+                    var buffer = new byte[1024];
+                    var read = await stream.ReadAsync(buffer, cancellationToken);
+                    // One read is enough: a proxied request puts the absolute URI on the first
+                    // line, which is the whole point of looking.
+                    Volatile.Write(ref _lastRequestLine, Encoding.ASCII.GetString(buffer, 0, read).Split("\r\n")[0]);
+                    await stream.WriteAsync(Response, cancellationToken);
+                    await stream.FlushAsync(cancellationToken);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            _accepting.Wait(TimeSpan.FromSeconds(5));
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
@@ -24,6 +24,14 @@ public class ProxyBotClientTests
 {
     private static readonly Uri TelegramApiRoot = new("https://api.telegram.org");
 
+    /// <summary>
+    /// A destination that refuses immediately, so a request that goes direct fails fast and one
+    /// that goes through the recording proxy is answered by the proxy without ever reaching here.
+    /// Port 1 rather than a released ephemeral port: the ephemeral range is what the OS hands out
+    /// next, so on a busy machine something can claim it between the probe and the request.
+    /// </summary>
+    private static readonly Uri Unreachable = new("http://127.0.0.1:1/");
+
     [Fact]
     public void ChooseConnection_BypassRequested_TurnsProxyingOff()
     {
@@ -122,7 +130,6 @@ public class ProxyBotClientTests
         // listener means UseProxy = false did not take effect. Loopback only — no outbound
         // traffic and no state shared with other tests.
         using var proxy = new RecordingProxy();
-        var destination = new Uri($"http://127.0.0.1:{ClosedPort()}/");
 
         var (bypassHandler, _) = ProxyBotClient.ChooseConnection(bypassProxy: true, systemProxy: null);
         Assert.NotNull(bypassHandler);
@@ -130,7 +137,12 @@ public class ProxyBotClientTests
 
         using (var direct = ProxyBotClient.CreateHttpClient(bypassHandler))
         {
-            await Assert.ThrowsAsync<HttpRequestException>(() => direct.GetStringAsync(destination));
+            // The client's own timeout is the long-poll 120 s, which is far too long to wait on
+            // should something ever answer at Unreachable. Cap it so an unexpected connection
+            // fails the test in seconds with a wrong exception type rather than stalling a build.
+            using var giveUp = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await Assert.ThrowsAsync<HttpRequestException>(
+                () => direct.GetStringAsync(Unreachable, giveUp.Token));
         }
 
         Assert.Equal(0, proxy.RequestCount);
@@ -139,19 +151,9 @@ public class ProxyBotClientTests
         // count of zero above is evidence rather than a listener that never worked.
         using var proxyingHandler = new HttpClientHandler { Proxy = proxy.AsWebProxy(), UseProxy = true };
         using var proxied = ProxyBotClient.CreateHttpClient(proxyingHandler);
-        Assert.Equal(RecordingProxy.ResponseBody, await proxied.GetStringAsync(destination));
+        Assert.Equal(RecordingProxy.ResponseBody, await proxied.GetStringAsync(Unreachable));
         Assert.Equal(1, proxy.RequestCount);
-        Assert.Equal($"GET {destination} HTTP/1.1", proxy.LastRequestLine);
-    }
-
-    /// <summary>A port nothing listens on, so a direct attempt is refused rather than left hanging.</summary>
-    private static int ClosedPort()
-    {
-        var probe = new TcpListener(IPAddress.Loopback, 0);
-        probe.Start();
-        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
-        probe.Stop();
-        return port;
+        Assert.Equal($"GET {Unreachable} HTTP/1.1", proxy.LastRequestLine);
     }
 
     private sealed class StubProxy : IWebProxy
@@ -214,18 +216,12 @@ public class ProxyBotClientTests
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                TcpClient client;
+                // The whole body, not just the accept: a client that disconnects mid-exchange
+                // would otherwise fault this task, and Dispose would rethrow that at teardown as
+                // an AggregateException on top of whatever the test was actually asserting.
                 try
                 {
-                    client = await _listener.AcceptTcpClientAsync(cancellationToken);
-                }
-                catch (Exception ex) when (ex is OperationCanceledException or SocketException or ObjectDisposedException)
-                {
-                    return;
-                }
-
-                using (client)
-                {
+                    using var client = await _listener.AcceptTcpClientAsync(cancellationToken);
                     Interlocked.Increment(ref _requestCount);
                     var stream = client.GetStream();
                     var buffer = new byte[1024];
@@ -236,6 +232,11 @@ public class ProxyBotClientTests
                     await stream.WriteAsync(Response, cancellationToken);
                     await stream.FlushAsync(cancellationToken);
                 }
+                catch (Exception ex) when (ex is OperationCanceledException or IOException
+                    or SocketException or ObjectDisposedException)
+                {
+                    return;
+                }
             }
         }
 
@@ -243,6 +244,7 @@ public class ProxyBotClientTests
         {
             _cts.Cancel();
             _listener.Stop();
+            // The loop swallows its own teardown exceptions, so this only ever waits.
             _accepting.Wait(TimeSpan.FromSeconds(5));
             _cts.Dispose();
         }


### PR DESCRIPTION
**Branch Name**: `fix/direct-connection-really-bypasses-proxy`
**Linked Issue**: #199

---

## Description

`BOT_DIRECT_CONNECTION=1` printed `🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)`
and then sent every request through the system proxy anyway. `new HttpClient()` takes the stock
handler, which leaves `UseProxy = true` with a null `Proxy`, so on Windows it resolves through
`HttpClient.DefaultProxy` — the same WinInet settings `WebRequest.GetSystemWebProxy()` reads.
Nothing set `UseProxy = false`.

The code change is one line. The value of this PR is the evidence, because a flag that lies is
worse than a flag that does not exist: the operator this flag exists for sets it, reads the
success message, watches the long poll drop again, and crosses a working workaround off the list
on false evidence. That is what happened, and "the message printed" is what made it believable —
so this PR does not repeat the mistake of asserting the bypass without showing it.

---

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

- `ProxyBotClient.ChooseConnection` — new `internal` seam returning `(HttpClientHandler?, string)`:
  the handler to build the client on and the line that describes it. The bypass path returns
  `new HttpClientHandler { UseProxy = false }`.
- `ProxyBotClient.CreateHttpClient` — new `internal` seam, the single place the 120 s long-poll
  timeout is applied.
- The exception fallback now supplies an `HttpClient` instead of `new TelegramBotClient(token)`,
  so it keeps 120 s rather than silently taking the .NET default of 100 s. That mattered beyond
  the poll itself: `TelegramBotHostedService.PollingRecoveryGap` derives from
  `ITelegramBotClient.Timeout`, so falling onto that path moved the down-alert threshold too.
- `🔧 Using proxy: {uri}` is printed only when a proxy actually applies. It used to print
  unconditionally, *before* the check, so "no proxy" surfaced as
  `🔧 Using proxy: https://api.telegram.org/` — which means no proxy and reads as its opposite.
  That case now prints `🔧 No system proxy applies to api.telegram.org`.
- A null `GetProxy` result is treated as no proxy. `null != new Uri(...)`, so it used to take the
  proxy branch and print `🔧 Using proxy: ` with nothing after it.
- The fallback message no longer says "direct connection" — the stock handler it falls back to
  still proxies. Behaviour there is unchanged, only the wording.
- The two Persian comments in this method are gone with the code that carried them.
- `InternalsVisibleTo("TallaEgg.AllServices.Tests")` on the bot project, matching
  `Orders.Application` and `TallaEgg.TelegramBot.Simulator`.
- `NetworkTroubleshooting.md`: the #198 hedge is removed, the four-path table matches the new
  behaviour (including the 100 s row, now 120 s), and the console-output section says what each
  of the three lines now means.

### Why a seam, and why the smallest one

`CreateWithProxy` returns `ITelegramBotClient`, which exposes neither its handler nor its proxy
settings — so `UseProxy = false` cannot be asserted through it, and no test could ever have caught
this bug from outside. That is exactly why a confident, false message survived. Two `internal`
statics is the least that makes the claim checkable: `ChooseConnection` returns the handler *and*
the message as one value, so both the proxy decision and the sentence claiming it are assertable;
`CreateHttpClient` makes the timeout assertable on every path including the fallback. Nothing else
in the bot's network layer is touched.

---

## Testing Completed

### Unit Tests

- [x] New unit tests written — `tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs`, 10 cases
- [x] All unit tests pass (`dotnet test`)

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.
    0 Warning(s)
    0 Error(s)

dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 718, Skipped: 0, Total: 718
```

**The tests fail against the previous code.** Reverting the bypass branch to the stock handler:

```
Failed ProxyBotClientTests.ChooseConnection_BypassRequested_TurnsProxyingOff
Failed ProxyBotClientTests.ChooseConnection_BypassRequested_SendsNoTrafficToAConfiguredProxy
Failed!  - Failed: 2, Passed: 8, Skipped: 0, Total: 10
```

and reverting the null-`GetProxy` handling:

```
Failed ProxyBotClientTests.ChooseConnection_GetProxyReturnsNull_ReportsNoProxy
Failed!  - Failed: 1, Passed: 9, Skipped: 0, Total: 10
```

`SendsNoTrafficToAConfiguredProxy` is socket-level, not a property assertion: it attaches a
loopback proxy to the bypass handler, requests a closed port, and requires the listener to see
nothing while a control request through a proxying handler does reach it. Loopback only, no
outbound traffic, no process-wide state.

### End-to-end

Run on Windows 10 + .NET 9 on 2026-09-02, on a machine that is exactly the case the flag exists
for: WinInet reports a system proxy at `127.0.0.1:10808`, `netsh winhttp` reports direct access,
and Telegram is reachable **only** through that proxy:

```
curl.exe -x http://127.0.0.1:10808 https://api.telegram.org/bot0:0/getMe   →  http_code=401  remote=127.0.0.1:10808
curl.exe --noproxy "*"             https://api.telegram.org/bot0:0/getMe   →  http_code=000  (exit 7, could not connect)
```

That makes the request outcome self-verifying: **reaching Telegram at all proves the proxy was
used.** No message is being taken at its word anywhere below.

#### (a) With the flag set, traffic really does not go through the proxy

The production `ProxyBotClient.CreateWithProxy` driven in a real process, with every TCP
connection the process opened listed alongside the result:

```
CASE: fixed code, BOT_DIRECT_CONNECTION=1
🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)
client.Timeout = 00:02:00
RESULT after 3.1s: RequestException: Exception during making request
---- TCP connections opened by the process ----
  10.10.34.35:443 [SynSent]          ← api.telegram.org, direct. No 127.0.0.1:10808.
```

and the same harness against the **pre-fix** code, which is the bug itself:

```
CASE: pre-fix code, BOT_DIRECT_CONNECTION=1
🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)
client.Timeout = 00:02:00
RESULT after 1.2s: ApiRequestException: Unauthorized     ← reached Telegram, so it proxied
---- TCP connections opened by the process ----
  127.0.0.1:10808 [Established]      ← the proxy it claimed to have bypassed
```

Same message, opposite behaviour. After the fix the connection goes to Telegram's address and
never to the proxy.

The real bot shows the same thing, and comes with its own control — the startup diagnostics build
their own `HttpClient` and so still proxy, while only the `ProxyBotClient`-created client goes
direct:

```
dotnet run --project TelegramBot/TallaEgg.TelegramBot.Infrastructure   (BOT_DIRECT_CONNECTION=1)

🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)
✅ https://api.telegram.org - Status: OK          ← diagnostics' own HttpClient, still proxied
🔧 Testing with proxy settings...
System Proxy: http://127.0.0.1:10808/
[WRN] Could not delete webhook
Telegram.Bot.Exceptions.RequestException: Exception during making request
 ---> System.Net.Http.HttpRequestException: No connection could be made because the target
      machine actively refused it. (api.telegram.org:443)
```

The bot client failing to reach `api.telegram.org:443` while everything sharing the machine's
proxy succeeds is the bypass, observed. On this machine that means the bot cannot run with the
flag set — correctly, because here the proxy is doing real work. `NetworkTroubleshooting.md` now
says so.

#### (b) Without the flag, the previous behaviour is untouched

This is the regression that matters: the server deployment relies on the proxy path.

```
dotnet run --project TelegramBot/TallaEgg.TelegramBot.Infrastructure   (flag unset)

🔧 Using proxy: http://127.0.0.1:10808/
[INF] Webhook deleted successfully
[INF] Bot connection successful: @…
[INF] Bot is now running and listening for messages...
[INF] Application started. Press Ctrl+C to shut down.
```

Harness, same path: `RESULT: ApiRequestException: Unauthorized`, one TCP connection, to
`127.0.0.1:10808 [Established]`. Proxy path unchanged, and the client is still bound to the proxy
explicitly rather than resolving one ambiently.

#### (c) The console output is true in all three cases

| Case | Printed | True? |
|---|---|---|
| `BOT_DIRECT_CONNECTION=1` | `🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)` | yes — process opened no connection to the proxy, see (a) |
| A proxy applies | `🔧 Using proxy: http://127.0.0.1:10808/` | yes — and that is where the connection went, see (b) |
| No proxy applies | `🔧 No system proxy applies to api.telegram.org` | yes — was `🔧 Using proxy: https://api.telegram.org/` |

The third row was produced in a real process without editing the machine's WinInet settings:
`WebRequest.GetSystemWebProxy()` resolves through `HttpClient.DefaultProxy`, so replacing that
with an empty `WebProxy` reproduces "no proxy configured" faithfully.

```
WebRequest.GetSystemWebProxy().GetProxy(telegram) = https://api.telegram.org/
🔧 No system proxy applies to api.telegram.org
```

`GetProxy` returning null is covered by unit test only — no real `IWebProxy` on hand returns it.

### Environment
- [x] Tested locally (Windows 10, .NET 9, live WinInet proxy at `127.0.0.1:10808`)
- [x] Feature flag working as expected — that is the whole PR

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens — the harness token is a fake with a
      valid shape (`123456789:AAAA…`), and no real token appears in the diff or in this
      description
- [x] No sensitive data in logs or error messages — the bot username is redacted above; the
      evidence needs only the endpoints
- [x] `.gitignore` blocks sensitive files — `config/appsettings.global.json` was copied into the
      worktree to run the bot and is untracked, as designed in #33
- [x] Code compiles without warnings (`TreatWarningsAsErrors`, `--no-incremental`, 0 warnings)

---

## Code Quality

- [x] Code follows naming conventions (`STANDARDS.md`); tests named `Method_Scenario_ExpectedResult`
- [x] Comments in English, explaining why — the two Persian comments in this method are gone
- [x] No large blocks of commented-out code
- [x] No new dependencies

Deliberately **not** changed, per `STANDARDS.md` scope discipline: this file's namespace is
`TallaEgg.TelegramBot`, the name of a project that was deleted, and it logs through
`Console.WriteLine` rather than Serilog. Both are wrong and neither is this issue. Say the word
and I will open issues for them.

---

## Documentation

- [x] `NetworkTroubleshooting.md` updated — the #198 hedge removed, the path table corrected, and
      a new section on what each console line means and what each outcome of setting the flag
      tells you
- [x] Code comments in English

---

## Breaking Changes?

- [x] No breaking changes

`BOT_DIRECT_CONNECTION` is unset on the server, which takes the proxy path — unchanged and
verified in (b). The flag's behaviour changes for anyone who sets it, which is the point: it now
does what it always said.

---

## Deployment Notes

**Pre-Deployment**: none. No migration, no configuration, no new environment variable.

**Post-Deployment Verification**: the bot's first console line should read
`🔧 Using proxy: …` on the server exactly as before, and the bot should reach Telegram.

**Rollback**: revert the commit. The flag returns to being a no-op that claims otherwise.

---

## Related Issues

- Closes #199
- Follows #198, which documented this bug rather than fixing it and pointed here
- Touches the timeout `TelegramBotHostedService` reads for its polling-recovery gap (#148)

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description explains why and what
- [x] All tests pass locally
- [x] No secrets or sensitive data in code
- [x] Documentation updated
