### PR TITLE
chore(versioning): single-source the product version, document the tag convention, prep the first release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,14 @@
 ﻿<Project>
 
   <PropertyGroup>
+    <!-- Single source of truth for the product version (issue #217). Every project inherits
+         AssemblyVersion, FileVersion and InformationalVersion from this — none of them should
+         set AssemblyVersion itself. Bump the third number for a bug fix, the second for a new
+         capability that does not break an existing contract, the first for one that does. -->
+    <VersionPrefix>1.1.0</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- The count reached 168 because no single commit ever added a hundred warnings; they
          arrived one file at a time. It is at zero now, and TreatWarningsAsErrors is what keeps it
          there: the next one fails a build instead of joining a list nobody reads.

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -899,18 +899,18 @@ namespace TallaEgg.TelegramBot.Infrastructure
     /// A summary of each version's notable changes, for the update message.
     /// The key must match IVersionService.GetCurrentVersion exactly, for example "1.1.0".
     /// A version with no entry here sends the update message without a changelog.
-    /// Add an entry here whenever AssemblyVersion is raised.
+    /// Add an entry here whenever VersionPrefix (Directory.Build.props) is raised.
     /// </summary>
     public static class ReleaseNotes
     {
         private static readonly Dictionary<string, string[]> Notes = new()
         {
-            // Example:
-            // ["1.1.0"] = new[]
-            // {
-            //     "ثبت خودکار معاملات و به‌روزرسانی موجودی",
-            //     "نمایش تاریخچه معاملات در منوی حسابداری",
-            // },
+            ["1.1.0"] = new[]
+            {
+                "امکان معامله سکه تمام بهار آزادی و بیت‌کوین، علاوه بر طلای آبشده",
+                "نمایش صحیح‌تر تاریخچه معاملات (نوع خرید/فروش و تاریخ)",
+                "پایداری بیشتر در ثبت و تسویه معاملات",
+            },
         };
 
         /// <summary>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/TallaEgg.TelegramBot.Infrastructure.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
-       a database or foundational change the first. -->
-	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/process/STANDARDS.md
+++ b/docs/process/STANDARDS.md
@@ -377,3 +377,44 @@ New developers should:
       Configuration: .NET 9 SDK, SQL Server Express, and a `config/appsettings.global.json`
       copied from `config/appsettings.global.example.json`
 - [ ] Attend code review session to see standards in practice
+
+---
+
+## 11. Versioning & Releases
+
+### Where the version lives
+The product version is one `<VersionPrefix>` in the root `Directory.Build.props`, inherited by
+every project. No individual `.csproj` sets `AssemblyVersion`, `FileVersion` or
+`InformationalVersion` — MSBuild derives all three from `VersionPrefix`, so a release is a
+one-line change in one file. Before #217, five projects each hardcoded
+`<AssemblyVersion>1.0.0</AssemblyVersion>` by hand, none of them was ever bumped, and the
+deployed release tags reached `v1.0.3` while every built assembly still reported `1.0.0`.
+
+### What the numbers mean
+`MAJOR.MINOR.PATCH`, standard semver:
+- **PATCH** — a bug fix; no behavior change a caller would notice.
+- **MINOR** — a new capability, or a behavior change that does not break an existing integration.
+- **MAJOR** — reserved for a change that breaks a contract something else depends on. This
+  platform has no external consumer yet — it is a bot and its own backend — so MAJOR has not
+  been used and should stay rare.
+
+### Tag convention
+Release tags are `vX.Y.Z` — an annotated tag matching `VersionPrefix`, created **on `main` after
+merge**, never on a feature branch. This matches `v1`, `v1.0.1` and `v1.0.2`. One release,
+`1.0.3` (2025-10-07), was tagged without the `v`; a second tag, `v1.0.3`, was then cut the same
+day on a later commit (after two more PRs merged) with the prefix restored, but the version
+number was never bumped to reflect that those PRs had landed. That was an inconsistency, not a
+second convention — the old tag is not renamed or deleted (history is not rewritten, see #105),
+but every tag from here on uses the `v` prefix and moves in step with `VersionPrefix`.
+
+### Cutting a release
+1. Bump `VersionPrefix` in `Directory.Build.props`, in the PR that earns the bump, under the same
+   rules as any other change (branch, review, CI green).
+2. After that PR merges to `main`, tag `main` at the merge commit:
+   `git tag -a vX.Y.Z -m "..."`, `git push origin vX.Y.Z`.
+3. Verify the built assemblies actually carry the tagged version before publishing anything —
+   build, then read the metadata of at least one built DLL (`AssemblyName.GetAssemblyName(...)`
+   or `FileVersionInfo.GetVersionInfo(...)`). Do not assume the bump worked.
+4. `gh release create vX.Y.Z --notes-file <file>`. There is no release pipeline (section 8), so
+   this is manual and deliberate — publishing a release is external, user-visible communication,
+   not a byproduct of tagging.

--- a/src/Affiliate/Affiliate.Api/Affiliate.Api.csproj
+++ b/src/Affiliate/Affiliate.Api/Affiliate.Api.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <!--رفع باگ افزایش عدد سوم
-	  افزودن ویژگی جدید افزایش عدد دوم
-	  تغییر دیتابیس یا تغییرات پایه ای افزایش عدد اول-->
-	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Order/Orders.Api/Orders.Api.csproj
+++ b/src/Order/Orders.Api/Orders.Api.csproj
@@ -6,9 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
-       a database or foundational change the first. -->
-	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/User/Users.Api/Users.Api.csproj
+++ b/src/User/Users.Api/Users.Api.csproj
@@ -6,9 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
-       a database or foundational change the first. -->
-	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wallet/Wallet.Api/Wallet.Api.csproj
+++ b/src/Wallet/Wallet.Api/Wallet.Api.csproj
@@ -6,9 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-	  <!-- Versioning: bug fix bumps the third number, a new feature the second,
-       a database or foundational change the first. -->
-	  <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
The product version was inconsistent in three ways: release tags said `1.0.x` while every built assembly still hardcoded `1.0.0`; two tags (`1.0.3` and `v1.0.3`) exist for two different commits from the same day; and nothing derives a version at build time, so no build output can be traced back to a tag. This became an operational question rather than a cosmetic one on 2026-09-03, when the code was deployed to a real server for the first time and there was no way to answer "which build is on the server?" from the running binaries. This PR fixes the mechanism and its documentation; the first release since `v1.0.3` is cut from `main` right after merge, per the tag-on-`main` rule in §11 (draft, not published).

## Linked Task / Finding
Closes #217

## Type
- [x] Refactor
- [x] Docs

## Changes
- **Single source of truth**: `<VersionPrefix>1.1.0</VersionPrefix>` added to `Directory.Build.props`; the five hand-set `<AssemblyVersion>1.0.0</AssemblyVersion>` entries (Users.Api, Wallet.Api, Orders.Api, Affiliate.Api, the bot) removed, along with their now-redundant versioning-scheme comments. MSBuild derives `AssemblyVersion`, `FileVersion` and `InformationalVersion` for every project from the one property.
- **Tag convention documented** in `docs/process/STANDARDS.md` §11: `vX.Y.Z`, annotated, cut on `main` after merge — never on a branch. Explains the `1.0.3` vs `v1.0.3` history in one paragraph (see below) without touching either tag.
- **`CHANGELOG.md` stays deleted.** See "On CHANGELOG.md" below for why, rather than assuming the #198 deletion should be reverted.
- **Release notes drafted** for the 160 commits since `v1.0.3`, grouped by topic (dealer/quote model, outbox & settlement, wallet concurrency, charge idempotency, price band, first-deployment/Windows-service-path fixes, warning cleanup & global error handling, three audit rounds) rather than a raw commit list.

Per §11 (and the branch/tag rules — no tagging on a branch), the actual `v1.1.0` tag and the **draft** GitHub release built from these notes are cut after this PR merges to `main`, at the merge commit — not here. Link added to this PR once that's done.

## What `1.0.3` vs `v1.0.3` actually was
`1.0.3` (no `v`) was tagged 2025-10-07 08:47 UTC on the merge of PR #15 ("fix cors bug in orders.api"). Two more PRs merged the same day (#16 wallet decimal precision, #17 an API-key constructor overload), and at 13:14 UTC a second tag, `v1.0.3`, was cut on that later commit — with the `v` prefix restored to match `v1`/`v1.0.1`/`v1.0.2` — but the version number was never bumped to reflect that two more PRs had landed. So these are not one version tagged twice; they're two different commits that share a version number because of that gap. Neither tag is renamed or deleted (history is not rewritten — #105); §11 records this so it isn't rediscovered as a mystery later.

## On `CHANGELOG.md`
It stays deleted. #198 removed it as abandoned (a year stale), unverifiable (its oldest entries predate this repo's first commit), and actively wrong (a fee structure this platform has never charged, mojibake from an encoding accident). Restoring it now — right after that PR argued, correctly, that a hand-maintained ledger drifts from the code it describes — would recreate the exact problem #198 fixed, with nothing to stop it from going stale again between releases. GitHub Releases, generated from `git log`/PR bodies at tag time the way this one was, don't have that failure mode: each one is tied to the tag it describes and never has to be maintained.

## Should the version be visible at runtime?
Yes, worth doing, but not built here — narrow scope. Filed as #218 with one finding that changes the cost calculus: the built DLL's `InformationalVersion` already carries `+<commit-hash>` (`1.1.0+8656393...`) with zero extra wiring — the .NET SDK adds it automatically inside a git checkout, no `SourceLink` package required. The remaining piece is small: log it at startup, and/or a `GET /version` on each API. #218 has the detail.

## Testing

### Build & static verification
```
dotnet build TallaEgg.sln --no-incremental
Build succeeded. 0 Warning(s) 0 Error(s)
```

### DLL metadata — read, not assumed
`AssemblyName.GetAssemblyName(...)` and `FileVersionInfo.GetVersionInfo(...)` against all five built assemblies:
```
Users.Api.dll                                AssemblyVersion 1.1.0.0  FileVersion 1.1.0.0  InformationalVersion 1.1.0+8656393...
Wallet.Api.dll                                AssemblyVersion 1.1.0.0  FileVersion 1.1.0.0  InformationalVersion 1.1.0+8656393...
Orders.Api.dll                                AssemblyVersion 1.1.0.0  FileVersion 1.1.0.0  InformationalVersion 1.1.0+8656393...
Affiliate.Api.dll                             AssemblyVersion 1.1.0.0  FileVersion 1.1.0.0  InformationalVersion 1.1.0+8656393...
TallaEgg.TelegramBot.Infrastructure.dll       AssemblyVersion 1.1.0.0  FileVersion 1.1.0.0  InformationalVersion 1.1.0+8656393...
```

### Unit tests
```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 790, Skipped: 0, Total: 790
```

### End-to-end (`run-tallaegg`-equivalent — see note)
`.claude/skills/run-tallaegg/driver.ps1` needs Windows PowerShell; this session ran on Linux, so the driver's own steps were run by hand instead of through it: built the solution, launched Users.Api/Wallet.Api/Orders.Api against a real SQL Server, confirmed all three came up (migrations applied, Swagger served, real HTTP responses), then ran the same interaction the driver's `smoke` command drives — `TelegramBot.Simulator` registering users, approving them, publishing quotes, and filling trades across all three symbols through the real handler and API code:
```
=== Done in 00:00:06. Registered 10 (9 approved), trades attempted 15, errors 0 ===
Filled trades by symbol: BTC/IRT: 5  MAUA/IRT: 5  SEKE_BAHAR/IRT: 5
```
Outbox drained afterward with 0 pending and 0 newly failed settlements. The version change is metadata-only — no runtime code path touches it — and this run confirms boot and behavior are both unaffected end to end, not just that the assemblies happen to load.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Follows naming conventions (STANDARDS.md)
- [ ] Tests added/updated in `tests/TallaEgg.AllServices.Tests` — not applicable, no testable behavior changed (version metadata only)
- [x] Docs updated (`docs/process/STANDARDS.md` §11)
- [ ] Peer reviewed

## Deployment Notes
No migration, no config change, no feature flag. Purely build-time metadata — safe to deploy the same way as any other change. The `v1.1.0` tag and release are cut after merge (see Changes) and the release stays a **draft** — it will not go live until published deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGAd5mTTHTsoJRTNNCQ5wD


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGAd5mTTHTsoJRTNNCQ5wD)_