### PR TITLE
[Hotfix][Critical] Resolve config and log paths from the binary, not the working directory — issues #212, #211

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ CI runs `dotnet test TallaEgg.sln` rather than naming this project by path, so a
 
 ## Logging
 
-Each service writes to the console and to rolling files under its own `logs/` directory — for example `src/Order/Orders.Api/logs/orders-api-<date>.log`.
+Each service writes to the console and to a rolling file in a `logs/` directory **beside its own binary**, not in the directory it was launched from.
+
+Under `dotnet run` that is the build output — `src/Order/Orders.Api/bin/Debug/net9.0/logs/orders-api-<date>.log`. On a deployed machine it is the publish folder — `C:\TallaEgg\publish\Orders.Api\logs\orders-api-<date>.log`. See [`docs/operations/WINDOWS_DEPLOYMENT.md`](docs/operations/WINDOWS_DEPLOYMENT.md) for the deployment case, which was writing into `C:\Windows\System32\logs\` until [#211](https://github.com/MohKardan/TallaEgg/issues/211).
 
 ## Deployment
 

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/NetworkTroubleshooting.md
@@ -51,18 +51,20 @@ Through `ILogger`, so both the console and Serilog's rolling file. That matters 
 installed with `sc.exe create` (#70) and a native Windows service has no console — while these
 were `Console.WriteLine` they went nowhere at all under the SCM.
 
-**Know which file, though.** The sink path in `Program.cs` is *relative*, and Serilog resolves it
-against the process's **working directory**, not the folder the binary sits in:
+**Know which file, though.** The sink path is absolute, built from `AppContext.BaseDirectory`, so
+the log always lands in a `logs\` folder beside the binary — never wherever the process happened
+to be started from:
 
 | How it was started | Where `telegrambot-<date>.log` lands |
 |---|---|
-| `dotnet run --project …` | the project folder's `logs\` |
-| The published exe, launched from a shell | `logs\` under whatever that shell's directory was |
-| A service from `sc.exe create` | `C:\Windows\System32\logs\` — `sc.exe` sets no working directory |
+| `dotnet run --project …` | `bin\Debug\net9.0\logs\` under the project — beside the DLL, not at the project root |
+| The published exe, launched from a shell | `logs\` beside the exe, whatever the shell's directory was |
+| A service from `sc.exe create` | `logs\` beside the exe — `<InstallRoot>\publish\Bot\logs\` |
 
-So on a server, look under the working directory of the service, not next to the exe.
-`docs/operations/WINDOWS_DEPLOYMENT.md` describes the log as `logs\telegrambot-.log` relative to
-the publish folder, which holds only when something set the working directory there.
+Until #211 the path was *relative*, and Serilog resolved it against the process's working
+directory. `sc.exe create` sets none, so the SCM's `C:\Windows\System32` is where all four
+services' logs were found on the first real deployment. That is the row that changed; the other
+two moved only as far as the binary's own folder.
 
 Everything else in this project still printing with `Console.WriteLine` — the startup diagnostics
 in particular — remains invisible under the service regardless.

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -185,6 +185,17 @@ public class Program
     /// Under <c>dotnet run</c> the content root is the project folder, the same directory the
     /// working directory pointed at, so the development path is unchanged.
     /// </para>
+    ///
+    /// <para>
+    /// The Serilog sink next to this uses <see cref="AppContext.BaseDirectory"/> rather than the
+    /// content root, and the two differ in exactly one case: a *published* exe launched by hand
+    /// from some other directory, where the content root is still that shell's directory and this
+    /// walk can miss a config the sink would have found. Anchoring here on
+    /// <c>AppContext.BaseDirectory</c> too would cover that case, and is deliberately not done —
+    /// it would make the bot the one host of six resolving configuration differently, which is the
+    /// asymmetry issue #212 was about. If this is ever worth changing, change all six together.
+    /// The sink cannot use the content root regardless: it is configured before the host exists.
+    /// </para>
     /// </remarks>
     private static string ResolveSharedConfigPath(IHostEnvironment environment, string fileName)
     {

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -33,7 +33,7 @@ public class Program
         // exception left no trace once the console it printed to was gone (issue #99).
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()
-            .WriteTo.File("logs/telegrambot-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+            .WriteTo.File(TallaEgg.Core.StartupLogging.LogFilePath("telegrambot-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
             .CreateLogger();
 
         // Configuration guards throw before the host exists, and the bot runs as a Windows
@@ -53,7 +53,7 @@ public class Program
             .UseSerilog()
             .ConfigureAppConfiguration((context, configBuilder) =>
             {
-                var sharedConfigPath = ResolveSharedConfigPath(SharedConfigFileName);
+                var sharedConfigPath = ResolveSharedConfigPath(context.HostingEnvironment, SharedConfigFileName);
                 configBuilder.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
 
                 var tempConfiguration = configBuilder.Build();
@@ -168,9 +168,27 @@ public class Program
 
             });
 
-    private static string ResolveSharedConfigPath(string fileName)
+    /// <summary>
+    /// Walks up from the content root looking for <c>config/<paramref name="fileName"/></c>.
+    /// </summary>
+    /// <remarks>
+    /// The anchor is the content root, not the working directory, which is what the five API
+    /// services have always used. The bot was the only host of the six reading
+    /// <c>Directory.GetCurrentDirectory()</c>, and that asymmetry was drift rather than a
+    /// decision: <c>UseWindowsService()</c> sets the content root to
+    /// <c>AppContext.BaseDirectory</c> but leaves the working directory alone, and
+    /// <c>sc.exe create</c> has no option to set one — so the SCM started the bot in
+    /// <c>C:\Windows\System32</c>, where the walk up never reaches the deployment's
+    /// <c>config\</c> folder. The bot could not start as a service at all (issue #212).
+    ///
+    /// <para>
+    /// Under <c>dotnet run</c> the content root is the project folder, the same directory the
+    /// working directory pointed at, so the development path is unchanged.
+    /// </para>
+    /// </remarks>
+    private static string ResolveSharedConfigPath(IHostEnvironment environment, string fileName)
     {
-        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        var current = new DirectoryInfo(environment.ContentRootPath);
         try
         {
             while (current is not null)
@@ -184,7 +202,7 @@ public class Program
                 current = current.Parent;
             }
 
-            var errorMsg = $"Shared configuration '{fileName}' not found relative to '{Directory.GetCurrentDirectory()}'.";
+            var errorMsg = $"Shared configuration '{fileName}' not found relative to '{environment.ContentRootPath}'.";
             Log.Error(errorMsg);
             throw new FileNotFoundException(errorMsg, fileName);
         }

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -73,11 +73,25 @@ in `install-services.ps1` rather than assuming SCM ordering alone is sufficient.
 
 ## Logs
 
-Each service writes its own `logs\<service>-.log` (bot: `logs\telegrambot-.log`) via Serilog,
-rolling daily, independent of anything the SCM does. Retention is capped at 30 files
-(`retainedFileCountLimit: 30` — issue #70's log-rotation item); before that fix these grew
-without bound. `Get-Content -Wait` on the relevant file is the fastest way to watch a service
-live; nothing here writes to the Windows Event Log.
+Each service writes its own log via Serilog into a `logs\` folder **beside its own binary**,
+rolling daily, independent of anything the SCM does:
+
+```
+C:\TallaEgg\publish\Wallet.Api\logs\wallet-api-<date>.log
+C:\TallaEgg\publish\Users.Api\logs\users-api-<date>.log
+C:\TallaEgg\publish\Orders.Api\logs\orders-api-<date>.log
+C:\TallaEgg\publish\Bot\logs\telegrambot-<date>.log
+```
+
+Retention is capped at 30 files (`retainedFileCountLimit: 30` — issue #70's log-rotation item);
+before that fix these grew without bound. `Get-Content -Wait` on the relevant file is the fastest
+way to watch a service live; nothing here writes to the Windows Event Log.
+
+Until #211 the sink path was relative, and Serilog resolves a relative path against the process
+working directory. `sc.exe create` has no option to set one, so the SCM started every service in
+`C:\Windows\System32` and all four logs were written there. **On a machine deployed before that
+fix, that is where the older files still are** — the fix changes where new ones go, it does not
+move what is already written.
 
 ## Removing the services
 

--- a/scripts/windows-services/publish-all.ps1
+++ b/scripts/windows-services/publish-all.ps1
@@ -10,10 +10,21 @@
     server after a `git pull`).
 
 .NOTES
-    Requires config\appsettings.global.json to exist in this repo checkout at publish time —
-    Directory.Build.props copies it into each output folder automatically when present. Without
-    it, ResolveSharedConfigPath() falls back to walking up from <InstallRoot>\config\, which
-    install-services.ps1 checks for separately before creating any service.
+    Does NOT require config\appsettings.global.json in this repo checkout. Directory.Build.props
+    copies it into each output folder when present, but that copy lands at the output root and
+    ResolveSharedConfigPath() only ever looks inside a config\ subfolder of each ancestor — so it
+    is never the file that gets loaded. The single mechanism that works is the walk up from the
+    binary's own folder:
+
+        C:\TallaEgg\publish\<Service>\   <- where the walk starts (AppContext.BaseDirectory,
+                                            which UseWindowsService() sets ContentRootPath to)
+        C:\TallaEgg\publish\             <- checked for config\, absent
+        C:\TallaEgg\                     <- config\appsettings.global.json found here
+
+    So <InstallRoot>\config\appsettings.global.json is what every service reads, and
+    install-services.ps1 refuses to create a service until it exists. Before #212 the bot walked
+    up from the working directory instead, which the SCM sets to C:\Windows\System32 — it could
+    not start as a service at all.
 #>
 [CmdletBinding()]
 param(

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -21,7 +21,7 @@ var builder = WebApplication.CreateBuilder(args);
 // matches its siblings, where that is the whole point.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/affiliate-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .WriteTo.File(StartupLogging.LogFilePath("affiliate-api-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -37,7 +37,7 @@ builder.Host.UseWindowsService();
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Warning)
     .WriteTo.Console()
-    .WriteTo.File("logs/orders-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .WriteTo.File(StartupLogging.LogFilePath("orders-api-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/TallaEgg/TallaEgg.Api/Program.cs
+++ b/src/TallaEgg/TallaEgg.Api/Program.cs
@@ -25,7 +25,7 @@ var builder = WebApplication.CreateBuilder(args);
 // matches its siblings, where that is the whole point.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/tallaegg-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .WriteTo.File(StartupLogging.LogFilePath("tallaegg-api-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
+++ b/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
@@ -8,6 +8,27 @@ namespace TallaEgg.Core;
 public static class StartupLogging
 {
     /// <summary>
+    /// Builds an absolute path to <paramref name="fileName"/> in a <c>logs</c> directory beside
+    /// the running binary, for a Serilog file sink.
+    /// </summary>
+    /// <remarks>
+    /// Serilog resolves a relative sink path against the process working directory. The four
+    /// deployed hosts are installed with <c>sc.exe create</c> (issue #70), which has no option to
+    /// set one, so the SCM hands every service <c>C:\Windows\System32</c> — and that is exactly
+    /// where all four logs were found on the first real deployment (issue #211).
+    ///
+    /// <para>
+    /// <c>UseWindowsService()</c> does not help here: it points <c>ContentRootPath</c> at
+    /// <see cref="AppContext.BaseDirectory"/> but leaves <c>Environment.CurrentDirectory</c>
+    /// alone. The sink is also configured before the host exists, so there is no
+    /// <c>IHostEnvironment</c> to read yet. <see cref="AppContext.BaseDirectory"/> is the one
+    /// anchor available at that point that does not depend on how the process was launched.
+    /// </para>
+    /// </remarks>
+    public static string LogFilePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "logs", fileName);
+
+    /// <summary>
     /// Reports any exception that terminates the process through the configured Serilog sinks.
     /// </summary>
     /// <remarks>
@@ -32,8 +53,9 @@ public static class StartupLogging
     /// </para>
     ///
     /// <para>
-    /// The log path itself is still relative to the working directory, which <c>sc.exe</c> does
-    /// not set — tracked on issue #105.
+    /// The file it reaches is now the one the operator is told to look at: <see cref="LogFilePath"/>
+    /// anchors the sink beside the binary, so it no longer follows the working directory the SCM
+    /// picks (issue #211).
     /// </para>
     /// </remarks>
     public static void ReportUnhandledExceptionsToLog()

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -35,7 +35,7 @@ builder.Host.UseWindowsService();
 // service has (issue #205).
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/users-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .WriteTo.File(StartupLogging.LogFilePath("users-api-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -31,7 +31,7 @@ builder.Host.UseWindowsService();
 // service has (issue #205).
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
-    .WriteTo.File("logs/wallet-api-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+    .WriteTo.File(StartupLogging.LogFilePath("wallet-api-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
     .CreateLogger();
 
 builder.Host.UseSerilog();

--- a/tests/TallaEgg.AllServices.Tests/ServiceHostPathAnchorTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ServiceHostPathAnchorTests.cs
@@ -9,10 +9,10 @@ namespace TallaEgg.AllServices.Tests;
 /// <para>
 /// Both were relative to the process working directory, and <c>sc.exe create</c> has no option to
 /// set one, so the SCM handed every installed service <c>C:\Windows\System32</c>. The bot could
-/// not start at all, and all four services wrote their logs into a Windows system directory. The
-/// working directory is not something the deployment can influence; the content root and
-/// <c>AppContext.BaseDirectory</c> both point at the binary's own folder under
-/// <c>UseWindowsService()</c>, and are.
+/// not start at all, and all four services wrote their logs into a Windows system directory. A
+/// deployment cannot influence the working directory at all; it controls where the binary sits,
+/// which is what <see cref="AppContext.BaseDirectory"/> reports and what
+/// <c>UseWindowsService()</c> points the content root at.
 /// </para>
 ///
 /// <para>
@@ -38,6 +38,19 @@ public class ServiceHostPathAnchorTests
         "src/Order/Orders.Api/Program.cs",
         "src/Affiliate/Affiliate.Api/Program.cs",
         "src/TallaEgg/TallaEgg.Api/Program.cs",
+        "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs",
+    ];
+
+    /// <summary>
+    /// The four hosts <c>install-services.ps1</c> actually installs. <c>Affiliate.Api</c> and
+    /// <c>TallaEgg.Api</c> are not among them and do not call <c>UseWindowsService()</c> — see
+    /// #69: nothing calls <c>TallaEgg.Api</c>, and <c>Affiliate.Api</c> ships no migrations.
+    /// </summary>
+    public static TheoryData<string> DeployedHostEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
         "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs",
     ];
 
@@ -99,6 +112,30 @@ public class ServiceHostPathAnchorTests
 
         Assert.Empty(workingDirectoryReads);
         Assert.Contains(lines, line => IsCode(line) && line.Contains("ContentRootPath", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Reading the content root is only half of it. <c>ContentRootPath</c> defaults to the working
+    /// directory; the one thing that moves it to the binary's folder is <c>UseWindowsService()</c>,
+    /// which does so only inside a real SCM session. Delete that call from a deployed host and
+    /// issue #212 comes straight back — the content root falls back to <c>C:\Windows\System32</c>,
+    /// the walk up finds no <c>config\</c>, and the host throws inside <c>HostBuilder.Build()</c>
+    /// — while every other assertion in this class stays green, because they only check what the
+    /// walk starts from.
+    ///
+    /// <para>
+    /// Blunt, like the rest of this file: it checks the call is written, not that it took effect.
+    /// Nothing here can check the latter, since it is a no-op outside a service session, which is
+    /// the whole difficulty with this class of bug.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DeployedHostEntryPoints))]
+    public void EveryDeployedHost_CallsUseWindowsServiceSoTheContentRootFollowsTheBinary(string relativePath)
+    {
+        Assert.Contains(
+            ReadLines(relativePath),
+            line => IsCode(line) && line.Contains("UseWindowsService()", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/tests/TallaEgg.AllServices.Tests/ServiceHostPathAnchorTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ServiceHostPathAnchorTests.cs
@@ -1,0 +1,118 @@
+using TallaEgg.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// What each host resolves its two startup paths against — the shared configuration file and the
+/// Serilog file sink (issues #212 and #211).
+///
+/// <para>
+/// Both were relative to the process working directory, and <c>sc.exe create</c> has no option to
+/// set one, so the SCM handed every installed service <c>C:\Windows\System32</c>. The bot could
+/// not start at all, and all four services wrote their logs into a Windows system directory. The
+/// working directory is not something the deployment can influence; the content root and
+/// <c>AppContext.BaseDirectory</c> both point at the binary's own folder under
+/// <c>UseWindowsService()</c>, and are.
+/// </para>
+///
+/// <para>
+/// These read the source, like <see cref="StartupGuardPlacementTests"/>, and for the same reason:
+/// the property is about how a host is wired before it exists, so there is nothing to resolve
+/// from a container and no host-level harness to hang an assertion on. A run under
+/// <c>dotnet test</c> gets the working directory it wants either way, which is exactly why this
+/// class of bug survives a green suite.
+/// </para>
+/// </summary>
+public class ServiceHostPathAnchorTests
+{
+    /// <summary>
+    /// The six programs that build a host. <c>TallaEgg.TelegramBot.Simulator</c> is deliberately
+    /// not among them: it is a CLI tool run by hand from a developer's clone and is never
+    /// installed as a service, so resolving its configuration from the working directory is
+    /// correct there rather than drift.
+    /// </summary>
+    public static TheoryData<string> HostEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+        "src/Affiliate/Affiliate.Api/Program.cs",
+        "src/TallaEgg/TallaEgg.Api/Program.cs",
+        "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs",
+    ];
+
+    private static string[] ReadLines(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+    }
+
+    private static bool IsCode(string line) =>
+        !line.TrimStart().StartsWith("//", StringComparison.Ordinal)
+        && !line.TrimStart().StartsWith("///", StringComparison.Ordinal);
+
+    /// <summary>
+    /// A sink path given as a bare literal is relative, and Serilog resolves it against the
+    /// working directory. Going through <see cref="StartupLogging.LogFilePath"/> is what makes it
+    /// absolute, so the check is that no host passes <c>WriteTo.File</c> a string of its own.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(HostEntryPoints))]
+    public void EveryLogSinkPath_IsAnchoredOnTheBinaryFolderRatherThanTheWorkingDirectory(string relativePath)
+    {
+        var lines = ReadLines(relativePath);
+
+        var relativeSinks = lines
+            .Select((line, index) => (Line: line, Number: index + 1))
+            .Where(entry => IsCode(entry.Line))
+            .Where(entry => entry.Line.Contains("WriteTo.File(\"", StringComparison.Ordinal))
+            .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
+            .ToList();
+
+        Assert.Empty(relativeSinks);
+        Assert.Contains(lines, line => IsCode(line) && line.Contains("StartupLogging.LogFilePath(", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The shared configuration is found by walking up looking for a <c>config</c> folder. What
+    /// the walk starts from is the whole issue: the content root follows the binary under
+    /// <c>UseWindowsService()</c>, the working directory does not.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(HostEntryPoints))]
+    public void NoHost_ResolvesSharedConfigurationFromTheWorkingDirectory(string relativePath)
+    {
+        var lines = ReadLines(relativePath);
+
+        var workingDirectoryReads = lines
+            .Select((line, index) => (Line: line, Number: index + 1))
+            .Where(entry => IsCode(entry.Line))
+            .Where(entry => entry.Line.Contains("GetCurrentDirectory()", StringComparison.Ordinal))
+            .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
+            .ToList();
+
+        Assert.Empty(workingDirectoryReads);
+        Assert.Contains(lines, line => IsCode(line) && line.Contains("ContentRootPath", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The one part of this that is behaviour rather than source shape.
+    /// </summary>
+    [Fact]
+    public void LogFilePath_ReturnsAnAbsolutePathBesideTheBinary()
+    {
+        var path = StartupLogging.LogFilePath("example-.log");
+
+        Assert.True(Path.IsPathRooted(path));
+        Assert.Equal(
+            Path.Combine(AppContext.BaseDirectory, "logs"),
+            Path.GetDirectoryName(path));
+        Assert.Equal("example-.log", Path.GetFileName(path));
+    }
+}


### PR DESCRIPTION
## Description

`sc.exe create` has no option to set a working directory, so the SCM starts every service in
`C:\Windows\System32`. Two separate things were anchored there: the bot's shared-configuration
lookup (**#212** — it could not start at all) and all six Serilog file sinks (**#211** — every log
landed in a Windows system directory). Both now resolve from the binary's own folder, which is
what the five API services were already doing for configuration.

## Issue/Task Reference

Closes #212
Closes #211

Both were first described on #105 (comment of 2026-09-02), which predicted the chain correctly and
flagged link 4 — that an SCM-started service really gets `C:\Windows\System32` — as the one step
not yet observed. The deployment of 2026-09-03 settled it.

## Type of Change

- [x] Hotfix (urgent bug fix)

## Changes Made

**#212 — the broken symmetry**

- `TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs` — `ResolveSharedConfigPath` takes
  an `IHostEnvironment` and walks up from `ContentRootPath`, matching `Users.Api`, `Wallet.Api`,
  `Orders.Api`, `TallaEgg.Api` and `Affiliate.Api`. The failure message names the content root for
  the same reason. It was the only host of the six reading `Directory.GetCurrentDirectory()`.

**#211 — six relative sinks**

- `StartupLogging.LogFilePath(fileName)` added to `TallaEgg.Core` — `Path.Combine(AppContext.BaseDirectory, "logs", fileName)`.
- All six `WriteTo.File(...)` calls go through it: `Affiliate.Api:24`, `Orders.Api:40`,
  `TallaEgg.Api:28`, `Users.Api:38`, `Wallet.Api:34`, `TelegramBot.Infrastructure:36`.

One helper rather than six copies of `Path.Combine(AppContext.BaseDirectory, …)`, because the
*why* is a paragraph and it is the same paragraph six times. `StartupLogging` is where it belongs:
that class already exists to make startup failures reachable under the SCM, and all six projects
already reference it. Its own remark that "the log path itself is still relative to the working
directory — tracked on issue #105" is now false and has been replaced.

**Tests** — `tests/TallaEgg.AllServices.Tests/ServiceHostPathAnchorTests.cs` (17 assertions).

**Docs** — `WINDOWS_DEPLOYMENT.md`, `README.md`, `NetworkTroubleshooting.md`, `publish-all.ps1`.

---

## The Simulator is deliberately unchanged

`TelegramBot/TallaEgg.TelegramBot.Simulator/Program.cs:141` still uses
`Directory.GetCurrentDirectory()`. Left alone, for three reasons:

1. It is a CLI tool run by hand from a clone and is never installed as a service, so the working
   directory is the *correct* anchor — running it from the repo is how it is used.
2. It has no Serilog file sink at all, so #211 does not reach it.
3. It is not a host. It builds a `ServiceCollection` directly, so there is no `IHostEnvironment`
   and no `UseWindowsService()` to move a content root; "match the APIs" has nothing to match.

`ServiceHostPathAnchorTests` lists the six hosts explicitly and says in its doc comment why the
Simulator is not among them, so the exclusion is recorded rather than merely absent.

---

## The layout question, confirmed rather than assumed

The issue asks whether `AppContext.BaseDirectory` actually reaches `config/` in the deployment
layout. It does — the walk checks a `config\` subfolder at each ancestor:

```
C:\TallaEgg\publish\Bot\        <- start (AppContext.BaseDirectory)
C:\TallaEgg\publish\Bot\config\   absent
C:\TallaEgg\publish\config\       absent
C:\TallaEgg\config\               <- appsettings.global.json found here
```

Reproduced under that exact shape below (test 3).

**`publish-all.ps1`'s header was wrong, and in a way the issue understated.** It claimed
`Directory.Build.props` copies the config into each output folder, with the walk-up as a
*fallback*. Both halves are wrong. The copy does happen, but it lands at the output **root**:

```
<publish>\Bot\appsettings.global.json              <- the Directory.Build.props copy
<publish>\Bot\Properties\appsettings.global.json
<publish>\Bot\config\                              <- does not exist
```

`ResolveSharedConfigPath` only ever looks inside a `config\` subfolder, so that copy is never the
file that gets loaded — under any launch method, before or after this PR. The walk up to
`<InstallRoot>\config\` is not a fallback, it is the only mechanism. The header now says so, and
says the script does *not* require a local config to run.

`install-services.ps1`'s closing line — "Logs are under each publish folder's `logs\` directory" —
needed no change: it was wrong when written and this PR makes it true.

`NetworkTroubleshooting.md:59-61` **is** changed, despite already being correct, because it
describes precisely the behaviour this PR alters: its table said the sink path is *relative* and
gave `C:\Windows\System32\logs\` for the `sc.exe` row. That is now the row that no longer holds.

---

# Proof

`dotnet run` sets the working directory to the project folder — the one condition under which this
bug does **not** occur — so a successful `dotnet run` proves nothing. All four steps below were run
against a `dotnet publish` output in a replicated `<InstallRoot>\publish\<Service>\` +
`<InstallRoot>\config\` layout.

**One caveat, stated up front.** This machine has no administrator rights
(`IsInRole(Administrator)` → `False`), so no real service could be created locally. Under
`UseWindowsService()` the content root only moves when `WindowsServiceHelpers.IsWindowsService()`
is true, which it is not for a process started from a shell — so the first post-fix run below
still failed, correctly, with the content root sitting on the working directory.

`UseWindowsService()` moves it by calling `UseContentRoot(AppContext.BaseDirectory)`, which sets
the host-configuration key `contentRoot` — the same key `--contentRoot <path>` sets on the command
line. Tests 2–4 use that flag to put the content root where the SCM would, which is a substitution
of mechanism, not of behaviour. **The remaining link — that the SCM really hands a service
`C:\Windows\System32` — is already observed on the server**: the three APIs run this exact code
path, and on 2026-09-03 they found `C:\TallaEgg\config\` while their logs were written to
`C:\Windows\System32\logs\`. That is the same content-root-vs-working-directory split, confirmed on
real hardware.

### (الف)(ب)(ج) Before the change — the server's failure, reproduced

Published bot, run with a working directory that has no `config\` ancestor:

```
[14:33:38 ERR] Shared configuration 'appsettings.global.json' not found relative to '…\scratchpad\nocwd'.
System.IO.FileNotFoundException: Shared configuration 'appsettings.global.json' not found relative to '…\scratchpad\nocwd'.
   at …Program.ResolveSharedConfigPath(String fileName) in …\Program.cs:line 189
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeAppConfiguration()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
```

Verbatim the server's message, and it dies inside `HostBuilder.Build()`, before any hosted service
starts. The same run reproduced #211 at the same time:

```
…\scratchpad\nocwd\logs\telegrambot-20260903.log      <- the working directory, not the publish folder
```

### 2. After the change — the anchor demonstrably moved

The discriminating test, because it is the one a weaker check would pass by accident. Working
directory = the repo clone, which **has** a valid `config\appsettings.global.json` directly above
it. Content root = a publish folder with no `config\` anywhere above it. Identical command line,
identical layout; the only difference between the two runs is the one changed line.

| Binary | Result |
| --- | --- |
| Pre-fix (`Directory.GetCurrentDirectory()`) | **Started.** Still running after 40s — reached Telegram |
| Post-fix (`ContentRootPath`) | **Refused.** `not found relative to '…\Isolated\Bot'` |

Pre-fix, same command:

```
[14:40:08 INF] 🔧 Using proxy: http://127.0.0.1:10808/
[14:40:08 INF] Order API URL: http://localhost:5140/api
…
✅ https://api.telegram.org - Status: OK
```

Post-fix, same command:

```
[14:39:40 ERR] Shared configuration 'appsettings.global.json' not found relative to '…\scratchpad\Isolated\Bot'.
```

The post-fix binary ignored a perfectly good config sitting one level above its working directory.
That is the behaviour change, isolated.

### (د) 3. After the change — the deployment layout starts, and the log lands right

Content root = `<Deploy>\publish\Bot\`, config at `<Deploy>\config\`, working directory an **empty**
folder with no `config\` ancestor:

```
>>> STILL RUNNING after 40s: the host came up <<<
[14:41:10 INF] 🔧 Using proxy: http://127.0.0.1:10808/
[14:41:10 INF] Order API URL: http://localhost:5140/api
[14:41:10 INF] Users API URL: http://localhost:5136/api
[14:41:10 INF] Affiliate API URL: http://localhost:60812/api
[14:41:10 INF] Wallet API URL: http://localhost:60933/api
[14:41:10 INF] Require Referral Code: False
[14:41:10 INF] Default Referral Code: admin
🌐 Testing network connectivity...
✅ https://api.telegram.org - Status: OK
```

It walked `publish\Bot` → `publish` → `<Deploy>` and found the config there. From the rolling file:

```
[INF] PendingQuoteNotifierService started (poll every 30s).
[INF] Application started. Press Ctrl+C to shut down.
[INF] Hosting environment: Production
[INF] Content root path: …\scratchpad\Deploy\publish\Bot
```

And the log location:

```
…\Deploy\publish\Bot\logs\telegrambot-20260903.log     <- beside the binary

nocwd\logs\  ->  does not exist
nocwd        ->  (empty)
```

The working directory was left completely untouched.

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 789, Skipped: 0, Total: 789
```

772 before; 17 new.

### The new tests were verified by breaking them on purpose

Source-inspection tests, like `StartupGuardPlacementTests` and for the same reason: this is about
how a host is wired *before* it exists, there is no container to resolve from, and a `dotnet test`
run gets the working directory it wants either way — which is exactly why this bug survived a green
suite for as long as it did. So they were confirmed to actually fail. One sink reverted to a
literal and the bot's resolver reverted to `GetCurrentDirectory()`:

```
Failed ServiceHostPathAnchorTests.EveryLogSinkPath_IsAnchoredOnTheBinaryFolderRatherThanTheWorkingDirectory
       (relativePath: "src/Wallet/Wallet.Api/Program.cs")
   Assert.Empty() Failure: Collection was not empty

Failed ServiceHostPathAnchorTests.NoHost_ResolvesSharedConfigurationFromTheWorkingDirectory
       (relativePath: "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Pr"···)
   Assert.Empty() Failure: Collection was not empty

Failed!  - Failed: 2, Passed: 11, Skipped: 0, Total: 13
```

Both were then restored.

## Review response (`/code-review high`, 3 findings — 2 fixed, 1 recorded)

**1. Nothing pinned `UseWindowsService()` — the call the whole fix depends on.** Correct and the
most useful finding here. The suite pinned what the config walk *starts from*, but
`ContentRootPath` defaults to the working directory; `UseWindowsService()` is the only thing that
moves it to the binary. Delete that one line and #212 returns in full — content root falls back to
`C:\Windows\System32`, `FileNotFoundException` inside `HostBuilder.Build()`, restart loop — with all
thirteen assertions still green. Fixed in `3fa6d44`, over the four hosts `install-services.ps1`
actually installs. Verified by commenting the call out of the bot:

```
Failed ServiceHostPathAnchorTests.EveryDeployedHost_CallsUseWindowsServiceSoTheContentRootFollowsTheBinary
       (relativePath: "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Pr"···)
   Assert.Contains() Failure: Filter not matched in collection
Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4
```

**3. The class doc ended mid-sentence and claimed all six hosts call `UseWindowsService()`.** Both
true. `Affiliate.Api` and `TallaEgg.Api` do not call it and are not deployed (#69) — which is
exactly why the new assertion runs over four entry points rather than six. Rewritten in `3fa6d44`.

**2. The two halves use different anchors.** Also true: the sink is absolute on
`AppContext.BaseDirectory`, the config walk starts at `ContentRootPath`, and they diverge in one
case — a *published* exe launched by hand from another directory, where the walk follows that
shell's directory and can miss a config the sink would have found. **Deliberately not changed**,
and now written down in the resolver's own remark. Anchoring the config walk on
`AppContext.BaseDirectory` would fix that case and would make the bot the one host of six resolving
configuration differently from the other five — which is the asymmetry #212 exists to remove, and
what both #212's fix shape and #105 asked for instead. If it is ever worth changing, all six change
together. The sink cannot use the content root either way: it is configured before the host exists.

### End-to-end — the development path is not broken

```
driver.ps1 start
Build succeeded. 0 Warning(s) 0 Error(s)
All services up after 2s.

driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
Restored auto-quote for BTC/IRT to IsEnabled=True.
Restored auto-quote for MAUA/IRT to IsEnabled=True.
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
=== Done in 00:00:28.9. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
```

Date/time run: 2026-09-03.

### Doc-link check (#207)

```
scripts/check-doc-paths.sh
check-doc-paths: 385 tracked text file(s) checked, every reference resolves.
```

## Breaking Changes?

- [x] No breaking changes to any API contract. No migrations, no new configuration keys.

**One visible change for developers, and it is not a break.** Logs move from the project root to
the build output — the binary is what they follow now:

```
src/Order/Orders.Api/logs/orders-api-<date>.log                    <- before
src/Order/Orders.Api/bin/Release/net9.0/logs/orders-api-<date>.log <- after
```

Confirmed during the smoke run above: all three files appeared under `bin\Release\net9.0\logs\`,
and no `logs\` folder was created at any project root. `README.md` and
`NetworkTroubleshooting.md`'s per-launch-method table both state the new location. The driver's own
`run-logs/` redirect is unaffected.

## Security Checklist

- [x] No hardcoded credentials
- [x] No secrets in the diff — `config/appsettings.global.json` is untouched and uncommitted, and
      no value from it appears in this PR or its logs
- [x] No server name, address, or personal path in any file or in this description
- [x] Code compiles without warnings
- [x] Writing into `C:\Windows\System32` — possible only because the services run as `LocalSystem`
      — stops

## Deployment Notes

**Pre-deployment**: none. No migrations, no new keys, no configuration change.

**Deploy**: re-run `publish-all.ps1`, then `install-services.ps1`. The services do not need to be
recreated for the fix itself — the change is entirely in the binaries — but re-running is safe and
is what the runbook says.

**The old logs are not moved.** `C:\Windows\System32\logs\*.log` from the 2026-09-03 deployment
stay where they are; this changes where new lines go. Delete them once they are not needed.

**Rollback**: revert the commit and re-publish. The bot returns to being unable to start as a
service, so rollback is only meaningful together with a rollback of the deployment itself.

---

# What only you can run — final verification on the VM

I have no access to the server, and the last link (that the SCM really hands a service
`C:\Windows\System32`) can only be closed there. Four commands, in an elevated PowerShell.

### 1. Publish and reinstall

```powershell
cd <repo>
git pull
.\scripts\windows-services\publish-all.ps1 -InstallRoot C:\TallaEgg
.\scripts\windows-services\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString)
```

Expected: four "Creating service …" / "Starting …" lines, no throw. The script refuses if
`C:\TallaEgg\config\appsettings.global.json` is missing — that file is still required and still
must not come from the repo.

### 2. The bot stays running — this is #212

```powershell
Get-Service TallaEgg* | Select-Object Name, Status, StartType
```

Expected — all four `Running`, where `TallaEggBot` was `Stopped` before:

```
Name                Status  StartType
----                ------  ---------
TallaEggBot         Running Automatic
TallaEggOrdersApi   Running Automatic
TallaEggUsersApi    Running Automatic
TallaEggWalletApi   Running Automatic
```

Give it ~30 seconds and re-run it once. The failure mode being fixed is a restart loop
(`sc.exe failure … restart/10000/…`), so a bot that is `Running` on the first check and `Stopped`
on the second has not been fixed.

### 3. Logs are beside the binaries — this is #211

```powershell
Get-ChildItem C:\TallaEgg\publish\*\logs\*.log | Select-Object FullName, LastWriteTime
```

Expected — four files, all with timestamps from just now:

```
C:\TallaEgg\publish\Bot\logs\telegrambot-<date>.log
C:\TallaEgg\publish\Orders.Api\logs\orders-api-<date>.log
C:\TallaEgg\publish\Users.Api\logs\users-api-<date>.log
C:\TallaEgg\publish\Wallet.Api\logs\wallet-api-<date>.log
```

And the negative half, which matters just as much:

```powershell
Get-ChildItem C:\Windows\System32\logs\*.log | Select-Object Name, LastWriteTime
```

Expected: the four files from the 2026-09-03 deployment are still listed, with their **old**
timestamps and none newer. If a timestamp there is current, a service is still writing to
`System32` and #211 is not fixed on that machine.

### 4. The bot actually reached Telegram

```powershell
Get-Content C:\TallaEgg\publish\Bot\logs\telegrambot-*.log -Tail 30
```

Expected — no `FileNotFoundException`, and the startup block that proves it read
`C:\TallaEgg\config\appsettings.global.json`:

```
[INF] Order API URL: http://localhost:5140/api
[INF] Users API URL: http://localhost:5136/api
[INF] Affiliate API URL: http://localhost:60812/api
[INF] Wallet API URL: http://localhost:60933/api
[INF] Require Referral Code: …
[INF] Default Referral Code: …
[INF] Content root path: C:\TallaEgg\publish\Bot
[INF] Application started. Press Ctrl+C to shut down.
```

`Content root path: C:\TallaEgg\publish\Bot` is the line that closes link 4 on #105 — it is the SCM
reporting a content root that is *not* `C:\Windows\System32`.

Then the real check, which no log can make for you: **message the bot on Telegram and confirm it
answers.** That is what "the product is reachable" means, and it is the thing that has never been
true on this deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
