### PR TITLE
[Fix] Users.Api sends X-API-Key when creating default wallets — issue #209

### DIFF
--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -134,6 +134,14 @@ builder.Services.AddHttpClient("WalletAPI", client =>
 {
     client.BaseAddress = walletApiBaseAddress;
     client.Timeout = TimeSpan.FromSeconds(30);
+
+    // Wallet.Api requires X-API-Key in Production, so without this every registration on a
+    // deployed system got 401 and created no wallets. It stayed hidden because Development
+    // registers no authentication at all, and because a missing wallet is created lazily on
+    // first write — the first deposit or trade produced the rows registration had failed to
+    // (issue #209). The typed clients set the same header in their constructors; a named
+    // client has no constructor to set it in, so it goes here.
+    client.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
 });
 
 // CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -130,6 +130,19 @@ builder.Services.AddTallaEggErrorHandling();
 // this client and swallows what it throws (UserService.CreateDefaultWalletsAsync), so deferring
 // the failure means users registered with no wallets and nothing said about it.
 var walletApiBaseAddress = ConfigurationGuard.RequireUri(builder.Configuration, "WalletApiUrl");
+
+// Read here rather than inside the configure delegate below, for the reason the address is:
+// the delegate does not run until the first client is created, so a missing key would surface
+// one registration at a time inside the broad catch in UserService.CreateDefaultWalletsAsync
+// instead of stopping the service (issue #205). Production demands the real key — sending the
+// placeholder to a Wallet.Api that enforces the real one reproduces issue #209 exactly, with
+// the header present so the code reads as fixed. Outside Production the placeholder is right:
+// no service registers API-key authentication there, and requiring the variable would stop
+// every clone and CI job that has no reason to hold it.
+var walletApiKey = builder.Environment.IsProduction()
+    ? APIKeyConstant.RequireTallaEggApiKey()
+    : APIKeyConstant.TallaEggApiKey;
+
 builder.Services.AddHttpClient("WalletAPI", client =>
 {
     client.BaseAddress = walletApiBaseAddress;
@@ -141,8 +154,13 @@ builder.Services.AddHttpClient("WalletAPI", client =>
     // first write — the first deposit or trade produced the rows registration had failed to
     // (issue #209). The typed clients set the same header in their constructors; a named
     // client has no constructor to set it in, so it goes here.
-    client.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
-});
+    client.DefaultRequestHeaders.Add("X-API-Key", walletApiKey);
+})
+// The only key-bearing client in the solution built through IHttpClientFactory, whose logging
+// handlers write request headers at Trace and redact nothing by default. The other four are
+// raw HttpClients and never reach those handlers, so this is the one place the shared key
+// could be written to a log by lowering a level.
+.RedactLoggedHeaders(["X-API-Key"]);
 
 // CORS — issue #31: a whitelist read from configuration, not AllowAnyOrigin.
 builder.Services.AddTallaEggCors(builder.Configuration);

--- a/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs
@@ -277,6 +277,33 @@ public class DefaultWalletCreationFailureTests
     }
 
     /// <summary>
+    /// The credential, from the calling side. Wallet.Api requires <c>X-API-Key</c> in Production
+    /// and registers no authentication at all in Development, so a sender that omits it passes
+    /// every local run, every simulator run and every test in this project, and 401s on every
+    /// registration once deployed — where lazy wallet creation then hides the result behind the
+    /// first deposit or trade (issue #209). It was missing for the life of the deployment.
+    ///
+    /// <para>
+    /// Asserted against the source for the same reason as the test above: the registration lives
+    /// in Users.Api's top-level statements, and composing it for real needs the shared
+    /// configuration file and a database. The header is matched inside the <c>"WalletAPI"</c>
+    /// registration rather than anywhere in the file, so moving it to a different client does not
+    /// keep this green, and the value has to be an identifier — a string literal here would be a
+    /// key checked into a public repository (issue #33).
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void UsersApi_WalletApiNamedClient_SendsTheSharedApiKeyHeader()
+    {
+        var program = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(), "src", "User", "Users.Api", "Program.cs"));
+
+        Assert.Matches(
+            @"AddHttpClient\(\s*""WalletAPI""[\s\S]*?DefaultRequestHeaders\.Add\(\s*""X-API-Key"",\s*\w+\s*\)",
+            program);
+    }
+
+    /// <summary>
     /// Walks up from the test assembly to the directory holding <c>TallaEgg.sln</c>. The same
     /// anchor <c>ConfigurationPrecedenceTests</c> and <c>SolutionMembershipTests</c> use, and
     /// duplicated for the reason they duplicate it: sharing it would mean editing tests this


### PR DESCRIPTION
## Description

`Users.Api` creates a new user's default wallets by calling `Wallet.Api` through the `"WalletAPI"`
named client. That client sent no `X-API-Key`, and `Wallet.Api` requires one in Production, so
every registration on a deployed system was refused with 401 and the user got no wallet rows.
This adds the header every other inter-service client already sends.

## Issue/Task Reference

Closes #209

## Type of Change

- [x] Hotfix (urgent bug fix) — no
- [x] Bug fix, not urgent

Not urgent for the reason the evidence below makes precise: the deployed product looks healthy,
because lazy creation produces the missing rows as soon as anyone touches the user.

---

## Step 0 — what actually happened on the server

The issue was written from a static read of the code and said so. This PR confirms it three ways
before changing anything.

**(a) The client sends no key** — `src/User/Users.Api/Program.cs:133-137` on `main` set
`BaseAddress` and `Timeout` and nothing else.

**(b) `Wallet.Api` requires it in Production only** — `src/Wallet/Wallet.Api/Program.cs:97-115`
registers the `ApiKey` scheme and `FallbackPolicy = RequireAuthenticatedUser()` inside
`IsProduction()`; the `else` branch adds authorization *with no authentication in front of it*.
`src/Wallet/Wallet.Api/Program.cs:152-156` calls `UseAuthentication()` in Production only. That is
why no local run, simulator run or manual test has ever seen this.

**(c) The server log** — recorded by the product owner on the deployment in the #209 comment:
the `[ERR] ... was refused: HTTP 401` line from #208 fires on every registration, `Wallet.Api`
answers `401` with "Missing API Key", and the wallet rows appear later, when an operator grants
credit. So the 401 did happen and lazy creation masked it.

## Verification: Production, before and after

Development proves nothing here, so both runs used `ASPNETCORE_ENVIRONMENT=Production` and a
`TALLAEGG_API_KEY` on both services, registering one user through `POST /api/user/register` and
reading the wallet table **before any deposit**. Both excerpts below are from the code as merged —
the "after" run was repeated on the second commit.

One thing worth recording for whoever reproduces this next: the first attempt showed no 401 at
all and looked like the issue was wrong. `dotnet run` applies `Properties/launchSettings.json`,
which pins `ASPNETCORE_ENVIRONMENT=Development` over the ambient variable, so that run was
Development wearing a Production label. `--no-launch-profile` is what makes the condition real.

| | Before the fix | After the fix |
| --- | --- | --- |
| HTTP response to `POST api/wallet/create-default/{id}` | `401` | `200` |
| `users-api-*.log` | `[ERR] Default wallet creation for user "..." was refused: HTTP 401.` | no error line |
| Wallet rows, before any deposit | `ROW COUNT = 0` | `IRT`, `MAUA`, `CREDIT_MAUA` — `ROW COUNT = 3` |

Before:

```
[INF] Sending HTTP request POST http://localhost:60933/api/wallet/create-default/2454ad26-...
[INF] Received HTTP response headers after 154.5894ms - 401
[ERR] Default wallet creation for user "2454ad26-..." was refused: HTTP 401. Response: .
      Registration continues; this user's default wallets may be missing or incomplete.

=== wallet rows, BEFORE any deposit ===
ROW COUNT = 0
```

After:

```
[INF] Sending HTTP request POST http://localhost:60933/api/wallet/create-default/2a219922-...
[INF] Received HTTP response headers after 706.6875ms - 200

=== wallet rows, BEFORE any deposit ===
CREDIT_MAUA | balance=0.00000000
IRT         | balance=0.00000000
MAUA        | balance=0.00000000
ROW COUNT = 3
```

"Before any deposit" is the whole point: wallets are created lazily, so a successful trade — or
the mere existence of wallet rows afterwards — would not have distinguished a fixed registration
path from a broken one masked by the first write.

## Changes Made

- `src/User/Users.Api/Program.cs` — the `"WalletAPI"` named client now sets `X-API-Key`, resolves
  the key at startup (Production requires the real one; elsewhere the placeholder), and declares
  `RedactLoggedHeaders` so the key cannot reach a log
- `tests/TallaEgg.AllServices.Tests/DefaultWalletCreationFailureTests.cs` — one regression test
  pinning the header inside that registration

The second commit applies this PR's own self-review; the reasoning for each of the eight findings
is in the review comment below. Two things it corrected are worth having in the description
rather than only in a comment, because both were wrong here first:

### The key is resolved per environment, not unconditionally

The issue asked whether `RequireTallaEggApiKey()` belonged here. This description originally
argued no, on the grounds that requiring it would stop every clone and CI job. That objection is
real but it only applies outside Production:

```csharp
var walletApiKey = builder.Environment.IsProduction()
    ? APIKeyConstant.RequireTallaEggApiKey()
    : APIKeyConstant.TallaEggApiKey;
```

Without this, `APIKeyConstant.TallaEggApiKey` substitutes the public dev placeholder whenever
`TALLAEGG_API_KEY` is unset — so a Production host that never received the variable would send a
placeholder to a `Wallet.Api` enforcing the real key and reproduce #209 exactly, with the header
present so the code reads as fixed. Users.Api's own `RequireTallaEggApiKey()` at `:104` does not
prevent that: it sits in an `AddScheme` options delegate, which runs on first authenticated
request rather than at startup. Verified — Production with no key now refuses to start:

```
[FTL] The service is terminating on an unhandled exception.
System.InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set.
```

Development with no key set is unaffected; the smoke run recorded below had none in its
environment.

The read is hoisted next to `walletApiBaseAddress` rather than left inside the configure delegate,
for the reason the comment above it already gives about the address (#205): the delegate does not
run until the first client is created, so a guard placed there fails one registration at a time
inside a broad catch instead of stopping the service.

### There is a regression test, and the reasoning that said otherwise was wrong

This description originally claimed no test was practical without booting the host. That was
wrong. `WalletApi_MapsDefaultWalletCreation_AsPostNotGet`, in the same test file, already reads
`Program.cs` as source text and asserts against it, and `StartupGuardPlacementTests` does the same
across all five services for exactly this reason. The new test follows that pattern, matches the
header *inside* the `"WalletAPI"` registration, and requires an identifier rather than a string
literal so an inline key fails it too (#33). Confirmed it fails when the header line is removed —
without it, deleting that one line leaves all 790 tests green, which is how the line came to be
missing for the life of the deployment.

## Testing Completed

### Unit Tests

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 790, Skipped: 0, Total: 790
```

### End-to-end

Production, by hand — the before/after table above.

Development, unchanged, via `driver.ps1` — run with no `TALLAEGG_API_KEY` in the environment,
which is the clone/CI condition:

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:23.4. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
Filled trades by symbol:  BTC/IRT: 17 filled  MAUA/IRT: 17 filled  SEKE_BAHAR/IRT: 16 filled
```

Auto-quote flags restored for both symbols the driver touched. Date/time run: 2026-09-03.

- [x] Tested locally (Windows + SQL Server Express)
- [x] `scripts/check-doc-paths.sh` — 386 tracked text files checked, every reference resolves

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens — the key is read from
      `TALLAEGG_API_KEY` through `APIKeyConstant`, and no key value appears in this diff, the
      commits, this description or any log quoted here
- [x] The key cannot reach a log — `RedactLoggedHeaders(["X-API-Key"])`. This is the only
      key-bearing client in the solution built through `IHttpClientFactory`, whose logging
      handlers write request headers at Trace and redact nothing by default
- [x] No sensitive data in logs or error messages
- [x] `config/appsettings.global.json` untouched and untracked
- [x] Code compiles without warnings
- [x] Authentication/authorization checks in place — this restores one that was being skipped

## Breaking Changes?

- [x] No breaking changes

A request that was being rejected in Production starts being accepted. Development is unaffected:
`Wallet.Api` registers no authentication there, and an unread header changes nothing.

## Deployment Notes

No migration, no new configuration. **`TALLAEGG_API_KEY` must be present in `Users.Api`'s
environment**, and after this change Production `Users.Api` will not start without it — it fails
with a message naming the variable, in `logs/users-api-*.log`. `install-services.ps1:99` already
sets it for every installed service, so a deployment installed that way needs nothing new; one
where the variable was set by hand should be checked before restarting.

**Post-deployment verification**: register one user and confirm no
`Default wallet creation ... was refused` line in `logs/users-api-*.log`. Since #215 those logs
sit beside the binary in the publish folder, not `System32`. Do not read a successful trade as
proof — that was exactly the trap this issue was hiding behind.

**Rollback**: revert this commit and restart `Users.Api`. Behaviour returns to registrations
logging a 401 with wallets created lazily on first write; no data written under this change needs
undoing.

## Related Issues

- Follows #206 / #208 — that PR made this failure path log at `Error`, which is what let the
  owner confirm the 401 on the server rather than guessing
- Follows #190, which left `create-default` as the only route into wallet creation
- Related to #214 (clients that discard the injected `HttpClient`) — same file, deliberately
  untouched here
- #215 moved these logs out of `System32`, which is why the log evidence above was readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
