### PR TITLE
[Refactor] Require service addresses instead of defaulting to literals — issue #205

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Create your own copy from the template below.
     },
     "Orders.Api": {
       "Urls": [ "http://localhost:5140" ],
+      "UsersApiUrl": "http://localhost:5136/api",
       "WalletApiUrl": "http://localhost:60933/api",
       "Matching": {
         "RequireMarketMakerCounterparty": true,

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -29,9 +29,11 @@ public class OrderApiClient : IOrderApiClient
         // branch meant talking to something that answers nothing, with nothing in the logs to
         // say so (issue #205).
         //
-        // TrimEnd because the paths below are concatenated, not resolved: Uri normalises an
-        // empty path to "/", which would otherwise produce "host//orders".
-        _baseUrl = ConfigurationGuard.RequireUri(configuration, "OrderApiUrl").ToString().TrimEnd('/');
+        // AbsoluteUri rather than ToString, which unescapes: a percent-escaped or non-ASCII
+        // host would come back decoded and be concatenated into a request against a different
+        // authority than was configured. TrimEnd because the paths below are concatenated, not
+        // resolved: Uri normalises an empty path to "/", which would produce "host//orders".
+        _baseUrl = ConfigurationGuard.RequireUri(configuration, "OrderApiUrl").AbsoluteUri.TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var handler = new HttpClientHandler();

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -23,7 +23,15 @@ public class OrderApiClient : IOrderApiClient
     public OrderApiClient(HttpClient httpClient, IConfiguration configuration, ILogger<OrderApiClient> logger)
     {
         _httpClient = httpClient;
-        _baseUrl = configuration["OrderApiUrl"] ?? "http://localhost:5135/api";
+
+        // Guarded rather than defaulted: the old fallback pointed at 5135, which is TallaEgg.Api
+        // — a host that starts, binds and maps no routes. Orders are on 5140, so taking that
+        // branch meant talking to something that answers nothing, with nothing in the logs to
+        // say so (issue #205).
+        //
+        // TrimEnd because the paths below are concatenated, not resolved: Uri normalises an
+        // empty path to "/", which would otherwise produce "host//orders".
+        _baseUrl = ConfigurationGuard.RequireUri(configuration, "OrderApiUrl").ToString().TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var handler = new HttpClientHandler();

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -36,6 +36,10 @@ public class Program
             .WriteTo.File("logs/telegrambot-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
             .CreateLogger();
 
+        // Configuration guards throw before the host exists, and the bot runs as a Windows
+        // service with no console to print to — same as the five APIs (issue #205).
+        TallaEgg.Core.StartupLogging.ReportUnhandledExceptionsToLog();
+
         using var host = CreateHostBuilder(args).Build();
         await host.RunAsync();
     }

--- a/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs
@@ -34,8 +34,9 @@ if (!serviceSection.Exists())
 // Some of the bot's own clients (OrderApiClient, UsersApiClient) read flat keys like
 // "OrderApiUrl" straight off IConfiguration rather than through TelegramBotOptions — the real
 // bot's Program.cs flattens Services:{ApplicationName}:* into root-level keys for exactly
-// this reason. Without this step those clients silently fall back to their compiled-in
-// defaults instead of the configured URLs.
+// this reason. Without this step those clients find no key at all and refuse to be built;
+// before issue #205 they were worse than that, falling back to compiled-in defaults so the
+// simulator ran against addresses nobody had configured.
 var prefix = $"Services:{BotApplicationName}:";
 var flattened = serviceSection.AsEnumerable(true)
     .Where(pair => pair.Value is not null)

--- a/config/appsettings.global.example.json
+++ b/config/appsettings.global.example.json
@@ -61,7 +61,6 @@
             "Urls": [
                 "http://localhost:5135"
             ],
-            "UsersApiUrl": "http://localhost:5136",
             "Cors": {
                 "AllowedOrigins": []
             }
@@ -79,6 +78,7 @@
             "Urls": [
                 "http://localhost:5140"
             ],
+            "UsersApiUrl": "http://localhost:5136/api",
             "WalletApiUrl": "http://localhost:60933/api",
             "Cors": {
                 "AllowedOrigins": []

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -15,9 +15,10 @@ using TallaEgg.Core.ErrorHandling;
 var builder = WebApplication.CreateBuilder(args);
 
 // Serilog before anything that can throw. This configuration reads nothing from the shared file
-// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
-// what lets a configuration failure reach the rolling log rather than a console no Windows
-// service has (issue #205).
+// — the sinks are fixed here — so it can be installed ahead of the file being located, and a
+// configuration failure reaches the rolling log rather than only stderr (issue #205). This
+// service is not one of the four installed with sc.exe, so it does have a console; the ordering
+// matches its siblings, where that is the whole point.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -14,6 +14,18 @@ using TallaEgg.Core.ErrorHandling;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Serilog before anything that can throw. This configuration reads nothing from the shared file
+// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
+// what lets a configuration failure reach the rolling log rather than a console no Windows
+// service has (issue #205).
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+StartupLogging.ReportUnhandledExceptionsToLog();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -61,8 +73,13 @@ if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKe
 }
 
 // تنظیم اتصال به دیتابیس SQL Server
+// SQL Server connection. Read here, not inside the options delegate below: that delegate does
+// not run until DbContextOptions<T> is first resolved, so a missing connection string failed
+// startup only because the migration block further down happens to resolve the context (#205).
+var affiliateConnectionString = ConfigurationGuard.RequireConnectionString(builder.Configuration, "AffiliateDb");
+
 builder.Services.AddDbContext<AffiliateDbContext>(options =>
-    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "AffiliateDb"),
+    options.UseSqlServer(affiliateConnectionString,
         b => b.MigrationsAssembly("Affiliate.Api")));
 
 // فقط در production محافظت فعال شود
@@ -98,14 +115,6 @@ builder.Services.AddTallaEggCors(builder.Configuration);
 builder.Services.AddScoped<IAffiliateRepository, AffiliateRepository>();
 builder.Services.AddScoped<AffiliateService>();
 builder.Services.AddTallaEggErrorHandling();
-
-// پیکربندی Serilog برای لاگ‌نویسی روی فایل و کنسول
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
-    .CreateLogger();
-
-builder.Host.UseSerilog();
 
 var app = builder.Build();
 

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -136,13 +136,13 @@ ConfigurationGuard.RequireUri(builder.Configuration, "UsersApiUrl");
 builder.Services.AddScoped<UsersApiClient>();
 
 
-// Add Wallet API Client. The address is read and parsed out here rather than inside the
-// configure delegate, which does not run until the first client is created (issue #205).
-var walletApiBaseAddress = ConfigurationGuard.RequireUri(builder.Configuration, "WalletApiUrl");
-builder.Services.AddHttpClient<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>(client =>
-{
-    client.BaseAddress = walletApiBaseAddress;
-});
+// Add Wallet API Client. No configure delegate: WalletApiClient's constructor reads
+// WalletApiUrl and assigns BaseAddress itself, so anything set here would be overwritten a
+// moment later — which is what made the old fallback on this line unreachable twice over.
+// The read below is what the delegate could not be: the typed client is transient, so its
+// constructor runs on first resolution, and only reading here fails a missing key at startup.
+ConfigurationGuard.RequireUri(builder.Configuration, "WalletApiUrl");
+builder.Services.AddHttpClient<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>();
 
 // CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.
 builder.Services.AddTallaEggCors(builder.Configuration);

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -30,6 +30,19 @@ var builder = WebApplication.CreateBuilder(args);
 // no third-party supervisor needed (issue #70).
 builder.Host.UseWindowsService();
 
+// Serilog before anything that can throw. This configuration reads nothing from the shared file
+// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
+// what lets a configuration failure reach the rolling log rather than a console no Windows
+// service has (issue #205).
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Warning)
+    .WriteTo.Console()
+    .WriteTo.File("logs/orders-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+StartupLogging.ReportUnhandledExceptionsToLog();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -76,9 +89,14 @@ if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKe
     builder.WebHost.UseUrls(urls);
 }
 
-// SQL Server connection.
+// SQL Server connection. Read here, not inside the options delegate below: that delegate does
+// not run until DbContextOptions<T> is first resolved, so a missing connection string failed
+// startup only because the migration block further down happens to resolve the context. Reorder
+// or guard that block and the same mistake would surface at the first request instead (#205).
+var ordersConnectionString = ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb");
+
 builder.Services.AddDbContext<OrdersDbContext>(options =>
-    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
+    options.UseSqlServer(ordersConnectionString,
         b => b.MigrationsAssembly("Orders.Infrastructure"))
     .LogTo(Console.WriteLine, LogLevel.None)); // Disable all EF Core logging
 
@@ -111,22 +129,25 @@ builder.Services.AddScoped<ITradeRepository, TradeRepository>();
 builder.Services.AddScoped<OrderMatchingRepository>();
 builder.Services.AddScoped<OrderService>();
 builder.Services.AddScoped<TradeService>();
+// UsersApiClient is scoped, so its constructor — which reads UsersApiUrl — would not run until
+// the first request. Reading the key here as well makes an absent one stop the service coming
+// up, which is where a configuration mistake belongs (issue #205).
+ConfigurationGuard.RequireUri(builder.Configuration, "UsersApiUrl");
 builder.Services.AddScoped<UsersApiClient>();
 
 
-// Add Wallet API Client
+// Add Wallet API Client. The address is read and parsed out here rather than inside the
+// configure delegate, which does not run until the first client is created (issue #205).
+var walletApiBaseAddress = ConfigurationGuard.RequireUri(builder.Configuration, "WalletApiUrl");
 builder.Services.AddHttpClient<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>(client =>
 {
-    var walletApiUrl = builder.Configuration.GetValue<string>("WalletApiUrl") ?? "http://localhost:60933";
-    client.BaseAddress = new Uri(walletApiUrl);
+    client.BaseAddress = walletApiBaseAddress;
 });
 
 // CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.
 builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddTallaEggErrorHandling();
-
-builder.Services.AddScoped<TallaEgg.Infrastructure.Clients.IWalletApiClient, TallaEgg.Infrastructure.Clients.WalletApiClient>();
 
 // Matching engine — a single instance (issue #53). The reasoning lives in
 // MatchingEngineRegistration, which the tests call too.
@@ -212,15 +233,6 @@ builder.Services.AddSwaggerGen(c =>
         c.IncludeXmlComments(xmlPath);
     }
 });
-
-// Serilog: rolling files, console, and an EF Core filter.
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Warning)
-    .WriteTo.Console()
-    .WriteTo.File("logs/orders-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
-    .CreateLogger();
-
-builder.Host.UseSerilog();
 
 var app = builder.Build();
 

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -19,9 +19,10 @@ using System.IO;
 var builder = WebApplication.CreateBuilder(args);
 
 // Serilog before anything that can throw. This configuration reads nothing from the shared file
-// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
-// what lets a configuration failure reach the rolling log rather than a console no Windows
-// service has (issue #205).
+// — the sinks are fixed here — so it can be installed ahead of the file being located, and a
+// configuration failure reaches the rolling log rather than only stderr (issue #205). This
+// service is not one of the four installed with sc.exe, so it does have a console; the ordering
+// matches its siblings, where that is the whole point.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -18,6 +18,18 @@ using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Serilog before anything that can throw. This configuration reads nothing from the shared file
+// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
+// what lets a configuration failure reach the rolling log rather than a console no Windows
+// service has (issue #205).
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+StartupLogging.ReportUnhandledExceptionsToLog();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -64,9 +76,13 @@ if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKe
     builder.WebHost.UseUrls(urls);
 }
 
-// SQL Server connection.
+// SQL Server connection. Read here, not inside the options delegate below: that delegate does
+// not run until DbContextOptions<T> is first resolved, so a missing connection string failed
+// startup only because the migration block further down happens to resolve the context (#205).
+var ordersConnectionString = ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb");
+
 builder.Services.AddDbContext<OrdersDbContext>(options =>
-    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "OrdersDb"),
+    options.UseSqlServer(ordersConnectionString,
         b => b.MigrationsAssembly("TallaEgg.Api")));
 
 // Only the Orders and Price services are registered.
@@ -82,14 +98,6 @@ builder.Services.AddScoped<IOrderRepository, OrderRepository>();
 builder.Services.AddTallaEggCors(builder.Configuration);
 
 builder.Services.AddTallaEggErrorHandling();
-
-// Serilog: log to rolling files and the console.
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
-    .CreateLogger();
-
-builder.Host.UseSerilog();
 
 var app = builder.Build();
 

--- a/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
+++ b/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace TallaEgg.Core;
 
@@ -35,23 +35,10 @@ public static class ConfigurationGuard
     /// <param name="name">Connection string name, e.g. <c>OrdersDb</c>.</param>
     /// <exception cref="InvalidOperationException">The value is absent, empty, or whitespace.</exception>
     public static string RequireConnectionString(IConfiguration configuration, string name)
-    {
-        ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
-
-        var value = configuration.GetConnectionString(name);
-
-        // Whitespace counts as missing. A key present but blank is a half-finished edit, and
-        // letting it through only moves the failure to the first query.
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            throw new InvalidOperationException(
-                $"Connection string '{name}' is missing. Add it under \"ConnectionStrings\" in " +
-                $"{SHARED_CONFIG_FILE_NAME}. The service will not start without it.");
-        }
-
-        return value;
-    }
+        => ReadNonBlank(configuration, name, static (c, n) => c.GetConnectionString(n))
+           ?? throw new InvalidOperationException(
+                  $"Connection string '{name}' is missing. Add it under \"ConnectionStrings\" in " +
+                  $"{SHARED_CONFIG_FILE_NAME}. The service will not start without it.");
 
     /// <summary>
     /// Returns the named configuration value as an absolute http(s) URI, or throws naming what
@@ -78,11 +65,31 @@ public static class ConfigurationGuard
     /// The value is absent, empty, whitespace, or not an absolute http(s) URI.
     /// </exception>
     public static Uri RequireUri(IConfiguration configuration, string key)
-    {
-        ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        => RequireAbsoluteHttpUri(ReadNonBlank(configuration, key, static (c, k) => c[k]), key);
 
-        var value = configuration[key];
+    /// <summary>
+    /// The same guard as <see cref="RequireUri"/>, for an address that has already been read out
+    /// of configuration by someone else.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RequireUri"/> cannot serve every caller: the bot and the simulator bind their
+    /// section to a strongly typed options object and hand the resulting string to a constructor,
+    /// which never sees an <see cref="IConfiguration"/>. That constructor still has to reject a
+    /// missing or unusable address, and it has to reject it with the same words — an operator
+    /// reading a log should not have to know which of the two routes the value took.
+    ///
+    /// The value still comes from <c>Services:{ApplicationName}</c> in the shared file, so the
+    /// message names that section either way, and <paramref name="key"/> is the key it was read
+    /// from rather than the parameter it arrived in.
+    /// </remarks>
+    /// <param name="value">The configured value, or null if the key was absent.</param>
+    /// <param name="key">Configuration key the value came from, e.g. <c>WalletApiUrl</c>.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The value is absent, empty, whitespace, or not an absolute http(s) URI.
+    /// </exception>
+    public static Uri RequireAbsoluteHttpUri(string? value, string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
 
         // Whitespace counts as missing, for the same reason it does for a connection string.
         if (string.IsNullOrWhiteSpace(value))
@@ -105,5 +112,23 @@ public static class ConfigurationGuard
         }
 
         return uri;
+    }
+
+    /// <summary>
+    /// The argument guards and the blank check that every reader above shares. Returns null when
+    /// the value is absent or blank, leaving the caller to phrase the failure — a connection
+    /// string and a service address live in different parts of the file and need different
+    /// instructions.
+    /// </summary>
+    private static string? ReadNonBlank(
+        IConfiguration configuration,
+        string key,
+        Func<IConfiguration, string, string?> read)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var value = read(configuration, key);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
+++ b/src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace TallaEgg.Core;
 

--- a/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
+++ b/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
@@ -1,0 +1,45 @@
+﻿using Serilog;
+
+namespace TallaEgg.Core;
+
+/// <summary>
+/// Makes a failure during host construction reach the log file rather than only stderr.
+/// </summary>
+public static class StartupLogging
+{
+    /// <summary>
+    /// Reports any exception that terminates the process through the configured Serilog sinks.
+    /// </summary>
+    /// <remarks>
+    /// Every service throws before it can serve a request when configuration is missing — that
+    /// is the rule <c>AGENT.md</c> states and what <see cref="ConfigurationGuard"/> enforces.
+    /// The message names the key and the file to edit, so it is written to be acted on by an
+    /// operator with no debugger attached.
+    ///
+    /// <para>
+    /// That operator could not read it. The services are installed with <c>sc.exe</c> and run
+    /// under <c>UseWindowsService()</c> (issue #70), and a Windows service has no console: an
+    /// exception escaping the top-level statements went to stderr and nowhere else — the same
+    /// class of problem issue #202 fixed for the proxy decision. Serilog is configured before
+    /// anything can throw, so a handler here puts the reason in the rolling file the operator
+    /// is told to look at (issue #205).
+    /// </para>
+    ///
+    /// <para>
+    /// The log path itself is still relative to the working directory, which <c>sc.exe</c> does
+    /// not set — tracked on issue #105.
+    /// </para>
+    /// </remarks>
+    public static void ReportUnhandledExceptionsToLog()
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+        {
+            Log.Fatal(
+                args.ExceptionObject as Exception,
+                "The service is terminating on an unhandled exception.");
+
+            // The process is going down either way; flush before it does.
+            Log.CloseAndFlush();
+        };
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
+++ b/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
@@ -1,4 +1,4 @@
-﻿using Serilog;
+using Serilog;
 
 namespace TallaEgg.Core;
 
@@ -17,12 +17,18 @@ public static class StartupLogging
     /// operator with no debugger attached.
     ///
     /// <para>
-    /// That operator could not read it. The services are installed with <c>sc.exe</c> and run
-    /// under <c>UseWindowsService()</c> (issue #70), and a Windows service has no console: an
-    /// exception escaping the top-level statements went to stderr and nowhere else — the same
-    /// class of problem issue #202 fixed for the proxy decision. Serilog is configured before
-    /// anything can throw, so a handler here puts the reason in the rolling file the operator
-    /// is told to look at (issue #205).
+    /// That operator could not read it. The four deployed hosts — Wallet, Users, Orders and the
+    /// bot — are installed with <c>sc.exe</c> and run under <c>UseWindowsService()</c> (issue
+    /// #70), and a Windows service has no console: an exception escaping the top-level
+    /// statements went to stderr and nowhere else — the same class of problem issue #202 fixed
+    /// for the proxy decision. Serilog is configured before anything can throw, so a handler
+    /// here puts the reason in the rolling file the operator is told to look at (issue #205).
+    ///
+    /// <para>
+    /// It reports through Serilog's static <see cref="Log"/>, which is what a guard throwing
+    /// before the host is built can reach. <c>UseSerilog()</c> only redirects the host's
+    /// <c>ILogger&lt;T&gt;</c>, and at that point there is no host.
+    /// </para>
     /// </para>
     ///
     /// <para>

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -31,9 +31,11 @@ public class UsersApiClient : IUsersApiClient
         // one with an /api suffix and one without, so the address that worked was landed on
         // rather than chosen (issue #205). Every caller now defines its own key.
         //
-        // TrimEnd because the paths below are concatenated, not resolved: Uri normalises an
-        // empty path to "/", which would otherwise produce "host//users/list".
-        _baseUrl = ConfigurationGuard.RequireUri(configuration, "UsersApiUrl").ToString().TrimEnd('/');
+        // AbsoluteUri rather than ToString, which unescapes: a percent-escaped or non-ASCII
+        // host would come back decoded and be concatenated into a request against a different
+        // authority than was configured. TrimEnd because the paths below are concatenated, not
+        // resolved: Uri normalises an empty path to "/", which would produce "host//users/list".
+        _baseUrl = ConfigurationGuard.RequireUri(configuration, "UsersApiUrl").AbsoluteUri.TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var handler = new HttpClientHandler();

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -23,7 +23,17 @@ public class UsersApiClient : IUsersApiClient
     public UsersApiClient(HttpClient httpClient, IConfiguration configuration, ILogger<UsersApiClient> logger)
     {
         _httpClient = httpClient;
-        _baseUrl = ResolveUsersApiBaseUrl(configuration) ?? "http://localhost:5001/api";
+
+        // Read from this host's own section and nowhere else. It used to fall through to a scan
+        // of every key in the merged configuration for anything ending in "UsersApiUrl", which
+        // meant Orders.Api — whose section defined no such key — was served by whichever other
+        // service's section the enumeration reached first. Two of them held incompatible shapes,
+        // one with an /api suffix and one without, so the address that worked was landed on
+        // rather than chosen (issue #205). Every caller now defines its own key.
+        //
+        // TrimEnd because the paths below are concatenated, not resolved: Uri normalises an
+        // empty path to "/", which would otherwise produce "host//users/list".
+        _baseUrl = ConfigurationGuard.RequireUri(configuration, "UsersApiUrl").ToString().TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var handler = new HttpClientHandler();
@@ -33,31 +43,6 @@ public class UsersApiClient : IUsersApiClient
 #endif
         _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
-    }
-
-    private static string? ResolveUsersApiBaseUrl(IConfiguration? configuration)
-    {
-        if (configuration is null)
-        {
-            return null;
-        }
-
-        var directValue = configuration["UsersApiUrl"];
-        if (!string.IsNullOrWhiteSpace(directValue))
-        {
-            return directValue;
-        }
-
-        foreach (var pair in configuration.AsEnumerable())
-        {
-            if (pair.Key?.EndsWith("UsersApiUrl", StringComparison.OrdinalIgnoreCase) == true &&
-                !string.IsNullOrWhiteSpace(pair.Value))
-            {
-                return pair.Value;
-            }
-        }
-
-        return null;
     }
 
     public async Task<ApiResponse<PagedResult<UserDto>>> GetUsersAsync(

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -20,7 +20,7 @@ public class WalletApiClient : IWalletApiClient
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<WalletApiClient> _logger;
-    private readonly string? _walletApiUrl;
+    private readonly Uri _walletApiUrl;
 
     /// <summary>
     /// Builds its own <see cref="HttpClient"/> for callers outside a DI container. The logger is
@@ -29,6 +29,11 @@ public class WalletApiClient : IWalletApiClient
     /// this class is unconditional and a null field would turn a successful lock into a
     /// <see cref="NullReferenceException"/>.
     /// </summary>
+    /// <param name="apiUrl">
+    /// The value of <c>WalletApiUrl</c> from this host's own configuration section. Guarded, not
+    /// defaulted: the bot and the simulator both reach this constructor through
+    /// <c>TelegramBotOptions</c>, where an absent key arrives as null (issue #205).
+    /// </param>
     public WalletApiClient(string? apiUrl, ILogger<WalletApiClient>? logger = null)
     {
         _logger = logger ?? NullLogger<WalletApiClient>.Instance;
@@ -40,18 +45,22 @@ public class WalletApiClient : IWalletApiClient
 #endif
         _httpClient = new HttpClient(handler);
 
-        _walletApiUrl = apiUrl ?? "http://localhost:60933/api";
-        _httpClient.BaseAddress = new Uri(_walletApiUrl);
+        _walletApiUrl = ConfigurationGuard.RequireAbsoluteHttpUri(apiUrl, "WalletApiUrl");
+        _httpClient.BaseAddress = _walletApiUrl;
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }
     public WalletApiClient(HttpClient httpClient, IConfiguration configuration, ILogger<WalletApiClient> logger)
     {
         _httpClient = httpClient;
         _logger = logger;
-        _walletApiUrl = configuration["WalletApiUrl"] ?? "http://localhost:60933/api";
+
+        // Guarded rather than defaulted for the reason in ConfigurationGuard: the old fallback
+        // was the address this client actually used in Orders.Api, so a missing key started the
+        // service against a host nobody had configured (issue #205).
+        _walletApiUrl = ConfigurationGuard.RequireUri(configuration, "WalletApiUrl");
 
         // Configure HttpClient base address
-        _httpClient.BaseAddress = new Uri(_walletApiUrl);
+        _httpClient.BaseAddress = _walletApiUrl;
         _httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -29,6 +29,18 @@ var builder = WebApplication.CreateBuilder(args);
 // no third-party supervisor needed (issue #70).
 builder.Host.UseWindowsService();
 
+// Serilog before anything that can throw. This configuration reads nothing from the shared file
+// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
+// what lets a configuration failure reach the rolling log rather than a console no Windows
+// service has (issue #205).
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+StartupLogging.ReportUnhandledExceptionsToLog();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -75,9 +87,13 @@ if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKe
     builder.WebHost.UseUrls(urls);
 }
 
-// SQL Server connection.
+// SQL Server connection. Read here, not inside the options delegate below: that delegate does
+// not run until DbContextOptions<T> is first resolved, so a missing connection string failed
+// startup only because the migration block further down happens to resolve the context (#205).
+var usersConnectionString = ConfigurationGuard.RequireConnectionString(builder.Configuration, "UsersDb");
+
 builder.Services.AddDbContext<UsersDbContext>(options =>
-    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "UsersDb"),
+    options.UseSqlServer(usersConnectionString,
         b => b.MigrationsAssembly("Users.Api")));
 
 // Protection is only wired up in Production.
@@ -137,14 +153,6 @@ builder.Services.AddSwaggerGen(c =>
         c.IncludeXmlComments(xmlPath);
     }
 });
-
-// Serilog: log to rolling files and the console.
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
-    .CreateLogger();
-
-builder.Host.UseSerilog();
 
 var app = builder.Build();
 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -24,6 +24,18 @@ var builder = WebApplication.CreateBuilder(args);
 // so this is always safe to include. Lets `sc.exe create` manage this process directly —
 // no third-party supervisor needed (issue #70).
 builder.Host.UseWindowsService();
+
+// Serilog before anything that can throw. This configuration reads nothing from the shared file
+// — the sinks are fixed here — so it can be installed ahead of the file being located, which is
+// what lets a configuration failure reach the rolling log rather than a console no Windows
+// service has (issue #205).
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File("logs/wallet-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
+StartupLogging.ReportUnhandledExceptionsToLog();
 
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
@@ -71,17 +83,13 @@ if (string.IsNullOrWhiteSpace(builder.Configuration[WebHostDefaults.ServerUrlsKe
     builder.WebHost.UseUrls(urls);
 }
 
-// Serilog: log to rolling files and the console.
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .WriteTo.File("logs/wallet-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
-    .CreateLogger();
+// SQL Server connection. Read here, not inside the options delegate below: that delegate does
+// not run until DbContextOptions<T> is first resolved, so a missing connection string failed
+// startup only because the migration block further down happens to resolve the context (#205).
+var walletConnectionString = ConfigurationGuard.RequireConnectionString(builder.Configuration, "WalletDb");
 
-builder.Host.UseSerilog();
-
-// SQL Server connection.
 builder.Services.AddDbContext<WalletDbContext>(options =>
-    options.UseSqlServer(ConfigurationGuard.RequireConnectionString(builder.Configuration, "WalletDb"),
+    options.UseSqlServer(walletConnectionString,
         b => b.MigrationsAssembly("Wallet.Api")));
 
 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Serilog;

--- a/tests/TallaEgg.AllServices.Tests/BotHandlerRegistrationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BotHandlerRegistrationTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/TallaEgg.AllServices.Tests/BotHandlerRegistrationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BotHandlerRegistrationTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -39,7 +39,16 @@ public class BotHandlerRegistrationTests
     {
         var services = new ServiceCollection();
 
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+        // The real ports, because the clients now require a usable address rather than falling
+        // back to one (issue #205). Nothing here makes a request — the addresses are only parsed.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OrderApiUrl"] = "http://localhost:5140/api",
+                ["UsersApiUrl"] = "http://localhost:5136/api",
+                ["WalletApiUrl"] = "http://localhost:60933/api",
+            })
+            .Build());
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddLogging();
         services.AddHttpClient();

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using TallaEgg.Core;
 
 namespace TallaEgg.AllServices.Tests;

--- a/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ConfigurationGuardTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using TallaEgg.Core;
 
 namespace TallaEgg.AllServices.Tests;
@@ -165,5 +165,59 @@ public class ConfigurationGuardTests
             () => ConfigurationGuard.RequireUri(configuration, "WalletApiUrl"));
 
         Assert.Contains("localhost:60933", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The overload for a value that reached the caller by some other route — the bot and the
+    /// simulator bind their section to <c>TelegramBotOptions</c> and hand the string to a
+    /// constructor, which never sees an <see cref="IConfiguration"/> (issue #205).
+    /// </summary>
+    [Fact]
+    public void RequireAbsoluteHttpUri_WhenTheValueIsUsable_ReturnsTheParsedUri()
+    {
+        var uri = ConfigurationGuard.RequireAbsoluteHttpUri("http://localhost:60933/api", "WalletApiUrl");
+
+        Assert.Equal(new Uri("http://localhost:60933/api"), uri);
+    }
+
+    /// <summary>
+    /// An absent key arrives at that constructor as null. It has to be rejected there, or the
+    /// bot starts with a wallet client pointed at a compiled-in address.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RequireAbsoluteHttpUri_WhenTheValueIsMissingOrBlank_Throws(string? value)
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireAbsoluteHttpUri(value, "WalletApiUrl"));
+    }
+
+    /// <summary>Same rejection as the configuration overload — one implementation, one behaviour.</summary>
+    [Theory]
+    [InlineData("60933")]
+    [InlineData("localhost:60933")]
+    [InlineData("REPLACE_WITH_WALLET_URL")]
+    public void RequireAbsoluteHttpUri_WhenTheValueIsNotAnAbsoluteHttpUrl_Throws(string value)
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireAbsoluteHttpUri(value, "WalletApiUrl"));
+    }
+
+    /// <summary>
+    /// Both routes to the same guard have to produce the same words. An operator reading a log
+    /// line cannot be expected to know whether the value arrived through IConfiguration or
+    /// through a bound options object.
+    /// </summary>
+    [Fact]
+    public void RequireAbsoluteHttpUri_AndRequireUri_ReportAMissingValueIdentically()
+    {
+        var throughConfiguration = Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireUri(Configuration(), "WalletApiUrl"));
+        var throughTheString = Assert.Throws<InvalidOperationException>(
+            () => ConfigurationGuard.RequireAbsoluteHttpUri(null, "WalletApiUrl"));
+
+        Assert.Equal(throughConfiguration.Message, throughTheString.Message);
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/ServiceAddressConfigurationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ServiceAddressConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;

--- a/tests/TallaEgg.AllServices.Tests/ServiceAddressConfigurationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ServiceAddressConfigurationTests.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Service addresses come from the calling service's own configuration section, and a missing
+/// one stops the host rather than defaulting (issue #205).
+///
+/// <para>
+/// Five clients used to end their address read with <c>?? "http://localhost:…"</c>. None of the
+/// fallbacks was ever taken, because configuration happened to supply every value — which is why
+/// they survived. Two pointed at ports this system does not serve: 5001 at nothing at all, and
+/// 5135 at <c>TallaEgg.Api</c>, a host that starts, binds and maps no routes. Taking either
+/// branch meant a service talking to something that answers nothing, with nothing in the logs.
+/// </para>
+/// </summary>
+public class ServiceAddressConfigurationTests
+{
+    private static IConfiguration Configuration(params (string Key, string? Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(s => s.Key, s => s.Value))
+            .Build();
+
+    private static UsersApiClient NewUsersClient(IConfiguration configuration) =>
+        new(new HttpClient(), configuration, NullLogger<UsersApiClient>.Instance);
+
+    /// <summary>
+    /// The defect behind section 2 of #205, and the one the removed scan hid.
+    ///
+    /// <para>
+    /// <c>Orders.Api</c> defined no <c>UsersApiUrl</c>, so the client fell past its direct lookup
+    /// into a scan of every key in the merged configuration for anything ending in
+    /// <c>UsersApiUrl</c> — and the whole shared file is loaded, so other services' sections were
+    /// visible as full-path keys. Two of them matched, with incompatible shapes: one bare root,
+    /// one carrying an <c>/api</c> suffix. Which one <c>Orders.Api</c> received depended on
+    /// configuration enumeration order. It worked; it was not chosen.
+    /// </para>
+    ///
+    /// <para>
+    /// A key belonging to another service must now be no key at all.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void UsersApiClient_WhenOnlyAnotherServicesSectionDefinesTheKey_Throws()
+    {
+        var configuration = Configuration(
+            ("Services:TallaEgg.Api:UsersApiUrl", "http://localhost:5136"),
+            ("Services:TallaEgg.TelegramBot.Infrastructure:UsersApiUrl", "http://localhost:5136/api"));
+
+        Assert.Throws<InvalidOperationException>(() => NewUsersClient(configuration));
+    }
+
+    /// <summary>The flattened key from the host's own section is what the client reads.</summary>
+    [Fact]
+    public void UsersApiClient_WhenItsOwnKeyIsPresent_IsConstructed()
+    {
+        var client = NewUsersClient(Configuration(("UsersApiUrl", "http://localhost:5136/api")));
+
+        Assert.NotNull(client);
+    }
+
+    /// <summary>The fallback was <c>http://localhost:5001/api</c>, a port nothing here serves.</summary>
+    [Fact]
+    public void UsersApiClient_WhenTheKeyIsAbsent_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => NewUsersClient(Configuration()));
+    }
+
+    /// <summary>
+    /// The fallback was <c>http://localhost:5135/api</c> — <c>TallaEgg.Api</c>, which maps zero
+    /// endpoints. Orders are on 5140.
+    /// </summary>
+    [Fact]
+    public void OrderApiClient_WhenTheKeyIsAbsent_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => new OrderApiClient(
+            new HttpClient(), Configuration(), NullLogger<OrderApiClient>.Instance));
+    }
+
+    [Fact]
+    public void OrderApiClient_WhenItsOwnKeyIsPresent_IsConstructed()
+    {
+        var client = new OrderApiClient(
+            new HttpClient(),
+            Configuration(("OrderApiUrl", "http://localhost:5140/api")),
+            NullLogger<OrderApiClient>.Instance);
+
+        Assert.NotNull(client);
+    }
+
+    /// <summary>
+    /// The constructor <c>Orders.Api</c> resolves. Its fallback was the live address in that
+    /// service — the registration at <c>Program.cs:118</c> was shadowed, so the configure
+    /// delegate's address never applied and this read was the only one that counted.
+    /// </summary>
+    [Fact]
+    public void WalletApiClient_WhenTheKeyIsAbsent_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => new WalletApiClient(
+            new HttpClient(), Configuration(), NullLogger<WalletApiClient>.Instance));
+    }
+
+    /// <summary>The configured address is what the client dials, parsed once at construction.</summary>
+    [Fact]
+    public void WalletApiClient_WhenTheKeyIsPresent_UsesItAsTheBaseAddress()
+    {
+        var httpClient = new HttpClient();
+
+        _ = new WalletApiClient(
+            httpClient,
+            Configuration(("WalletApiUrl", "http://localhost:60933/api")),
+            NullLogger<WalletApiClient>.Instance);
+
+        Assert.Equal(new Uri("http://localhost:60933/api"), httpClient.BaseAddress);
+    }
+
+    /// <summary>
+    /// The other constructor, the one the bot and the simulator use. They pass a value bound
+    /// into <c>TelegramBotOptions</c>, so an absent key arrives here as null.
+    /// </summary>
+    [Fact]
+    public void WalletApiClient_WhenTheAddressPassedInIsNull_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => new WalletApiClient(apiUrl: null));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/StartupGuardPlacementTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/StartupGuardPlacementTests.cs
@@ -1,0 +1,99 @@
+﻿namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Where the startup guards sit in each <c>Program.cs</c>, which is behaviour even though it
+/// looks like formatting (issue #205).
+///
+/// <para>
+/// <c>ConfigurationGuard</c> exists so a missing key stops a service before it can serve a
+/// request. That only holds if the guard actually runs during startup. Every service called
+/// <c>RequireConnectionString</c> from inside the <c>AddDbContext</c> options delegate, which
+/// does not run until <c>DbContextOptions&lt;T&gt;</c> is first resolved — so the guard fired at
+/// startup only because the migration block a few lines later happened to resolve the context.
+/// <c>Orders.Api</c> had the same shape inside an <c>AddHttpClient</c> configure delegate, where
+/// nothing resolved it at all. Reorder or remove those incidental resolutions and a missing key
+/// silently becomes a first-request failure.
+/// </para>
+///
+/// <para>
+/// Nothing else in this solution pins that. There is no host-level startup harness to hang the
+/// assertion on, so moving a guarded read back inside a delegate would leave every other test
+/// green. These two rules read the source instead, which is blunt but is the difference between
+/// a property that is checked and one that is merely true today.
+/// </para>
+/// </summary>
+public class StartupGuardPlacementTests
+{
+    public static TheoryData<string> ServiceEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+        "src/Affiliate/Affiliate.Api/Program.cs",
+        "src/TallaEgg/TallaEgg.Api/Program.cs",
+    ];
+
+    private const string GuardCall = "ConfigurationGuard.Require";
+
+    private static string[] ReadLines(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+    }
+
+    private static bool IsGuardCall(string line) =>
+        line.Contains(GuardCall, StringComparison.Ordinal)
+        && !line.TrimStart().StartsWith("//", StringComparison.Ordinal);
+
+    /// <summary>
+    /// These files are top-level statements, so a guard that runs during startup is written at
+    /// column zero. Indentation means it sits inside a lambda — a configure delegate — and runs
+    /// whenever the container gets around to it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void EveryConfigurationGuardCall_RunsAtStartupRatherThanInsideAConfigureDelegate(string relativePath)
+    {
+        var indented = ReadLines(relativePath)
+            .Select((line, index) => (Line: line, Number: index + 1))
+            .Where(entry => IsGuardCall(entry.Line))
+            .Where(entry => char.IsWhiteSpace(entry.Line[0]))
+            .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
+            .ToList();
+
+        Assert.Empty(indented);
+    }
+
+    /// <summary>Each service still reads at least one value through the guard.</summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void EveryService_ReadsAtLeastOneValueThroughTheGuard(string relativePath)
+    {
+        Assert.Contains(ReadLines(relativePath), IsGuardCall);
+    }
+
+    /// <summary>
+    /// A guard's message names the key and the file to edit, so it is written to be acted on by
+    /// an operator with no debugger attached — and under <c>sc.exe</c> that operator has no
+    /// console to read it in. Serilog has to be installed before the first guard can throw, or
+    /// the one line that says what is wrong reaches nothing.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void Serilog_IsInstalledBeforeTheFirstGuardCanThrow(string relativePath)
+    {
+        var lines = ReadLines(relativePath);
+
+        var serilog = Array.FindIndex(lines, line =>
+            line.Contains("builder.Host.UseSerilog()", StringComparison.Ordinal));
+        var firstGuard = Array.FindIndex(lines, IsGuardCall);
+
+        Assert.InRange(serilog, 0, firstGuard - 1);
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/StartupGuardPlacementTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/StartupGuardPlacementTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TallaEgg.AllServices.Tests;
+namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
 /// Where the startup guards sit in each <c>Program.cs</c>, which is behaviour even though it
@@ -55,6 +55,13 @@ public class StartupGuardPlacementTests
     /// These files are top-level statements, so a guard that runs during startup is written at
     /// column zero. Indentation means it sits inside a lambda — a configure delegate — and runs
     /// whenever the container gets around to it.
+    ///
+    /// <para>
+    /// The rule is deliberately blunt: it cannot tell a lambda body from an ordinary nested
+    /// block, so a guard legitimately placed inside, say, an <c>if (IsProduction())</c> block
+    /// would trip it too. When that day comes, either hoist the read above the block or relax
+    /// this rule on purpose — do not quietly indent around it.
+    /// </para>
     /// </summary>
     [Theory]
     [MemberData(nameof(ServiceEntryPoints))]
@@ -83,17 +90,25 @@ public class StartupGuardPlacementTests
     /// an operator with no debugger attached — and under <c>sc.exe</c> that operator has no
     /// console to read it in. Serilog has to be installed before the first guard can throw, or
     /// the one line that says what is wrong reaches nothing.
+    ///
+    /// <para>
+    /// It is the <c>Log.Logger</c> assignment that is anchored on, not <c>UseSerilog()</c>.
+    /// <see cref="StartupLogging.ReportUnhandledExceptionsToLog"/> writes through Serilog's
+    /// static logger; <c>UseSerilog()</c> only redirects <c>ILogger&lt;T&gt;</c> resolved from
+    /// the host, which does not exist yet when a guard throws. Anchoring on the wrong one would
+    /// leave this test green while a startup failure went to <c>SilentLogger</c>.
+    /// </para>
     /// </summary>
     [Theory]
     [MemberData(nameof(ServiceEntryPoints))]
-    public void Serilog_IsInstalledBeforeTheFirstGuardCanThrow(string relativePath)
+    public void TheStaticSerilogLogger_IsAssignedBeforeTheFirstGuardCanThrow(string relativePath)
     {
         var lines = ReadLines(relativePath);
 
-        var serilog = Array.FindIndex(lines, line =>
-            line.Contains("builder.Host.UseSerilog()", StringComparison.Ordinal));
+        var loggerAssigned = Array.FindIndex(lines, line =>
+            line.Contains("Log.Logger = new LoggerConfiguration()", StringComparison.Ordinal));
         var firstGuard = Array.FindIndex(lines, IsGuardCall);
 
-        Assert.InRange(serilog, 0, firstGuard - 1);
+        Assert.InRange(loggerAssigned, 0, firstGuard - 1);
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/WalletApiClientFailureMessageTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/WalletApiClientFailureMessageTests.cs
@@ -40,8 +40,13 @@ public class WalletApiClientFailureMessageTests
     }
 
     private static WalletApiClient ClientAnswering(HttpStatusCode status, string body) =>
-        new(new HttpClient(new CannedHandler(status, body)) { BaseAddress = new Uri("http://wallet.test/") },
-            new ConfigurationBuilder().Build(),
+        new(new HttpClient(new CannedHandler(status, body)),
+            // The constructor sets the base address from this key and now requires it to be
+            // there (issue #205). The canned handler answers whatever is asked, so the host is
+            // only ever a label.
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["WalletApiUrl"] = "http://wallet.test/api" })
+                .Build(),
             NullLogger<WalletApiClient>.Instance);
 
     private static WalletRequest AnyRequest() => new()


### PR DESCRIPTION
## Description

Five clients ended their service-address read with `?? "http://localhost:…"`, and `Orders.Api`
found its Users address by scanning every key in the merged configuration for one ending in
`UsersApiUrl`. Neither branch was ever taken wrongly, because configuration happened to supply
every value — which is exactly why they survived. All of it now goes through
`ConfigurationGuard`, so a missing key stops the host, as `AGENT.md` requires.

## Issue/Task Reference

Closes #205

## Type of Change

- [x] Refactor (code organization, no behavior change *when configuration is complete*)

Behaviour changes only on a host where a key is absent — which is the point.

## The open question in the issue, settled first

> `Orders.Api` registers `IWalletApiClient` twice […] which registration wins (and therefore
> whether the delegate at :118 runs at all) was not established.

**The `AddScoped` at `:129` wins, and the `AddHttpClient` configure delegate never ran.** Proved
by replicating the two registrations and resolving through a scope, not by reasoning:

```
lastDescriptorLifetime=Scoped;  resolved=WalletApiClient;  delegateRan=False
baseAddress=http://from-config.invalid/api      <- the value of configuration["WalletApiUrl"],
                                                   not the marker set inside the delegate
```

Three consequences:

1. **Last registration wins** for `GetRequiredService<IWalletApiClient>()`, and `:129` came after
   `:118`.
2. **It did not fail to resolve** — `WalletApiClient`'s constructor needs an `HttpClient`, and in
   .NET 9 `AddHttpClient()` itself registers a bare transient one (probed separately:
   `bareHttpClient=registered`). That is the *unnamed default* client, so the delegate registered
   under the name `IWalletApiClient` never applied to it.
3. **Line 120 was dead twice over.** Even had the delegate run, `WalletApiClient.cs:54` overwrites
   `BaseAddress` from `configuration["WalletApiUrl"]` immediately afterwards.

So the live wallet address in `Orders.Api` came from `WalletApiClient.cs:51`, not from
`Program.cs:120`. Both are guarded now, and the duplicate registration is removed — asked about
before doing it, per the issue's scope note, and confirmed.

## Section 2, confirmed and narrower than the issue assumed

Replicating `Orders.Api`'s configuration build over the example file:

```
resolved='http://localhost:5136/api'
enumerationOrder=[ Services:TallaEgg.TelegramBot.Infrastructure:UsersApiUrl=http://localhost:5136/api
                 | Services:TallaEgg.Api:UsersApiUrl=http://localhost:5136 ]
```

It landed on the *bot's* key. The other candidate is the bare root, and `UsersApiClient`
concatenates (`{_baseUrl}/users/list`) against routes mapped at `/api/users/list` — so had the
enumeration gone the other way, **every `Orders.Api` to `Users.Api` call would have 404'd**. Not a
cosmetic difference between two shapes: one works and one does not.

Demonstrated against the running stack, both directions — see Testing below.

## Changes Made

**The guards** (`src/TallaEgg/TallaEgg.Core/ConfigurationGuard.cs`)
- Extracted `ReadNonBlank`, the argument guards and blank check both public guards duplicated.
  Deliberately left alone in #204 under scope discipline; there is more than one caller now.
- Added `RequireAbsoluteHttpUri(string?, key)` for a value that reached the caller some other way.
  `RequireUri` is now `ReadNonBlank` + this, so the bot's options-bound path and the services'
  `IConfiguration` path produce the *same words* — pinned by a test.

**The five fallback literals**

| Location | Was | Now |
| --- | --- | --- |
| `Orders.Api/Program.cs:120` | `?? "http://localhost:60933"` | `RequireUri` at startup; the configure delegate is gone, since the client sets its own `BaseAddress` |
| `UsersApiClient.cs:26` | `?? "http://localhost:5001/api"` | `RequireUri` on its own key |
| `WalletApiClient.cs:43` (string ctor) | `?? "http://localhost:60933/api"` | `RequireAbsoluteHttpUri` |
| `WalletApiClient.cs:51` (config ctor) | `?? "http://localhost:60933/api"` | `RequireUri` |
| `OrderApiClient.cs:26` | `?? "http://localhost:5135/api"` | `RequireUri` |

**The scan** — `ResolveUsersApiBaseUrl` is deleted. `Services:Orders.Api:UsersApiUrl` added to the
example file. `Services:TallaEgg.Api:UsersApiUrl` removed from it: with the scan gone it has no
consumer at all — `TallaEgg.Api` never constructs a `UsersApiClient` and maps no endpoints — and
leaving a consumer-less key is what made this confusing in the first place.

**Lazy evaluation (section 3)** — every `ConfigurationGuard` call is out of the `AddDbContext` and
`AddHttpClient` delegates in all five services. `UsersApiClient` in `Orders.Api` is scoped, so its
constructor would not run until the first request either; `Orders.Api` therefore reads that key at
startup as well.

**Logging (section 4)** — Serilog moves to the top of each `Program.cs`, ahead of everything that
can throw, and `StartupLogging.ReportUnhandledExceptionsToLog()` reports a terminating exception
through it. The bot gets the same handler.

## Section 4 turned out to be fully solvable

The issue expected a remainder:

> Not fully solvable in place: the "shared config file not found" case throws before there is any
> configuration to build a logger from.

It is not built from configuration — `WriteTo.Console()` and `WriteTo.File("logs/…")` are fixed in
code — so it can be installed before the file is located. Run from a directory where the walk-up
finds no config:

```
[13:37:58 FTL] The service is terminating on an unhandled exception.
System.IO.FileNotFoundException: Shared configuration 'appsettings.global.json' not found relative to '…\nocfg'.
```

```
…\nocfg\logs\wallet-api-20260903.log      <- written
```

**What does remain**: the sink path is relative to the working directory, and `sc.exe` sets none —
so on an installed service the file lands beside `C:\Windows\System32`, not the service directory.
That is the working-directory half of the same problem, already tracked on #105. This PR makes the
message reach *a* file; #105 is what makes it reach the expected one.

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 772, Skipped: 0, Total: 772
```

741 before; 31 new. Ten existing tests failed on the first run because they built clients from
empty configuration — the guards doing their job. They now supply the real ports.

### The positional part *is* pinned, contrary to the issue's expectation

> Nothing pins the positional part of this. Move a guarded read back inside a configure delegate
> and every test still passes.

`StartupGuardPlacementTests` reads the five `Program.cs` files and asserts (a) every
`ConfigurationGuard.Require*` call sits at column zero — these are top-level statements, so
indentation means it is inside a lambda — (b) each service still reads at least one value through
the guard, and (c) the `Log.Logger` assignment precedes the first guard call — the static logger, not
`UseSerilog()`, is what a guard throwing before the host exists can reach.

Blunt, and it is source inspection rather than behaviour. But it is the difference between a
property that is checked and one that merely happens to hold. Verified by breaking it on purpose —
guard moved back inside `Wallet.Api`'s `AddDbContext` delegate:

```
Failed StartupGuardPlacementTests.EveryConfigurationGuardCall_RunsAtStartupRatherThanInsideAConfigureDelegate
       (relativePath: "src/Wallet/Wallet.Api/Program.cs")
   Assert.Empty() Failure: Collection was not empty
```

`ServiceAddressConfigurationTests` pins the client side, including the one that matters most: a
`UsersApiUrl` defined only in *another service's* section must now be no key at all.

### (a) With complete configuration, nothing changes

All five services and the bot come up. The bot logs all four addresses from its own section and
proceeds to its network diagnostics — no guard fires:

```
[13:48:31 INF] Order API URL: http://localhost:5140/api
[13:48:31 INF] Users API URL: http://localhost:5136/api
[13:48:31 INF] Affiliate API URL: http://localhost:60812/api
[13:48:31 INF] Wallet API URL: http://localhost:60933/api
```

End to end:

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:33.2. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Those 50 settlements are also the proof that removing the duplicate registration is safe:
settlement resolves `IWalletApiClient` from the outbox processor's scope, which now goes through
the typed-client registration that was previously shadowed.

### (b) The guard fires, at startup

No config had to be edited for this: `Services:Orders.Api:UsersApiUrl` did not exist yet, so
running `Orders.Api` before the key was added gave, before any port was bound:

```
[13:37:21 FTL] The service is terminating on an unhandled exception.
System.InvalidOperationException: Configuration value 'UsersApiUrl' is missing. Add it under
this service's own section, Services:{ApplicationName}, in appsettings.global.json. The service
will not start without it.
   at Program.<Main>$(String[] args) in src/Order/Orders.Api/Program.cs:line 135
```

and the same in `src/Order/Orders.Api/logs/orders-api-20260903.log` — the `[FTL]` line is
Serilog's, which is section 4 working. The key was then added and the service starts normally.

### (c) `Orders.Api` reads Users from its own key, and the two shapes are not interchangeable

`POST /api/orders` reaches `OrderService.cs:117`, `_usersApiClient.GetUserByIdAsync`. Same request,
same user, two configurations:

| `Services:Orders.Api:UsersApiUrl` | Orders.Api log |
| --- | --- |
| `http://localhost:5136/api` (its own key) | `[INF] Validating balance for user …` — no warning; the lookup succeeded |
| `http://localhost:5136` (overridden to the root shape) | `[WRN] Users API returned 404 while fetching user by id …` |

The override reaching the client proves it reads *that* key. The 404 proves the old scan was a coin
flip between working and 404'ing every `Orders.Api` to `Users.Api` call, decided by section-name
enumeration order. Probe orders were placed on simulated users only (negative `TelegramId`) and
cancelled afterwards.

### Doc-link check (#207)

```
scripts/check-doc-paths.sh
check-doc-paths: 382 tracked text file(s) checked, every reference resolves.
```

## Security Checklist

- [x] No hardcoded credentials
- [x] No TLS bypass in production code
- [x] No secrets in the diff — `config/appsettings.global.json` is untouched and uncommitted; only
      the example file changed, and no value from the live file appears in this PR
- [x] Code compiles without warnings

## Reported, deliberately not fixed

**`APIKeyConstant.RequireTallaEggApiKey()` has the same lazy shape**, in all four API services
(`Users.Api:105`, `Wallet.Api:102`, `Orders.Api:109`, `Affiliate.Api:91`): it is called inside the
`AddScheme` options delegate, which does not run until authentication first executes — so in
Production a missing `TALLAEGG_API_KEY` surfaces at the first request, not at startup. Left alone
because it is not one of the six the issue names, it reads an environment variable rather than the
shared file, and hoisting it moves a Production-only auth read earlier, which is a behaviour change
in the auth path. **Worth an issue of its own.**

**`UsersApiClient` and `OrderApiClient` discard the `HttpClient` they are given** and construct
their own in the constructor body, so the injected one — and the handler pooling behind it — is
wasted. Pre-existing, unrelated to configuration, untouched here.

## Breaking Changes?

- [x] No breaking changes to any API contract.

Two things a reader should not have to discover for themselves:

- **Configuration is stricter**, which is the intent. See Deployment Notes.
- **`IWalletApiClient` in `Orders.Api` goes from Scoped to Transient.** Removing the shadowing
  `AddScoped` leaves the typed-client registration, which `AddHttpClient<TClient, TImplementation>`
  registers as transient. Within one request, `OrderService`, `OrderCollateralReconciler` and
  `QuoteFillService` previously shared one instance and now each get their own. Harmless today —
  `WalletApiClient` holds no per-request state — but any future per-request field would no longer
  be shared across the three.

## Deployment Notes

**Newly required keys.** A host missing one of these will now fail to start, by design, with a
message naming the key:

| Key | Note |
| --- | --- |
| `Services:Orders.Api:UsersApiUrl` | **New key** — must be added before deploying. Value: `http://localhost:5136/api`, with the `/api` suffix |
| `Services:Orders.Api:WalletApiUrl` | Already in the example file, but until now a host could omit it and the client would default |
| `Services:TallaEgg.TelegramBot.Infrastructure:` `OrderApiUrl` / `UsersApiUrl` / `WalletApiUrl` | Effectively required already — `TelegramBotHostedService.ValidateConfiguration` refused a blank one |
| `Services:Users.Api:WalletApiUrl` | Required since #204; unchanged |

No migrations. `config/appsettings.global.example.json` carries all of them.

**Rollback**: revert the commit. The added configuration key is harmless if left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
