### PR TITLE
[Hotfix] Log the proxy decision instead of printing it to a console the service does not have

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
@@ -24,15 +24,8 @@ with it, because `TelegramBotHostedService` derives its polling-recovery gap fro
 
 ### Reading the line it logs
 
-Exactly one line is logged, and it means what it says. Until #199 two of the three did not, so
-output from a build older than that fix cannot be read this way.
-
-It goes through `ILogger`, so it reaches the console during a local `dotnet run` **and**
-`logs/telegrambot-<date>.log`. The second half is the point on a server: the bot is installed with
-`sc.exe create` (#70) and a native Windows service has no console, so while these were
-`Console.WriteLine` they went nowhere on the one machine where a proxy problem is worth
-diagnosing. Everything else in this project still printing with `Console.WriteLine` — the startup
-diagnostics in particular — is still invisible there.
+One line is logged, and it means what it says. Until #199 two of the four did not, so output from
+a build older than that fix cannot be read this way.
 
 - **`🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)`** — the handler has
   `UseProxy = false`, so nothing the bot sends is proxied: not the system proxy, not one
@@ -47,6 +40,32 @@ diagnostics in particular — is still invisible there.
   itself, or with null. Both mean no proxy. The first used to surface as
   `🔧 Using proxy: https://api.telegram.org/`, which says *no proxy* and reads as its opposite;
   the second took the proxy branch outright and printed `🔧 Using proxy: ` with nothing after it.
+- **`Could not resolve the system proxy; falling back to the default handler…`** — logged at
+  **Warning**, with the exception attached, and the only one of the four with no emoji. Reading the
+  system proxy threw. The client is built on the stock handler, which still consults
+  `HttpClient.DefaultProxy`, so this is not a bypass: treat it as "proxy state unknown".
+
+### Where the line goes
+
+Through `ILogger`, so both the console and Serilog's rolling file. That matters because the bot is
+installed with `sc.exe create` (#70) and a native Windows service has no console — while these
+were `Console.WriteLine` they went nowhere at all under the SCM.
+
+**Know which file, though.** The sink path in `Program.cs` is *relative*, and Serilog resolves it
+against the process's **working directory**, not the folder the binary sits in:
+
+| How it was started | Where `telegrambot-<date>.log` lands |
+|---|---|
+| `dotnet run --project …` | the project folder's `logs\` |
+| The published exe, launched from a shell | `logs\` under whatever that shell's directory was |
+| A service from `sc.exe create` | `C:\Windows\System32\logs\` — `sc.exe` sets no working directory |
+
+So on a server, look under the working directory of the service, not next to the exe.
+`docs/operations/WINDOWS_DEPLOYMENT.md` describes the log as `logs\telegrambot-.log` relative to
+the publish folder, which holds only when something set the working directory there.
+
+Everything else in this project still printing with `Console.WriteLine` — the startup diagnostics
+in particular — remains invisible under the service regardless.
 
 ## The failure this file exists for
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
@@ -22,10 +22,17 @@ for it. Every row gets it now, the exception fallback included: that row used to
 with it, because `TelegramBotHostedService` derives its polling-recovery gap from
 `_botClient.Timeout` (#199).
 
-### Reading the console output
+### Reading the line it logs
 
-One line is printed, and it means what it says. Until #199 two of the three did not, so output
-from a build older than that fix cannot be read this way.
+Exactly one line is logged, and it means what it says. Until #199 two of the three did not, so
+output from a build older than that fix cannot be read this way.
+
+It goes through `ILogger`, so it reaches the console during a local `dotnet run` **and**
+`logs/telegrambot-<date>.log`. The second half is the point on a server: the bot is installed with
+`sc.exe create` (#70) and a native Windows service has no console, so while these were
+`Console.WriteLine` they went nowhere on the one machine where a proxy problem is worth
+diagnosing. Everything else in this project still printing with `Console.WriteLine` — the startup
+diagnostics in particular — is still invisible there.
 
 - **`🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)`** — the handler has
   `UseProxy = false`, so nothing the bot sends is proxied: not the system proxy, not one

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -102,7 +102,9 @@ public class Program
                         throw new InvalidOperationException("TelegramBotToken is not configured.");
                     }
 
-                    return ProxyBotClient.CreateWithProxy(options.TelegramBotToken);
+                    return ProxyBotClient.CreateWithProxy(
+                        options.TelegramBotToken,
+                        provider.GetRequiredService<ILogger<ProxyBotClient>>());
                 });
 
                 services.AddSingleton<OrderApiClient>(provider => new OrderApiClient(

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using Microsoft.Extensions.Logging;
 using Telegram.Bot;
 
 namespace TallaEgg.TelegramBot
@@ -16,7 +17,19 @@ namespace TallaEgg.TelegramBot
         // (issue #199).
         internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(120);
 
-        public static ITelegramBotClient CreateWithProxy(string token)
+        /// <summary>
+        /// Builds the bot's Telegram client and reports, through <paramref name="logger"/>, which
+        /// of the four connection paths it took.
+        /// </summary>
+        /// <remarks>
+        /// The report goes to the log rather than to <see cref="Console"/> because the bot is
+        /// installed with <c>sc.exe create</c> (issue #70) and a native Windows service has no
+        /// console: on the server every one of these lines was written to a handle nobody holds.
+        /// They are the lines that say whether the bot is proxying, which is the one thing worth
+        /// knowing when Telegram is unreachable — and issue #199 was a whole class of damage done
+        /// by trusting one of them, so they need to be legible where the failure actually happens.
+        /// </remarks>
+        public static ITelegramBotClient CreateWithProxy(string token, ILogger logger)
         {
             // Local override: when the machine can reach Telegram directly (e.g. a TUN-mode VPN),
             // the system HTTP proxy can be unstable on long-poll (getUpdates) and drops the
@@ -30,20 +43,25 @@ namespace TallaEgg.TelegramBot
             if (Environment.GetEnvironmentVariable("BOT_DIRECT_CONNECTION") == "1")
             {
                 var (directHandler, directMessage) = ChooseConnection(bypassProxy: true, systemProxy: null);
-                Console.WriteLine(directMessage);
+                // One property rather than a template with holes: the sentence is the artefact
+                // here, worded so an operator can act on it, and it is asserted whole in tests.
+                logger.LogInformation("{TelegramConnection}", directMessage);
                 return new TelegramBotClient(token, CreateHttpClient(directHandler));
             }
 
             try
             {
                 var (handler, message) = ChooseConnection(bypassProxy: false, WebRequest.GetSystemWebProxy());
-                Console.WriteLine(message);
+                logger.LogInformation("{TelegramConnection}", message);
                 return new TelegramBotClient(token, CreateHttpClient(handler));
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"⚠️ Error configuring proxy: {ex.Message}");
-                Console.WriteLine("Falling back to the default handler, which may still use the system proxy...");
+                // Warning, not Information: this path silently changes how the bot reaches
+                // Telegram. The exception is passed rather than just its Message so the file sink
+                // keeps the stack trace — on the server there is no console to re-run it in.
+                logger.LogWarning(ex,
+                    "Could not configure the Telegram proxy; falling back to the default handler, which may still use the system proxy.");
                 return new TelegramBotClient(token, CreateHttpClient(null));
             }
         }

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/ProxyBotClient.cs
@@ -24,12 +24,22 @@ namespace TallaEgg.TelegramBot
         /// <remarks>
         /// The report goes to the log rather than to <see cref="Console"/> because the bot is
         /// installed with <c>sc.exe create</c> (issue #70) and a native Windows service has no
-        /// console: on the server every one of these lines was written to a handle nobody holds.
+        /// console: under the SCM every one of these lines was written to a handle nobody holds.
         /// They are the lines that say whether the bot is proxying, which is the one thing worth
         /// knowing when Telegram is unreachable — and issue #199 was a whole class of damage done
-        /// by trusting one of them, so they need to be legible where the failure actually happens.
+        /// by trusting one of them, so they need to survive to somewhere readable.
         /// </remarks>
-        public static ITelegramBotClient CreateWithProxy(string token, ILogger logger)
+        public static ITelegramBotClient CreateWithProxy(string token, ILogger logger) =>
+            new TelegramBotClient(token, CreateHttpClient(ResolveHandler(logger)));
+
+        /// <summary>
+        /// Works out the handler and reports the choice. Separate from client construction so the
+        /// catch below covers only what its message blames: <see cref="TelegramBotClient"/>'s
+        /// constructor throws <see cref="ArgumentException"/> on a malformed token, and inside the
+        /// try that surfaced as a proxy warning followed by the same exception thrown again from
+        /// the fallback — a configuration typo reported as a network problem, twice.
+        /// </summary>
+        private static HttpClientHandler? ResolveHandler(ILogger logger)
         {
             // Local override: when the machine can reach Telegram directly (e.g. a TUN-mode VPN),
             // the system HTTP proxy can be unstable on long-poll (getUpdates) and drops the
@@ -44,25 +54,26 @@ namespace TallaEgg.TelegramBot
             {
                 var (directHandler, directMessage) = ChooseConnection(bypassProxy: true, systemProxy: null);
                 // One property rather than a template with holes: the sentence is the artefact
-                // here, worded so an operator can act on it, and it is asserted whole in tests.
+                // here, worded so an operator can act on it and quoted verbatim in
+                // NetworkTroubleshooting.md, so the tests pin it verbatim too.
                 logger.LogInformation("{TelegramConnection}", directMessage);
-                return new TelegramBotClient(token, CreateHttpClient(directHandler));
+                return directHandler;
             }
 
             try
             {
                 var (handler, message) = ChooseConnection(bypassProxy: false, WebRequest.GetSystemWebProxy());
                 logger.LogInformation("{TelegramConnection}", message);
-                return new TelegramBotClient(token, CreateHttpClient(handler));
+                return handler;
             }
             catch (Exception ex)
             {
                 // Warning, not Information: this path silently changes how the bot reaches
                 // Telegram. The exception is passed rather than just its Message so the file sink
-                // keeps the stack trace — on the server there is no console to re-run it in.
+                // keeps the stack trace — under the service there is no console to re-run it in.
                 logger.LogWarning(ex,
-                    "Could not configure the Telegram proxy; falling back to the default handler, which may still use the system proxy.");
-                return new TelegramBotClient(token, CreateHttpClient(null));
+                    "Could not resolve the system proxy; falling back to the default handler, which may still use the system proxy.");
+                return null;
             }
         }
 

--- a/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ProxyBotClientTests.cs
@@ -72,6 +72,24 @@ public class ProxyBotClientTests
         Assert.DoesNotContain("Using proxy", message);
     }
 
+    [Theory]
+    [InlineData(true, null, "🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)")]
+    [InlineData(false, "http://proxy.invalid:8080", "🔧 Using proxy: http://proxy.invalid:8080/")]
+    [InlineData(false, null, "🔧 No system proxy applies to api.telegram.org")]
+    public void ChooseConnection_EachPath_UsesExactlyTheWordingTheRunbookQuotes(
+        bool bypassProxy, string? proxyUri, string expected)
+    {
+        // NetworkTroubleshooting.md quotes these three lines and tells an operator which action
+        // each one calls for, so the wording is an interface rather than an implementation
+        // detail. Pinned exactly, not by substring: a reword should fail here and be made
+        // deliberately alongside the doc. The lesson of #199 is that these sentences get trusted.
+        var (handler, message) = ProxyBotClient.ChooseConnection(
+            bypassProxy, new StubProxy(proxyUri is null ? null : new Uri(proxyUri)));
+        handler?.Dispose();
+
+        Assert.Equal(expected, message);
+    }
+
     [Fact]
     public void ChooseConnection_ProxyApplies_UsesItAndNamesIt()
     {


### PR DESCRIPTION
**Branch Name**: `fix/proxy-diagnostics-reach-the-log`
**Linked Issue**: none — follow-up to #199 / #201, raised in that PR's review and requested inline
rather than as an issue

---

## Description

`ProxyBotClient` reported which of its four connection paths it took with `Console.WriteLine`. The
bot is installed with `sc.exe create` (#70), and a native Windows service has no console: on the
server all four lines were written to a handle nobody holds.

Those are the lines that say whether the bot is proxying. After #199 they are also the lines an
operator has been explicitly told to read carefully — and they were unreadable on the one machine
where the failure they describe actually happens. Fixing the message's honesty and leaving it
undeliverable was half a fix.

---

## Type of Change
- [x] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

- `ProxyBotClient.CreateWithProxy` takes an `ILogger`; `Program.cs` passes
  `ILogger<ProxyBotClient>` from the container, matching how `OrderApiClient`, `UsersApiClient` and
  the rest of that registration block already get theirs.
- The decision line is logged as a single property — `LogInformation("{TelegramConnection}", message)`
  — not a template with holes. The sentence is the artefact here: it is worded for an operator to
  act on, and `ProxyBotClientTests` asserts it whole. Splitting it into placeholders would only
  make those assertions weaker, and this is a message whose exact wording caused #199.
- The exception path logs at **Warning**, not Information — it silently changes how the bot reaches
  Telegram — and passes the exception object rather than just `ex.Message`, so the file sink keeps
  the stack trace. On the server there is no console to re-run it in.
- `ProxyBotClient.ResolveHandler` splits handler resolution from client construction, so the
  `catch` covers only what its message blames. It previously wrapped
  `new TelegramBotClient(token, …)` as well, which throws `ArgumentException` on a malformed token
  — a configuration typo logged "could not configure the proxy" and then threw the same exception
  again out of the DI factory from the fallback.
- `ProxyBotClientTests` pins all three connection messages **verbatim**. The runbook quotes them
  and tells an operator which action each one calls for, so a silent reword is precisely the #199
  failure mode; substring assertions would not have caught it.
- `NetworkTroubleshooting.md`: the section is "Reading the line it logs" now, documents the
  fallback warning as the fourth path (and that it is *not* a bypass), and gives the log file's
  location per launch method.

### Scope

This file only. `NetworkTest`, `ProxyTest`, `SimpleHttpTest`, `TestBotToken` and `OfflineTestMode`
still use `Console.WriteLine` — 44 calls between them — and are still invisible under the service.
That is a real gap and it is not this change; the doc now states it plainly instead of leaving it
to be rediscovered.

---

## Testing Completed

### Unit Tests
- [x] Three new cases pinning the exact wording of each connection message

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.
    0 Warning(s)
    0 Error(s)

dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 721, Skipped: 0, Total: 721
```

### End-to-end

Run on 2026-09-02 on a machine with a live WinInet proxy at `127.0.0.1:10808`. The claim is that
the line reaches the **file** sink, so the file is what is checked — not the console.

**Where that file actually is.** Serilog's path here is relative, and it resolves against the
process's working directory rather than the binary's folder — verified by running the built exe
with a working directory different from its own, which put the new `logs\` at the working
directory. `sc.exe create` sets no working directory, so under the SCM the file is
`C:\Windows\System32\logs\`. The sink path is deliberately **not** changed here: all four services
share this pattern and `WINDOWS_DEPLOYMENT.md` documents the current locations, making that a
deployment decision rather than part of a logging fix. What this PR changes is that the line
reaches a file at all, instead of a console the service does not have.

**`BOT_DIRECT_CONNECTION=1`** — console and file, same line:

```
console:  [17:11:43 INF] 🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)
logs/telegrambot-20260902.log:
          2026-09-02 17:11:43.951 +03:30 [INF] 🔗 Direct connection (proxy bypassed via BOT_DIRECT_CONNECTION=1)
```

**Flag unset**, the path the server actually takes:

```
logs/telegrambot-20260902.log:
          2026-09-02 17:12:30.500 +03:30 [INF] 🔧 Using proxy: http://127.0.0.1:10808/
          2026-09-02 17:12:49.990 +03:30 [INF] Bot is now running and listening for messages...
```

Before this change the log file contained neither line. The bot still starts, connects through the
proxy and receives updates — the behaviour #201 verified is untouched, only the destination of the
report changed.

### Environment
- [x] Tested locally (Windows 10, .NET 9)

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs — the logged line names the proxy endpoint and nothing else; the
      token was never part of any of these messages and still is not
- [x] Code compiles without warnings (`TreatWarningsAsErrors`, 0 warnings)

---

## Code Quality

- [x] Follows `AGENT.md` — "Use `ILogger<T>` for logging"
- [x] Comments in English, explaining why
- [x] No new dependencies — `Microsoft.Extensions.Logging` is already referenced

---

## Documentation

- [x] `NetworkTroubleshooting.md` updated

---

## Breaking Changes?

- [x] No breaking changes

`CreateWithProxy` gains a required parameter, and its one caller is updated in the same commit.

---

## Deployment Notes

**Pre-Deployment**: none.

**Post-Deployment Verification**: `logs/telegrambot-<date>.log` should now open with
`[INF] 🔧 Using proxy: …` on the server. Its absence is itself the signal — either the build did
not deploy, or startup failed before the client was constructed.

**Rollback**: revert the commit. The lines go back to being written to a console that does not
exist.

---

## Related Issues

- Follows #201 (issue #199), which made these messages true; this makes them reachable
- Depends on the Serilog file sink added in #99, and the service install in #70

---

## Final Checklist

- [x] All tests pass locally
- [x] No secrets or sensitive data in code
- [x] Documentation updated
