### PR TITLE
[Fix] Wallet creation is a POST, and its failures reach the log — issue #206

### DIFF
--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -215,16 +215,16 @@ public class UserService
             using var httpClient = _httpClientFactory.CreateClient("WalletAPI");
             _logger.Log(LogLevel.Information,"درخواست برای ساخت کیف پول های پیش فرض" + " " + httpClient.BaseAddress + $"api/wallet/create-default/{userId}");
 
-            var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
+            using var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
 
             if (!response.IsSuccessStatusCode)
             {
                 // A non-2xx never reaches the catch below — it is a completed request, not an
                 // exception — and it is the likelier of the two failures, so it needs its own
-                // Error entry. The body carries the wallet service's own reason for refusing.
-                var body = await response.Content.ReadAsStringAsync();
+                // Error entry. The body carries whatever reason the wallet service gave.
+                var body = Truncated(await response.Content.ReadAsStringAsync());
                 _logger.LogError(
-                    "Default wallet creation for user {UserId} was refused: HTTP {StatusCode}. Response: {ResponseBody}. Registration continues; this user has no wallets until one is created on first use.",
+                    "Default wallet creation for user {UserId} was refused: HTTP {StatusCode}. Response: {ResponseBody}. Registration continues; this user's default wallets may be missing or incomplete.",
                     userId, (int)response.StatusCode, body);
             }
         }
@@ -235,8 +235,20 @@ public class UserService
             // must not happen. The exception is logged, so its type is visible in the log
             // rather than flattened away here.
             _logger.LogError(ex,
-                "Default wallet creation for user {UserId} failed. Registration continues; this user has no wallets until one is created on first use.",
+                "Default wallet creation for user {UserId} failed. Registration continues; this user's default wallets may be missing or incomplete.",
                 userId);
         }
     }
+
+    /// <summary>
+    /// Caps a response body before it is logged. An intermediary answering with an HTML error
+    /// page would otherwise be copied whole into the rolling log once per registration, and a
+    /// registration burst is exactly when this logging fires.
+    /// </summary>
+    private static string Truncated(string body) =>
+        body.Length <= MaxLoggedResponseBody
+            ? body
+            : string.Concat(body.AsSpan(0, MaxLoggedResponseBody), "… (truncated)");
+
+    private const int MaxLoggedResponseBody = 500;
 }

--- a/src/User/Users.Application/UserService.cs
+++ b/src/User/Users.Application/UserService.cs
@@ -197,24 +197,46 @@ public class UserService
     /// <summary>
     /// Creates the default wallets for a new user.
     /// </summary>
+    /// <remarks>
+    /// A failure here deliberately does not fail the registration: a user should not be turned
+    /// away because Wallet.Api happens to be restarting. It does have to be recorded, though.
+    /// Until issue #206 it was not — failures went to <c>Console.WriteLine</c>, and under
+    /// <c>sc.exe</c> a Windows service has no console, so a registration burst during a
+    /// Wallet.Api restart committed users with no wallets and said so nowhere. These Error
+    /// entries are the only trace such a user leaves: a missing wallet is created lazily the
+    /// first time it is written to, so afterwards nothing in the wallet database distinguishes
+    /// them from anyone else.
+    /// </remarks>
     /// <param name="userId">User id.</param>
-    /// <returns>Whether it succeeded.</returns>
-    private async Task<bool> CreateDefaultWalletsAsync(Guid userId)
+    private async Task CreateDefaultWalletsAsync(Guid userId)
     {
         try
         {
             using var httpClient = _httpClientFactory.CreateClient("WalletAPI");
             _logger.Log(LogLevel.Information,"درخواست برای ساخت کیف پول های پیش فرض" + " " + httpClient.BaseAddress + $"api/wallet/create-default/{userId}");
-            
-            var response = await httpClient.GetAsync($"api/wallet/create-default/{userId}");
-            
-            return response.IsSuccessStatusCode;
+
+            var response = await httpClient.PostAsync($"api/wallet/create-default/{userId}", null);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // A non-2xx never reaches the catch below — it is a completed request, not an
+                // exception — and it is the likelier of the two failures, so it needs its own
+                // Error entry. The body carries the wallet service's own reason for refusing.
+                var body = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Default wallet creation for user {UserId} was refused: HTTP {StatusCode}. Response: {ResponseBody}. Registration continues; this user has no wallets until one is created on first use.",
+                    userId, (int)response.StatusCode, body);
+            }
         }
         catch (Exception ex)
         {
-            // Log the error but don't fail user creation
-            Console.WriteLine($"خطا در ایجاد کیف پول‌های پیش‌فرض برای کاربر {userId}: {ex.Message}");
-            return false;
+            // Stays broad on purpose: nothing is rethrown, so narrowing it would turn some
+            // failures into failed registrations, which is exactly what the remarks above say
+            // must not happen. The exception is logged, so its type is visible in the log
+            // rather than flattened away here.
+            _logger.LogError(ex,
+                "Default wallet creation for user {UserId} failed. Registration continues; this user has no wallets until one is created on first use.",
+                userId);
         }
     }
 }

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -302,8 +302,8 @@ app.MapGet("/api/wallet/transactions/{userId}", async (Guid userId, string? asse
 
 // Creates the wallets a new user starts with: Toman, gold, and the gold credit ledger.
 // POST, not GET: this creates rows, and GET is the verb every intermediary assumes it may
-// retry or prefetch freely. Idempotent — CreateWalletAsync returns the existing wallet — so a
-// repeat is harmless, but the verb should still say what the call does. Issue #206.
+// retry or prefetch freely. A repeat creates no duplicate rows — CreateWalletAsync keeps the
+// existing wallet — but the verb should still say what the call does. Issue #206.
 // userId: User id.
 // walletService: Wallet service.
 // Returns: The wallets that were created.

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -301,12 +301,15 @@ app.MapGet("/api/wallet/transactions/{userId}", async (Guid userId, string? asse
 .WithTags("Transactions");
 
 // Creates the wallets a new user starts with: Toman, gold, and the gold credit ledger.
+// POST, not GET: this creates rows, and GET is the verb every intermediary assumes it may
+// retry or prefetch freely. Idempotent — CreateWalletAsync returns the existing wallet — so a
+// repeat is harmless, but the verb should still say what the call does. Issue #206.
 // userId: User id.
 // walletService: Wallet service.
 // Returns: The wallets that were created.
 // 200: Default wallets created.
 // 400: Wallet creation failed.
-app.MapGet("/api/wallet/create-default/{userId}", async (Guid userId, IWalletService walletService) =>
+app.MapPost("/api/wallet/create-default/{userId}", async (Guid userId, IWalletService walletService) =>
 {
     try
     {

--- a/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
@@ -1,0 +1,238 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using TallaEgg.AllServices.Tests.Fakes;
+using TallaEgg.Core.DTOs;
+using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Enums.User;
+using Users.Application;
+using Users.Application.Mappers;
+using Users.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Registration creates a user's default wallets — Toman, MAUA, CREDIT_MAUA — by calling
+/// Wallet.Api, and deliberately does not fail the registration when that call fails. Until
+/// issue #206 it also did not record the failure: the exception path wrote to
+/// <c>Console.WriteLine</c> while an <c>ILogger</c> was injected and in use two lines above,
+/// and under <c>sc.exe</c> a Windows service has no console. The non-2xx path did not even
+/// reach that — <c>return response.IsSuccessStatusCode</c> turned a 404 or a 500 into a
+/// discarded <c>false</c> with no log line at all.
+///
+/// <para>
+/// That mattered more after #190 removed the only other route to wallet creation. A
+/// registration burst during a Wallet.Api restart committed users with no wallets, and nothing
+/// anywhere said which ones: a missing wallet is created lazily the first time it is written to
+/// (see <c>WalletLazyCreationTests</c>), so afterwards the wallet database cannot tell those
+/// users apart from anyone else. The Error entries asserted here are their only trace.
+/// </para>
+///
+/// <para>
+/// The same issue moved the wallet endpoint from GET to POST — a safe verb must not create
+/// rows — so the request the client sends is pinned here too.
+/// </para>
+/// </summary>
+public class DefaultWalletCreationFailureTests
+{
+    /// <summary>Records what was asked of it, then answers however the test told it to.</summary>
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> answer) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(answer(request));
+        }
+    }
+
+    /// <summary>Hands out one client over the handler the test supplied, like the real named client.</summary>
+    private sealed class SingleClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("http://wallet.test/") };
+    }
+
+    /// <summary>
+    /// Only <c>CreateAsync</c> is exercised: <c>RegisterUserAsync(User)</c> stores the user and
+    /// then creates its wallets, which is the whole path under test. The rest of the interface
+    /// throws rather than returning a plausible-looking default, so a test that strays into it
+    /// fails loudly instead of quietly passing.
+    /// </summary>
+    private sealed class OneUserRepository : IUserRepository
+    {
+        public List<User> Created { get; } = [];
+
+        public Task<User> CreateAsync(User user)
+        {
+            Created.Add(user);
+            return Task.FromResult(user);
+        }
+
+        public Task<User?> GetByTelegramIdAsync(long telegramId) => throw new NotSupportedException();
+        public Task<User?> GetByPhoneNumberAsync(string phone) => throw new NotSupportedException();
+        public Task<User> UpdateAsync(User user) => throw new NotSupportedException();
+        public Task<bool> ExistsByTelegramIdAsync(long telegramId) => throw new NotSupportedException();
+        public Task<PagedResult<UserDto>> GetAllAsync(string? q, int page, int size) => throw new NotSupportedException();
+        public Task<User?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<User?> UpdateUserRoleAsync(Guid id, UserRole role) => throw new NotSupportedException();
+        public Task<IEnumerable<User>> GetUsersByRoleAsync(UserRole role) => throw new NotSupportedException();
+        public Task<Affiliate.Core.Invitation?> GetInvitationByCodeAsync(string invitationCode) => throw new NotSupportedException();
+        public Task<Guid?> GetUserIdByInvitationCodeAsync(string invitationCode) => throw new NotSupportedException();
+        public Task<Guid?> GetUserIdByPhonenumberAsync(string phoneNumber) => throw new NotSupportedException();
+    }
+
+    private static User AnyNewUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        TelegramId = 1,
+        CreatedAt = DateTime.UtcNow,
+        InvitationCode = "abcde"
+    };
+
+    private static (UserService service, OneUserRepository repository, CapturingLogger<UserService> logger)
+        ServiceOver(HttpMessageHandler handler)
+    {
+        var repository = new OneUserRepository();
+        var logger = new CapturingLogger<UserService>();
+        var service = new UserService(repository, new UserMapper(), new SingleClientFactory(handler), logger);
+        return (service, repository, logger);
+    }
+
+    private static HttpResponseMessage Answer(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    /// <summary>
+    /// The transport failure — Wallet.Api down, connection refused. It reaches the catch, and
+    /// the entry has to carry the exception itself, not just its message: the type is what
+    /// tells an operator a refused connection from a timeout.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceUnreachable_LogsErrorWithTheException()
+    {
+        var handler = new RecordingHandler(_ => throw new HttpRequestException("Connection refused"));
+        var (service, _, logger) = ServiceOver(handler);
+
+        await service.RegisterUserAsync(AnyNewUser());
+
+        var error = Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.IsType<HttpRequestException>(error.Exception);
+    }
+
+    /// <summary>
+    /// A registration whose wallet creation fails still succeeds. That is the deliberate part
+    /// of this behaviour and the part a future change is most likely to break by accident.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceUnreachable_StillRegistersTheUser()
+    {
+        var handler = new RecordingHandler(_ => throw new HttpRequestException("Connection refused"));
+        var (service, repository, _) = ServiceOver(handler);
+        var user = AnyNewUser();
+
+        var registered = await service.RegisterUserAsync(user);
+
+        Assert.Equal(user.Id, registered.Id);
+        Assert.Single(repository.Created);
+    }
+
+    /// <summary>
+    /// The path that never reached the old catch at all. <c>return response.IsSuccessStatusCode</c>
+    /// turned a refusal into a discarded <c>false</c>, so the likelier of the two failures was
+    /// the one that logged nothing.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceReturnsNon2xx_LogsErrorWithStatusAndBody()
+    {
+        const string reason = "کیف پول وجود ندارد";
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.BadRequest, $"{{\"success\":false,\"message\":\"{reason}\"}}"));
+        var (service, _, logger) = ServiceOver(handler);
+
+        await service.RegisterUserAsync(AnyNewUser());
+
+        var error = Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains("400", error.Message);
+        Assert.Contains(reason, error.Message);
+    }
+
+    /// <summary>A refused wallet creation must not take the registration down with it either.</summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceReturnsNon2xx_StillRegistersTheUser()
+    {
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.InternalServerError, "boom"));
+        var (service, repository, _) = ServiceOver(handler);
+        var user = AnyNewUser();
+
+        var registered = await service.RegisterUserAsync(user);
+
+        Assert.Equal(user.Id, registered.Id);
+        Assert.Single(repository.Created);
+    }
+
+    /// <summary>
+    /// The verb, from the calling side. Wallet creation is a POST since issue #206; a GET here
+    /// would have to be matched by a GET route, which is the pairing that broke #190's endpoint.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_CreatesDefaultWallets_WithPostNotGet()
+    {
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.OK, "{\"success\":true}"));
+        var (service, _, _) = ServiceOver(handler);
+        var user = AnyNewUser();
+
+        await service.RegisterUserAsync(user);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal($"/api/wallet/create-default/{user.Id}", request.RequestUri?.AbsolutePath);
+    }
+
+    /// <summary>A wallet creation that works logs nothing at Error — otherwise the check is noise.</summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceSucceeds_LogsNoError()
+    {
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.OK, "{\"success\":true}"));
+        var (service, _, logger) = ServiceOver(handler);
+
+        await service.RegisterUserAsync(AnyNewUser());
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    /// <summary>
+    /// The verb, from the serving side. The two halves have to agree and only one of them is
+    /// covered by the client test above; standing Wallet.Api up for real needs the shared
+    /// configuration file and a database, so the mapping is asserted against its source. If the
+    /// route ever moves, this assertion is meant to be updated, not deleted.
+    /// </summary>
+    [Fact]
+    public void WalletApi_MapsDefaultWalletCreation_AsPostNotGet()
+    {
+        var program = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(), "src", "Wallet", "Wallet.Api", "Program.cs"));
+
+        Assert.Contains("app.MapPost(\"/api/wallet/create-default/{userId}\"", program);
+        Assert.DoesNotContain("app.MapGet(\"/api/wallet/create-default/{userId}\"", program);
+    }
+
+    /// <summary>
+    /// Walks up from the test assembly to the directory holding <c>TallaEgg.sln</c>. The same
+    /// anchor <c>ConfigurationPrecedenceTests</c> and <c>SolutionMembershipTests</c> use, and
+    /// duplicated for the reason they duplicate it: sharing it would mean editing tests this
+    /// change has no business touching.
+    /// </summary>
+    private static string FindRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TallaEgg.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+
+        return dir.FullName;
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
@@ -47,11 +47,22 @@ public class DefaultWalletCreationFailureTests
         }
     }
 
-    /// <summary>Hands out one client over the handler the test supplied, like the real named client.</summary>
+    /// <summary>
+    /// Hands out one client over the handler the test supplied, like the real named client, and
+    /// records the name it was asked for. The real factory answers an unregistered name with a
+    /// default client whose <c>BaseAddress</c> is null, and the broad catch in the method under
+    /// test would swallow the resulting <c>InvalidOperationException</c> into one Error line per
+    /// registration — so the name is a precondition worth asserting, not decoration.
+    /// </summary>
     private sealed class SingleClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {
-        public HttpClient CreateClient(string name) =>
-            new(handler, disposeHandler: false) { BaseAddress = new Uri("http://wallet.test/") };
+        public List<string> RequestedNames { get; } = [];
+
+        public HttpClient CreateClient(string name)
+        {
+            RequestedNames.Add(name);
+            return new(handler, disposeHandler: false) { BaseAddress = new Uri("http://wallet.test/") };
+        }
     }
 
     /// <summary>
@@ -152,8 +163,31 @@ public class DefaultWalletCreationFailureTests
         await service.RegisterUserAsync(AnyNewUser());
 
         var error = Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
-        Assert.Contains("400", error.Message);
+        // "HTTP 400", not "400": the message also interpolates a random Guid, and one in fifty
+        // of those contains "400" somewhere — an assertion that would go green on the wrong
+        // status code some of the time, which is worse than one that goes red some of the time.
+        Assert.Contains("HTTP 400", error.Message);
         Assert.Contains(reason, error.Message);
+    }
+
+    /// <summary>
+    /// The logged body is capped. An intermediary answering with a multi-kilobyte HTML error page
+    /// would otherwise be copied whole into the rolling log once per registration — and a
+    /// registration burst against a sick wallet service is the exact case this logging exists for,
+    /// so the unbounded version is at its worst precisely when it is most needed.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_WalletServiceReturnsAHugeBody_TruncatesItBeforeLogging()
+    {
+        var huge = new string('x', 20_000);
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.BadGateway, huge));
+        var (service, _, logger) = ServiceOver(handler);
+
+        await service.RegisterUserAsync(AnyNewUser());
+
+        var error = Assert.Single(logger.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains("(truncated)", error.Message);
+        Assert.True(error.Message.Length < 1_000, $"message was {error.Message.Length} characters");
     }
 
     /// <summary>A refused wallet creation must not take the registration down with it either.</summary>
@@ -188,6 +222,25 @@ public class DefaultWalletCreationFailureTests
         Assert.Equal($"/api/wallet/create-default/{user.Id}", request.RequestUri?.AbsolutePath);
     }
 
+    /// <summary>
+    /// The call goes through the configured "WalletAPI" client. Nothing else pins that name, and
+    /// a rename on one side only would leave the real factory handing back a default client with
+    /// no <c>BaseAddress</c> — a failure the broad catch turns into an Error line per
+    /// registration and no wallets for anyone.
+    /// </summary>
+    [Fact]
+    public async Task RegisterUserAsync_CreatesDefaultWallets_ThroughTheConfiguredWalletClient()
+    {
+        var handler = new RecordingHandler(_ => Answer(HttpStatusCode.OK, "{\"success\":true}"));
+        var factory = new SingleClientFactory(handler);
+        var service = new UserService(
+            new OneUserRepository(), new UserMapper(), factory, new CapturingLogger<UserService>());
+
+        await service.RegisterUserAsync(AnyNewUser());
+
+        Assert.Equal("WalletAPI", Assert.Single(factory.RequestedNames));
+    }
+
     /// <summary>A wallet creation that works logs nothing at Error — otherwise the check is noise.</summary>
     [Fact]
     public async Task RegisterUserAsync_WalletServiceSucceeds_LogsNoError()
@@ -203,8 +256,15 @@ public class DefaultWalletCreationFailureTests
     /// <summary>
     /// The verb, from the serving side. The two halves have to agree and only one of them is
     /// covered by the client test above; standing Wallet.Api up for real needs the shared
-    /// configuration file and a database, so the mapping is asserted against its source. If the
-    /// route ever moves, this assertion is meant to be updated, not deleted.
+    /// configuration file and a database, which is why nothing covers its route table today, so
+    /// the mapping is asserted against its source instead.
+    ///
+    /// <para>
+    /// The patterns tolerate whitespace and line breaks so that reformatting the call does not
+    /// turn this red. They cannot survive the route being extracted to a constant or mapped
+    /// through <c>MapMethods</c> — if that happens this assertion is meant to be rewritten
+    /// against whatever expresses the verb then, not deleted.
+    /// </para>
     /// </summary>
     [Fact]
     public void WalletApi_MapsDefaultWalletCreation_AsPostNotGet()
@@ -212,8 +272,8 @@ public class DefaultWalletCreationFailureTests
         var program = File.ReadAllText(Path.Combine(
             FindRepositoryRoot(), "src", "Wallet", "Wallet.Api", "Program.cs"));
 
-        Assert.Contains("app.MapPost(\"/api/wallet/create-default/{userId}\"", program);
-        Assert.DoesNotContain("app.MapGet(\"/api/wallet/create-default/{userId}\"", program);
+        Assert.Matches(@"app\.MapPost\(\s*""/api/wallet/create-default/\{userId\}""", program);
+        Assert.DoesNotMatch(@"app\.MapGet\(\s*""/api/wallet/create-default/\{userId\}""", program);
     }
 
     /// <summary>

--- a/tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj
+++ b/tests/TallaEgg.AllServices.Tests/TallaEgg.AllServices.Tests.csproj
@@ -32,6 +32,8 @@
     <ProjectReference Include="..\..\src\Wallet\Wallet.Infrastructure\Wallet.Infrastructure.csproj" />
     <!-- برای پین‌کردن رفتار MakeTradeAsync که پشت قرنطینهٔ C-8 است (issue #46). -->
     <ProjectReference Include="..\..\src\Wallet\Wallet.Application\Wallet.Application.csproj" />
+    <!-- UserService: the registration path that creates a user's default wallets (issue #206). -->
+    <ProjectReference Include="..\..\src\User\Users.Application\Users.Application.csproj" />
     <!-- OutboxMessage lives on the Orders side; its state machine is unit-tested here. -->
     <ProjectReference Include="..\..\src\Order\Orders.Core\Orders.Core.csproj" />
     <ProjectReference Include="..\..\src\Order\Orders.Infrastructure\Orders.Infrastructure.csproj" />


### PR DESCRIPTION
## Description

Registration creates a user's default wallets — Toman, MAUA, CREDIT_MAUA — by calling
`Wallet.Api`. #190 removed the only other route into wallet creation, which left this path both
the only one and, in two ways, the least observable one. The endpoint moves from GET to POST,
and the caller now records its failures through the injected `ILogger` instead of writing them
to a console a Windows service does not have.

## Issue/Task Reference

Part of #206 — parts 1 and 2. Part 3 needed a decision rather than code; see
"Part 3" below.

## Type of Change

- [x] Hotfix (urgent bug fix) — no
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)

Bug fix, not urgent: the flow works today, and everything here is about what happens when it
does not.

## Verification of the reported defects

Confirmed against the tree, not taken from the issue:

| Claim | Confirmed at |
| --- | --- |
| Wallet creation mapped to GET | `src/Wallet/Wallet.Api/Program.cs:309` (before this PR) |
| Exactly one caller, in this repository | `grep -rn "create-default"` returned three hits: the mapping, and the log line and the call in `UserService` |
| `Console.WriteLine` with `_logger` in scope | `UserService.cs:207` logs through `_logger`, `:216` through the console |
| The `bool` is discarded by both call sites | `UserService.cs:54`, `:164` |

One item the issue did not state, confirmed here and worth naming because it is the bigger half
of the problem: **a non-2xx response never reached the `catch` at all.** `return
response.IsSuccessStatusCode` treats a completed request as a completed request — a 404 or a 500
from `Wallet.Api` produced a discarded `false` and no log line whatsoever, whereas an exception
at least reached `Console.WriteLine`. The refusal is also the likelier of the two failures.

Two of the three things the issue's `catch (Exception)` bullet names cannot happen here any
more, which is why the catch stays broad (see below): a non-2xx is now handled before it, and a
misconfigured address stops the service at startup since #204's `ConfigurationGuard.RequireUri`.

## Changes Made

- `src/Wallet/Wallet.Api/Program.cs` — `MapGet` → `MapPost` for
  `/api/wallet/create-default/{userId}`, with a comment saying why. The route and the handler are
  otherwise untouched
- `src/User/Users.Application/UserService.cs` — `GetAsync` → `PostAsync`, in the same commit, as
  the issue asks. Both halves of a breaking change, and the only caller is in this repository
- The non-2xx branch logs at `Error` with the status code and the response body, capped at 500
  characters. (For this particular endpoint that body is currently always the same generic
  message — see #210 — but the status code alone separates 401 from 405 from 500)
- The `catch` logs at `Error` through `_logger` with the exception object, replacing
  `Console.WriteLine` with `ex.Message`. The type matters — it is what tells a refused connection
  from a timeout — and only the exception object carries it
- The `catch` deliberately stays broad. Nothing is rethrown, so narrowing it would turn some
  failures into failed registrations, which is exactly the behaviour the method exists to avoid.
  A comment says so, and the log entry now makes the type visible instead of flattening it away
- Return type `Task<bool>` → `Task`. Both call sites discarded the bool, and with the method
  recording its own failures there is nothing left for a caller to act on
- Nine tests in `tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs`, and the
  `Users.Application` project reference they need

Registration still succeeds when wallet creation fails. That was deliberate, the issue agrees it
is defensible, and it is unchanged — two of the new tests pin it.

`1ae7b78` applies the self-review findings on this PR's own code: the Error messages no longer
overclaim ("may be missing or incomplete", since a timeout or a partial creation can leave a
user with some wallets), the body is truncated, the response is disposed, and three test
weaknesses are closed. Full accounting in the review comment below.

## Part 3 — no remediation path, by decision

The issue's third part asked whether an operator needs a supported way to repair a user whose
registration-time wallet creation failed, and if so whether that should be an admin bot command
or an endpoint. Asked and answered by the product owner: **no repair surface**. Nothing is built
for it here.

Two things make that the cheap answer rather than a deferral:

- **A wallet-less user largely self-heals.** Since the lazy-creation work behind
  `WalletLazyCreationTests`, every *write* path creates a missing wallet for a valid currency on
  demand — `WalletService.IncreaseBalanceAsync` and `DecreaseBalanceAsync`,
  `WalletRepository.LockBalanceAsync`/`UnlockBalanceAsync` and the settlement path. The surface
  that genuinely breaks is a pure *read*: `WalletService.GetBalanceAsync` throws
  "کیف پول پیدا نشد" when there is no row.
- **The Error entries in part 2 are the "cheap way to find them" the issue asked about.** They
  name the user id, so `logs/users-api-*.log` now answers "which users need looking at", which
  before this PR nothing anywhere did. `WalletRepository.cs:280` still cannot tell a missing
  wallet from a lazily-created one, and that is unchanged — but it no longer has to be the place
  you find out.

Since part 3 closes by decision rather than by code, this PR says "part of #206". **Nothing is
left to build**; #206 can be closed once this merges.

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 741, Skipped: 0, Total: 741
```

Nine new, covering: the exception path logs `Error` carrying the exception; the non-2xx path
logs `Error` carrying status and body; both still register the user; a huge body is truncated
before it is logged; the request is a POST at the expected path, through the configured
`"WalletAPI"` client; a success logs no `Error`; and — from the serving side — `Wallet.Api` maps
the route as `MapPost` and not `MapGet`.

### The new tests were shown to fail

A check that has never been red is not a check. With the two source files stashed and the tests
left in place, the four that pin new behaviour go red and the three that pin the deliberate
unchanged behaviour stay green. (Run at `12b450e`, before self-review added the truncation and
client-name tests; those two cover code that did not exist at all beforehand.)

```
Failed  RegisterUserAsync_CreatesDefaultWallets_WithPostNotGet
        Assert.Equal() Failure: Values differ   Expected: POST   Actual: GET
Failed  RegisterUserAsync_WalletServiceUnreachable_LogsErrorWithTheException
        Assert.Single() Failure: The collection did not contain any matching items
        Collection: [Entry { Level = Information, ... }]
Failed  RegisterUserAsync_WalletServiceReturnsNon2xx_LogsErrorWithStatusAndBody
        Assert.Single() Failure: The collection did not contain any matching items
Failed  WalletApi_MapsDefaultWalletCreation_AsPostNotGet
        Assert.Contains() Failure: Sub-string not found

Failed! - Failed: 4, Passed: 3, Skipped: 0, Total: 7
```

### The normal path still works — the only thing this PR could break

A real registration through `POST /api/user/register` against the running stack, then the wallet
database queried directly for that user id:

```
CREDIT_MAUA  balance=0.00000000  locked=0.00000000  created=2026-09-03 06:00:48
IRT          balance=0.00000000  locked=0.00000000  created=2026-09-03 06:00:47
MAUA         balance=0.00000000  locked=0.00000000  created=2026-09-03 06:00:48
```

All three default wallets, created within a second of the user row, over POST. The probe user was
in the simulator's `TelegramId < 0` range and has since been cleared by `DataReset`.

### Failure is now visible — both paths, against the running stack

**Wallet.Api down** (the exception path). Registration succeeds, and the failure lands in
`src/User/Users.Api/logs/users-api-20260903.log` — the rolling file sink, which is what an
operator reads under `sc.exe` and is exactly what `Console.WriteLine` never reached:

```
2026-09-03 09:31:06.683 +03:30 [ERR] Default wallet creation for user
"e2853c8d-5d2a-4dbe-9b83-f8be0746a717" failed. Registration continues; this user's default
wallets may be missing or incomplete.
System.Net.Http.HttpRequestException: No connection could be made because the target machine
actively refused it. (localhost:60933)
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the
target machine actively refused it.
```

`registration success = True`, and the user has 0 wallet rows — the failure was real, not
simulated at the logging layer. (Rows checked on the first pass of this scenario, before the
review fixes reworded the message; the second pass re-verified the log line.)

**Answering non-2xx** (the path that skips the catch). The real service stopped and a stub bound
to port 60933 answering 500 to everything, so the request completes and never throws:

```
2026-09-03 09:31:22.465 +03:30 [ERR] Default wallet creation for user
"330feb78-db05-49e0-98e0-de4f6b7ce620" was refused: HTTP 500. Response:
{"success":false,"message":"stub: wallet service refused","data":null}. Registration
continues; this user's default wallets may be missing or incomplete.
```

`registration success = True` here too. Before this PR that registration produced no log line at
all.

### End to end

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:45.4. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Registration is phase 1, so all 20 users took this path over POST. The log holds exactly the two
deliberate failures above and nothing from the run itself.

### CI doc-path check (#207)

```
scripts/check-doc-paths.sh
check-doc-paths: 381 tracked text file(s) checked, every reference resolves.
```

### Environment

- [x] Tested locally — Windows + SQL Server Express, from a git worktree on this branch

## Security Checklist

- [x] No hardcoded credentials
- [x] No TLS bypass in production code
- [x] No secrets/tokens in the diff — `config/appsettings.global.json` is untouched and uncommitted
- [x] Code compiles without warnings

One thing worth a reviewer's eye: the new non-2xx entry logs the response body. It carries the
wallet service's own `BusinessRuleException` message, which is Persian text written for a human
and holds no credential or personal data. In Development an unhandled 500 could put a stack trace
there instead, which is diagnostic rather than sensitive.

## Code Quality

- [x] Naming follows `STANDARDS.md` — new tests are `Method_Scenario_ExpectedResult`
- [x] Comments in English and explain the "why". The existing Persian `Information` line is left
      as it was, per the rule that existing Persian strings are not translated
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies — one `ProjectReference` (`Users.Application`) that the new
      tests need

## Documentation

No `.md` changes. Nothing in `docs/` documents this route or the private method; `AGENT.md`'s
port table and configuration rules are unaffected. Swagger picks the verb up from the mapping.

## Breaking Changes?

- [x] No breaking changes

The verb change is a contract change in principle. In practice the route has exactly one caller,
it is in this repository, and it changes in the same commit. The four APIs bind loopback and are
called only by the bot on the same host, so there is no external consumer. A deployment that ships
one service without the other would see wallet creation fail with 405 — and, thanks to part 2,
would now say so in the log instead of silently registering users without wallets.

## Deployment Notes

No migrations, no new configuration. Deploy `Users.Api` and `Wallet.Api` together — see Breaking
Changes.

**Post-deployment verification**: register a user and confirm three wallet rows appear, or watch
`logs/users-api-*.log` for `Default wallet creation ... was refused: HTTP 405`, which is what a
half-deployed pair looks like.

**Rollback**: revert the commit. Both sides move back together, so there is no intermediate state.

## Related Issues

- Part of #206
- Follows #190 / #204, which removed the other route and made this one the only one
- **#209** — opened from this PR's self-review, and the more serious defect in this path:
  `Users.Api`'s `"WalletAPI"` client sends no `X-API-Key`, so this call gets 401 on any
  Production deployment and default wallets have never been created there. Pre-existing, not
  caused or fixed here — but this PR is what makes it visible in the log, and it should land soon
  after
- **#210** — also from self-review: the endpoint's `catch (BusinessRuleException)` is unreachable
  because the service wraps everything in `InvalidOperationException`, and the response is built
  from entities the repository may have discarded
- Same class of problem as #202 (output written where no console exists)
- #205 (the remaining configuration fallbacks) is untouched, deliberately — separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
