### PR TITLE
[Fix] Remove the unreachable create-default-wallets endpoint — issue #190

### DIFF
--- a/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
+++ b/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
@@ -54,21 +54,30 @@ public static class ConfigurationGuard
     }
 
     /// <summary>
-    /// Returns the named configuration value, or throws naming what is missing and where it belongs.
+    /// Returns the named configuration value as an absolute http(s) URI, or throws naming what
+    /// is wrong and where it belongs.
     /// </summary>
     /// <remarks>
-    /// The same reasoning as <see cref="RequireConnectionString"/>, applied to the settings a
-    /// service needs before it can talk to anything: the address of another service, for one.
-    /// A fallback literal there is worse than no value at all, because the service starts and
-    /// then dials a host nobody configured — issue #190 found
+    /// The same reasoning as <see cref="RequireConnectionString"/>, applied to the address of
+    /// another service. A fallback literal there is worse than no value at all: the service
+    /// starts and then dials a host nobody configured — issue #190 found
     /// <c>GetValue&lt;string&gt;("WalletApiUrl") ?? "https://localhost:60932/"</c> pointing at a
     /// port this system has never used, kept alive only by configuration always supplying the
     /// real one.
+    ///
+    /// It returns a <see cref="Uri"/> rather than the string so that the parse happens here,
+    /// at startup, and not wherever the caller eventually constructs one. A value that is
+    /// present but not a usable address — a bare port, a host with no scheme, a leftover
+    /// placeholder — is a configuration mistake in exactly the way an absent one is, and both
+    /// have to stop the service before it accepts a request. <c>HttpClient</c> would otherwise
+    /// raise it on the first call, far from the cause.
     /// </remarks>
     /// <param name="configuration">Configuration the service was built with.</param>
     /// <param name="key">Configuration key, e.g. <c>WalletApiUrl</c>.</param>
-    /// <exception cref="InvalidOperationException">The value is absent, empty, or whitespace.</exception>
-    public static string RequireValue(IConfiguration configuration, string key)
+    /// <exception cref="InvalidOperationException">
+    /// The value is absent, empty, whitespace, or not an absolute http(s) URI.
+    /// </exception>
+    public static Uri RequireUri(IConfiguration configuration, string key)
     {
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -79,10 +88,22 @@ public static class ConfigurationGuard
         if (string.IsNullOrWhiteSpace(value))
         {
             throw new InvalidOperationException(
-                $"Configuration value '{key}' is missing. Add it under the service's section in " +
-                $"{SHARED_CONFIG_FILE_NAME}. The service will not start without it.");
+                $"Configuration value '{key}' is missing. Add it under this service's own " +
+                $"section, Services:{{ApplicationName}}, in {SHARED_CONFIG_FILE_NAME}. The " +
+                $"service will not start without it.");
         }
 
-        return value;
+        // Uri.TryCreate alone is not enough: "localhost:60933" parses as absolute with the
+        // scheme "localhost", and HttpClient rejects it only when a request is finally made.
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"Configuration value '{key}' is not an absolute http(s) URL: '{value}'. Fix it " +
+                $"under this service's own section, Services:{{ApplicationName}}, in " +
+                $"{SHARED_CONFIG_FILE_NAME}. The service will not start without a usable address.");
+        }
+
+        return uri;
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
+++ b/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
@@ -52,4 +52,37 @@ public static class ConfigurationGuard
 
         return value;
     }
+
+    /// <summary>
+    /// Returns the named configuration value, or throws naming what is missing and where it belongs.
+    /// </summary>
+    /// <remarks>
+    /// The same reasoning as <see cref="RequireConnectionString"/>, applied to the settings a
+    /// service needs before it can talk to anything: the address of another service, for one.
+    /// A fallback literal there is worse than no value at all, because the service starts and
+    /// then dials a host nobody configured — issue #190 found
+    /// <c>GetValue&lt;string&gt;("WalletApiUrl") ?? "https://localhost:60932/"</c> pointing at a
+    /// port this system has never used, kept alive only by configuration always supplying the
+    /// real one.
+    /// </remarks>
+    /// <param name="configuration">Configuration the service was built with.</param>
+    /// <param name="key">Configuration key, e.g. <c>WalletApiUrl</c>.</param>
+    /// <exception cref="InvalidOperationException">The value is absent, empty, or whitespace.</exception>
+    public static string RequireValue(IConfiguration configuration, string key)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var value = configuration[key];
+
+        // Whitespace counts as missing, for the same reason it does for a connection string.
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"Configuration value '{key}' is missing. Add it under the service's section in " +
+                $"{SHARED_CONFIG_FILE_NAME}. The service will not start without it.");
+        }
+
+        return value;
+    }
 }

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -108,13 +108,15 @@ builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<UserMapper>();
 builder.Services.AddTallaEggErrorHandling();
 
-// HttpClient for calling the Wallet API. The address is read here rather than inside the
-// configure delegate, which would not run until the first client was created: a missing key
-// has to stop the service coming up, not surface later as a failed registration.
-var walletApiUrl = ConfigurationGuard.RequireValue(builder.Configuration, "WalletApiUrl");
+// HttpClient for calling the Wallet API. The address is read and parsed here rather than
+// inside the configure delegate, which would not run until the first client was created. A bad
+// address has to stop the service coming up: registration creates the default wallets through
+// this client and swallows what it throws (UserService.CreateDefaultWalletsAsync), so deferring
+// the failure means users registered with no wallets and nothing said about it.
+var walletApiBaseAddress = ConfigurationGuard.RequireUri(builder.Configuration, "WalletApiUrl");
 builder.Services.AddHttpClient("WalletAPI", client =>
 {
-    client.BaseAddress = new Uri(walletApiUrl);
+    client.BaseAddress = walletApiBaseAddress;
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -108,10 +108,13 @@ builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<UserMapper>();
 builder.Services.AddTallaEggErrorHandling();
 
-// HttpClient for calling the Wallet API.
+// HttpClient for calling the Wallet API. The address is read here rather than inside the
+// configure delegate, which would not run until the first client was created: a missing key
+// has to stop the service coming up, not surface later as a failed registration.
+var walletApiUrl = ConfigurationGuard.RequireValue(builder.Configuration, "WalletApiUrl");
 builder.Services.AddHttpClient("WalletAPI", client =>
 {
-    client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("WalletApiUrl") ?? "https://localhost:60932/");
+    client.BaseAddress = new Uri(walletApiUrl);
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
@@ -453,46 +456,6 @@ app.MapGet("/api/user/exists/{telegramId}", async (long telegramId, UserService 
 {
     var exists = await userService.UserExistsAsync(telegramId);
     return Results.Ok(new { exists = exists });
-})
-.WithTags("Users");
-
-// Creates the default wallets for an existing user.
-// userId: User id.
-// userService: User service.
-// Returns: Whether it succeeded.
-// 200: Default wallets created.
-// 400: Wallet creation failed.
-// 404: User not found.
-app.MapPost("/api/user/{userId}/create-default-wallets", async (Guid userId, UserService userService) =>
-{
-    var user = await userService.GetUserByIdAsync(userId);
-    if (user == null)
-    {
-        return Results.Json(
-            ApiResponse<object>.NotFound("کاربر مورد نظر یافت نشد."),
-            statusCode: 404
-        );
-    }
-
-    // Call the wallet endpoint.
-    using var httpClient = new HttpClient();
-    httpClient.BaseAddress = new Uri("https://localhost:7001/");
-    var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
-
-    if (response.IsSuccessStatusCode)
-    {
-        var content = await response.Content.ReadAsStringAsync();
-        return Results.Json(
-            ApiResponse<object?>.Ok(null, "کیف پول‌های پیش‌فرض با موفقیت ایجاد شدند.")
-        );
-    }
-    else
-    {
-        return Results.Json(
-            ApiResponse<object>.Error("خطا در ایجاد کیف پول‌های پیش‌فرض."),
-            statusCode: 500
-        );
-    }
 })
 .WithTags("Users");
 

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
@@ -82,15 +82,15 @@ public class ConfigurationGuardTests
         Assert.Contains("appsettings.global.json", exception.Message, StringComparison.Ordinal);
     }
 
-    /// <summary>The behaviour when configuration is correct is unchanged: the value comes back as-is.</summary>
+    /// <summary>A correctly configured address comes back parsed, ready to be a BaseAddress.</summary>
     [Fact]
-    public void RequireValue_WhenTheKeyIsPresent_ReturnsTheValue()
+    public void RequireUri_WhenTheKeyIsPresent_ReturnsTheParsedUri()
     {
         var configuration = Configuration(("WalletApiUrl", "http://localhost:60933/"));
 
-        var value = ConfigurationGuard.RequireValue(configuration, "WalletApiUrl");
+        var uri = ConfigurationGuard.RequireUri(configuration, "WalletApiUrl");
 
-        Assert.Equal("http://localhost:60933/", value);
+        Assert.Equal(new Uri("http://localhost:60933/"), uri);
     }
 
     /// <summary>
@@ -99,37 +99,71 @@ public class ConfigurationGuardTests
     /// nothing instead of refusing to run.
     /// </summary>
     [Fact]
-    public void RequireValue_WhenTheKeyIsAbsent_Throws()
+    public void RequireUri_WhenTheKeyIsAbsent_Throws()
     {
         var configuration = Configuration(("UsersApiUrl", "http://localhost:5136/"));
 
         Assert.Throws<InvalidOperationException>(
-            () => ConfigurationGuard.RequireValue(configuration, "WalletApiUrl"));
+            () => ConfigurationGuard.RequireUri(configuration, "WalletApiUrl"));
     }
 
     /// <summary>A present-but-blank key is a half-finished edit, not a configured value.</summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void RequireValue_WhenTheValueIsBlank_Throws(string value)
+    public void RequireUri_WhenTheValueIsBlank_Throws(string value)
     {
         var configuration = Configuration(("WalletApiUrl", value));
 
         Assert.Throws<InvalidOperationException>(
-            () => ConfigurationGuard.RequireValue(configuration, "WalletApiUrl"));
+            () => ConfigurationGuard.RequireUri(configuration, "WalletApiUrl"));
     }
 
     /// <summary>
-    /// The message has to be actionable on a server with no debugger attached: which key,
-    /// and which file it belongs in.
+    /// Present but unusable is a configuration mistake too, and the reason this guard returns a
+    /// parsed <see cref="Uri"/> instead of the string. "localhost:60933" is the trap: it parses
+    /// as an absolute URI whose scheme is "localhost", so only a scheme check catches it, and
+    /// without one it would surface as a failed registration long after startup.
+    /// </summary>
+    [Theory]
+    [InlineData("60933")]
+    [InlineData("localhost:60933")]
+    [InlineData("/api/wallet")]
+    [InlineData("REPLACE_WITH_WALLET_URL")]
+    [InlineData("ftp://localhost:60933/")]
+    public void RequireUri_WhenTheValueIsNotAnAbsoluteHttpUrl_Throws(string value)
+    {
+        var configuration = Configuration(("WalletApiUrl", value));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireUri(configuration, "WalletApiUrl"));
+    }
+
+    /// <summary>
+    /// The message has to be actionable on a server with no debugger attached: which key, which
+    /// section, and which file. The file defines WalletApiUrl in three sections with two
+    /// incompatible shapes, so naming the key alone would not be enough to act on.
     /// </summary>
     [Fact]
-    public void RequireValue_WhenTheKeyIsAbsent_TheMessageNamesTheKeyAndTheFile()
+    public void RequireUri_WhenTheKeyIsAbsent_TheMessageNamesTheKeyTheSectionAndTheFile()
     {
         var exception = Assert.Throws<InvalidOperationException>(
-            () => ConfigurationGuard.RequireValue(Configuration(), "WalletApiUrl"));
+            () => ConfigurationGuard.RequireUri(Configuration(), "WalletApiUrl"));
 
         Assert.Contains("WalletApiUrl", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Services:", exception.Message, StringComparison.Ordinal);
         Assert.Contains("appsettings.global.json", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A rejected value has to appear in the message, or there is nothing to correct.</summary>
+    [Fact]
+    public void RequireUri_WhenTheValueIsNotAUrl_TheMessageQuotesTheValue()
+    {
+        var configuration = Configuration(("WalletApiUrl", "localhost:60933"));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireUri(configuration, "WalletApiUrl"));
+
+        Assert.Contains("localhost:60933", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
@@ -4,7 +4,7 @@ using TallaEgg.Core;
 namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// Connection strings must be present, not defaulted (issue #68).
+/// Required configuration must be present, not defaulted (issues #68 and #190).
 ///
 /// <para>
 /// All five services used to read the connection string with
@@ -12,6 +12,12 @@ namespace TallaEgg.AllServices.Tests;
 /// configuration file was missing the key, every service silently started against a local
 /// SQL Server instead of refusing to run — so the failure surfaced far from its cause,
 /// as an empty or wrong database rather than as a configuration error.
+/// </para>
+///
+/// <para>
+/// Service addresses were defaulted the same way: <c>Users.Api</c> fell back to a wallet URL
+/// on a port this system has never used, which issue #190 found only because nothing had ever
+/// exercised the missing-key path.
 /// </para>
 ///
 /// <para>
@@ -73,6 +79,57 @@ public class ConfigurationGuardTests
             () => ConfigurationGuard.RequireConnectionString(Configuration(), "OrdersDb"));
 
         Assert.Contains("OrdersDb", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("appsettings.global.json", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The behaviour when configuration is correct is unchanged: the value comes back as-is.</summary>
+    [Fact]
+    public void RequireValue_WhenTheKeyIsPresent_ReturnsTheValue()
+    {
+        var configuration = Configuration(("WalletApiUrl", "http://localhost:60933/"));
+
+        var value = ConfigurationGuard.RequireValue(configuration, "WalletApiUrl");
+
+        Assert.Equal("http://localhost:60933/", value);
+    }
+
+    /// <summary>
+    /// The case issue #190 found: Users.Api fell back to a hardcoded wallet address on a port
+    /// this system has never used, so a missing key would have started the service pointed at
+    /// nothing instead of refusing to run.
+    /// </summary>
+    [Fact]
+    public void RequireValue_WhenTheKeyIsAbsent_Throws()
+    {
+        var configuration = Configuration(("UsersApiUrl", "http://localhost:5136/"));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireValue(configuration, "WalletApiUrl"));
+    }
+
+    /// <summary>A present-but-blank key is a half-finished edit, not a configured value.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RequireValue_WhenTheValueIsBlank_Throws(string value)
+    {
+        var configuration = Configuration(("WalletApiUrl", value));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireValue(configuration, "WalletApiUrl"));
+    }
+
+    /// <summary>
+    /// The message has to be actionable on a server with no debugger attached: which key,
+    /// and which file it belongs in.
+    /// </summary>
+    [Fact]
+    public void RequireValue_WhenTheKeyIsAbsent_TheMessageNamesTheKeyAndTheFile()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireValue(Configuration(), "WalletApiUrl"));
+
+        Assert.Contains("WalletApiUrl", exception.Message, StringComparison.Ordinal);
         Assert.Contains("appsettings.global.json", exception.Message, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Description

`POST /api/user/{userId}/create-default-wallets` in `Users.Api` could never succeed, and nothing
called it. It is removed. The dead wallet-URL fallback in the same file is replaced with a
startup guard, so a missing key stops the service instead of silently defaulting.

## Issue/Task Reference

Closes #190

## Type of Change

- [ ] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)

Bug fix, but not urgent: the endpoint has never worked, so nothing is currently regressing.

## Verification of the reported defects

All three were confirmed against the tree, not taken from the issue:

| Claim | Confirmed at |
| --- | --- |
| Hardcoded `https://localhost:7001/` | `src/User/Users.Api/Program.cs:479` (before this PR) |
| Target route is `MapGet`, so `PostAsync` gets 405 | `src/Wallet/Wallet.Api/Program.cs:309` |
| No consumer | `grep -rn "create-default-wallets" .` returned only the mapping at line 466 |

Port 7001 appears in neither the live shared config nor
`config/appsettings.global.example.json`. The scheme was also wrong: no service in this system
binds HTTPS, so the call failed in the TLS handshake before the verb ever mattered, and with no
`try` around it every request returned 500.

## Why removal rather than repair

The behaviour the endpoint was meant to expose already happens on its own. The real path:

```
POST /api/user/register                   Users.Api:227
POST /api/user/register-with-invitation   Users.Api:406
        ↓ both
UserService.RegisterUserAsync             UserService.cs:53, :163
        ↓
UserService.CreateDefaultWalletsAsync     UserService.cs:202  (private)
        ↓ _httpClientFactory.CreateClient("WalletAPI"), BaseAddress from configuration
GET api/wallet/create-default/{userId}    UserService.cs:209
        ↓
MapGet /api/wallet/create-default/{userId}  Wallet.Api:309
        ↓
WalletService.CreateDefaultWalletsAsync   → Toman, MAUA, CREDIT_MAUA
```

Right port, right verb, address from configuration. Removing the broken endpoint loses nothing.
The four APIs are loopback-bound and called only by the bot on the same host, so there is no
external consumer that could break.

## Changes Made

- Removed the `create-default-wallets` mapping and its handler from `src/User/Users.Api/Program.cs`
- Added `ConfigurationGuard.RequireUri`, alongside the existing `RequireConnectionString`. It
  returns a parsed `Uri`, so a value that is present but unusable — a bare port, a host with no
  scheme, a leftover placeholder — fails the same way an absent one does
- `Users.Api` now reads `WalletApiUrl` through it, replacing `?? "https://localhost:60932/"` —
  another port this system does not use
- Both the read and the parse sit outside the `AddHttpClient` configure delegate, which does not
  run until the first client is created. Inside it, a bad address surfaced as a failed
  registration long after startup — and `UserService.CreateDefaultWalletsAsync` catches
  everything and discards the result, so it surfaced as nothing at all. Outside it, the service
  refuses to start, which is what `AGENT.md` requires
- Eight new `RequireUri` tests covering presence, blankness, four malformed shapes, and the
  message contents

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 732, Skipped: 0, Total: 732
```

### The registration path still works — the only thing this PR could break

A real registration through `POST /api/user/register` against the running stack, then the wallet
database queried directly for that user id:

```
CREDIT_MAUA  balance=0.00000000  locked=0.00000000
IRT          balance=0.00000000  locked=0.00000000
MAUA         balance=0.00000000  locked=0.00000000
```

All three default wallets, created within the same second as the user row. The probe user was in
the simulator's `TelegramId < 0` range and has since been cleared by `DataReset`.

The removed endpoint now answers 404, as expected.

### End to end

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:18.3. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Registration is phase 1 of that run, so all 20 users took the same path.

### The startup guard, both directions

With the key present, all three services come up (`All services up after 2s.`). With
`Services:Users.Api:WalletApiUrl` removed from a scratch copy of the shared config, `Users.Api`
stops before binding a port and exits non-zero:

```
Unhandled exception. System.InvalidOperationException: Configuration value 'WalletApiUrl' is
missing. Add it under this service's own section, Services:{ApplicationName}, in
appsettings.global.json. The service will not start without it.
   at TallaEgg.Core.ConfigurationGuard.RequireUri(...) in ConfigurationGuard.cs
   at Program.<Main>$(String[] args) in src/User/Users.Api/Program.cs:line 114
```

Present-but-unusable values are rejected at startup too — the case self-review caught, since
`new Uri(...)` had been left inside the configure delegate:

```
--WalletApiUrl=localhost:60933  →  "is not an absolute http(s) URL: 'localhost:60933'"
--WalletApiUrl=60933            →  "is not an absolute http(s) URL: '60933'"
```

`localhost:60933` is the one worth naming: it parses as an absolute URI whose scheme is
`localhost`, so only a scheme check catches it. No fallback, no silent start against the wrong
host, no failure deferred to the first registration.

## Security Checklist

- [x] No hardcoded credentials
- [x] No TLS bypass in production code
- [x] No secrets/tokens in the diff — `config/appsettings.global.json` is untouched and uncommitted
- [x] Code compiles without warnings

## Reported, deliberately not fixed

**`Wallet.Api/Program.cs:309` is a `MapGet` that creates wallets** — a safe verb that mutates
state. Risk today is low: the APIs bind loopback only and sit behind an API key. But with this
PR merged it becomes the only remaining path to default-wallet creation, which makes it worth
correcting on its own terms rather than as a side effect here. **Should we open an issue for it?**

**Four more configuration fallbacks on ports this system does not use**, left alone under scope
discipline:

| Location | Fallback | Note |
| --- | --- | --- |
| `src/Order/Orders.Api/Program.cs:120` | `http://localhost:60933` | right port, still a fallback |
| `src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs:26` | `http://localhost:5001/api` | 5001 is not used here |
| `src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs:43, :51` | `http://localhost:60933/api` | right port, still a fallback |
| `TelegramBot/.../Clients/OrderApiClient.cs:26` | `http://localhost:5135/api` | 5135 is `TallaEgg.Api`, which maps no endpoints; orders are on 5140 |

`RequireUri` now exists for whoever picks these up. Worth a follow-up issue.

**Two more from self-review** (`/code-review 204`, answered in full in a comment below): the
configuration guards throw before Serilog is configured, so under `sc.exe` the message reaches no
log an operator is told to read; and `UserService.CreateDefaultWalletsAsync` catches every
exception, reports it with `Console.WriteLine` while holding an injected logger, and returns a
bool both callers discard — so a registration whose wallet creation fails is silent. Both are
pre-existing and outside this issue. Worth issues of their own.

## Breaking Changes?

- [x] No breaking changes

Removing an endpoint is a contract change in principle, but this one returned 500 to every
caller and had none.

## Deployment Notes

No migrations, no new configuration. `Services:Users.Api:WalletApiUrl` was already required in
practice and is present in both the live config and the example file; it is now required in fact.
A deployment missing it will fail fast at startup with a message naming the key — the intended
behaviour, but worth knowing before a rollout.

**Rollback**: revert the commit. Nothing depends on the removed endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
