### PR TITLE
[Feat] Report which build is running: startup log line and GET /version — issue #218

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs
@@ -40,6 +40,9 @@ public class Program
         // service with no console to print to — same as the five APIs (issue #205).
         TallaEgg.Core.StartupLogging.ReportUnhandledExceptionsToLog();
 
+        // Answers "which build is this?" from the log even when the service never finishes starting (issue #218).
+        TallaEgg.Core.StartupLogging.LogBuildVersion();
+
         using var host = CreateHostBuilder(args).Build();
         await host.RunAsync();
     }

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -57,6 +57,31 @@ neither belongs in a deployment. Decision recorded on
 `install-services.ps1` stops and recreates each service, so re-running it is the redeploy step —
 there's no separate update path to remember.
 
+## Which build is running (issue #218)
+
+Each service reports its own version and the commit it was built from, so a redeploy can be
+confirmed without a file-properties dialog over RDP:
+
+- **In the log**, as the first line each service writes at startup — the only answer available
+  for a service that crashes before it can serve anything:
+  ```
+  [08:21:31 INF] Starting Users.Api, version 1.1.0, built from commit ff95e00a327536efa53e2af247b661ba9be5f744.
+  ```
+- **Over HTTP**, from the three APIs. `GET /version` carries no exemption from the Production
+  authorization policy, so it needs the API key like every other endpoint:
+  ```powershell
+  Invoke-RestMethod http://localhost:<port>/version -Headers @{ 'X-API-Key' = $env:TALLAEGG_API_KEY }
+  # -> data.version 1.1.0, data.commitHash ff95e00a327536efa53e2af247b661ba9be5f744
+  ```
+  Ports are in the README's Ports and bind addresses section. The bot serves nothing, so its
+  log line is the whole of its answer.
+
+The hash names the commit checked out **on the machine that ran `publish-all.ps1`**, and says
+nothing about the server. `commitHash` is `null` when that build could not see a `.git`
+directory — publishing from a source archive rather than a checkout looks like this.
+Uncommitted changes on the build machine do not move it either: it is the last commit, not the
+working tree.
+
 ## Start order — what's covered and what isn't
 
 `Orders.Api` and `Users.Api` call `Wallet.Api` on startup paths, and all three run

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -43,6 +43,9 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 StartupLogging.ReportUnhandledExceptionsToLog();
 
+// Answers "which build is this?" from the log even when the service never finishes starting (issue #218).
+StartupLogging.LogBuildVersion();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -282,6 +285,14 @@ if (app.Environment.IsDevelopment())
         c.RoutePrefix = "api-docs";
     });
 }
+
+// Which build this service is running (issue #218) — the question a deployment leaves behind,
+// answered without RDP and a file-properties dialog. Deliberately not AllowAnonymous: the
+// Production fallback policy applies, so the caller needs the same X-API-Key as every other
+// endpoint. The commit hash names an exact line of a public repository, and the operator asking
+// the question already holds the key.
+app.MapGet("/version", () => Results.Ok(ApiResponse<BuildVersionDto>.Ok(BuildVersion.Current)))
+   .WithTags("Diagnostics");
 
 
 // Order management endpoints

--- a/src/TallaEgg/TallaEgg.Core/BuildVersion.cs
+++ b/src/TallaEgg/TallaEgg.Core/BuildVersion.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using TallaEgg.Core.DTOs;
+
+namespace TallaEgg.Core;
+
+/// <summary>
+/// Reads the version and commit hash out of a built assembly, so a running process can be asked
+/// which build it is (issue #218).
+/// </summary>
+/// <remarks>
+/// Nothing has to be generated or wired up for this to have an answer. Every project inherits one
+/// <c>VersionPrefix</c> from <c>Directory.Build.props</c> (issue #217), and the .NET SDK appends
+/// <c>+&lt;commit-hash&gt;</c> to <c>InformationalVersion</c> on its own whenever it can see a
+/// <c>.git</c> directory — no <c>SourceLink</c> package is involved. This class only reads what is
+/// already stamped into the assembly.
+/// </remarks>
+public static class BuildVersion
+{
+    /// <summary>
+    /// The build the current process is running.
+    /// </summary>
+    /// <remarks>
+    /// Read once: an assembly's attributes cannot change while it is loaded, and this is served
+    /// from a request path.
+    /// </remarks>
+    public static BuildVersionDto Current { get; } = Read(Assembly.GetEntryAssembly());
+
+    /// <summary>
+    /// Reads <paramref name="assembly"/>'s <see cref="AssemblyInformationalVersionAttribute"/> and
+    /// splits it into the version and the commit hash.
+    /// </summary>
+    /// <param name="assembly">
+    /// The assembly to read. <c>null</c> is accepted because
+    /// <see cref="Assembly.GetEntryAssembly"/> returns it when the process was not started from a
+    /// managed entry point; the fall-back reads this assembly instead, which reports the same
+    /// version because every project inherits it from the same place.
+    /// </param>
+    public static BuildVersionDto Read(Assembly? assembly)
+    {
+        assembly ??= typeof(BuildVersion).Assembly;
+
+        return Parse(
+            assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+            assembly.GetName().Version);
+    }
+
+    /// <summary>
+    /// Splits an informational version into its two halves.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Read"/>, and internal rather than private, so the split can be
+    /// tested against the strings a build actually produces. Fabricating an assembly per case
+    /// would test reflection rather than this.
+    /// </remarks>
+    /// <param name="informationalVersion">
+    /// The attribute's value — <c>1.1.0+ff95e00a327...</c> for a build made inside a git checkout,
+    /// <c>1.1.0</c> for one made outside it, and <c>null</c> when the attribute is absent.
+    /// </param>
+    /// <param name="assemblyVersion">
+    /// Fall-back for a missing attribute. Always present, and carries the same three numbers with
+    /// a fourth appended.
+    /// </param>
+    internal static BuildVersionDto Parse(string? informationalVersion, Version? assemblyVersion)
+    {
+        if (string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            return new BuildVersionDto(assemblyVersion?.ToString() ?? "unknown", null);
+        }
+
+        // The separator is SemVer's build-metadata '+', so everything after the first one is the
+        // hash. A version with no metadata has no '+' at all and keeps the whole string.
+        var separator = informationalVersion.IndexOf('+');
+        if (separator < 0)
+        {
+            return new BuildVersionDto(informationalVersion, null);
+        }
+
+        var hash = informationalVersion[(separator + 1)..];
+
+        return new BuildVersionDto(
+            informationalVersion[..separator],
+            string.IsNullOrWhiteSpace(hash) ? null : hash);
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/DTOs/BuildVersionDto.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/BuildVersionDto.cs
@@ -1,0 +1,17 @@
+namespace TallaEgg.Core.DTOs;
+
+/// <summary>
+/// Which build a running process is: the product version and the commit it was built from
+/// (issue #218).
+/// </summary>
+/// <param name="Version">
+/// The <c>VersionPrefix</c> the assembly was built with — <c>1.1.0</c> — from the single
+/// declaration in <c>Directory.Build.props</c> (issue #217).
+/// </param>
+/// <param name="CommitHash">
+/// The full commit hash the .NET SDK appended to <c>InformationalVersion</c>, or <c>null</c> when
+/// the assembly carries no hash. It is absent whenever the build could not see a
+/// <c>.git</c> directory — a published tree copied to a server builds nothing, so this is about
+/// the machine that produced the binary, not the one running it.
+/// </param>
+public record BuildVersionDto(string Version, string? CommitHash);

--- a/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
+++ b/src/TallaEgg/TallaEgg.Core/StartupLogging.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using System.Reflection;
 
 namespace TallaEgg.Core;
 
@@ -69,5 +70,30 @@ public static class StartupLogging
             // The process is going down either way; flush before it does.
             Log.CloseAndFlush();
         };
+    }
+
+    /// <summary>
+    /// Records which build this process is, as the first thing it logs (issue #218).
+    /// </summary>
+    /// <remarks>
+    /// Placed beside the two calls above and for their reason: it has to run before anything can
+    /// throw. A configuration guard failing at boot is exactly when "which build is on the
+    /// server?" is worth asking, and by then there is no host and no <c>ILogger&lt;T&gt;</c> to
+    /// ask it through — only Serilog's static <see cref="Log"/>, which is already configured.
+    ///
+    /// <para>
+    /// The three deployed APIs also answer this over HTTP at <c>GET /version</c>. That needs a
+    /// service that came up; this line is for one that did not.
+    /// </para>
+    /// </remarks>
+    public static void LogBuildVersion()
+    {
+        var build = BuildVersion.Current;
+
+        Log.Information(
+            "Starting {Assembly}, version {Version}, built from commit {CommitHash}.",
+            Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown assembly",
+            build.Version,
+            build.CommitHash ?? "unknown");
     }
 }

--- a/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
+++ b/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- BuildVersion.Parse is internal so the informational-version split can be tested
+         against real build strings without fabricating an assembly (issue #218). -->
+    <InternalsVisibleTo Include="TallaEgg.AllServices.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -41,6 +41,9 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 StartupLogging.ReportUnhandledExceptionsToLog();
 
+// Answers "which build is this?" from the log even when the service never finishes starting (issue #218).
+StartupLogging.LogBuildVersion();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -254,6 +257,14 @@ if (app.Environment.IsDevelopment())
         c.RoutePrefix = "api-docs";
     });
 }
+
+// Which build this service is running (issue #218) — the question a deployment leaves behind,
+// answered without RDP and a file-properties dialog. Deliberately not AllowAnonymous: the
+// Production fallback policy applies, so the caller needs the same X-API-Key as every other
+// endpoint. The commit hash names an exact line of a public repository, and the operator asking
+// the question already holds the key.
+app.MapGet("/version", () => Results.Ok(ApiResponse<BuildVersionDto>.Ok(BuildVersion.Current)))
+   .WithTags("Diagnostics");
 
 
 

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -37,6 +37,9 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 StartupLogging.ReportUnhandledExceptionsToLog();
 
+// Answers "which build is this?" from the log even when the service never finishes starting (issue #218).
+StartupLogging.LogBuildVersion();
+
 const string sharedConfigFileName = "appsettings.global.json";
 var sharedConfigPath = ResolveSharedConfigPath(builder.Environment, sharedConfigFileName);
 builder.Configuration.AddJsonFile(sharedConfigPath, optional: false, reloadOnChange: true);
@@ -174,6 +177,14 @@ if (app.Environment.IsDevelopment())
         c.RoutePrefix = "api-docs";
     });
 }
+
+// Which build this service is running (issue #218) — the question a deployment leaves behind,
+// answered without RDP and a file-properties dialog. Deliberately not AllowAnonymous: the
+// Production fallback policy applies, so the caller needs the same X-API-Key as every other
+// endpoint. The commit hash names an exact line of a public repository, and the operator asking
+// the question already holds the key.
+app.MapGet("/version", () => Results.Ok(ApiResponse<BuildVersionDto>.Ok(BuildVersion.Current)))
+   .WithTags("Diagnostics");
 
 // Wallet management endpoints
 app.MapGet("/api/wallet/balance/{userId}/{asset}", async (Guid userId, string asset, IWalletService walletService) =>

--- a/tests/TallaEgg.AllServices.Tests/BuildVersionTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BuildVersionTests.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using TallaEgg.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// How a build's <c>InformationalVersion</c> is split into the version and the commit hash
+/// reported by <c>GET /version</c> and by the startup log line (issue #218).
+/// </summary>
+/// <remarks>
+/// The strings below are the four shapes a real build produces: with build metadata (inside a git
+/// checkout), without it (outside one), with the attribute absent altogether, and with nothing to
+/// read at all.
+/// </remarks>
+public class BuildVersionTests
+{
+    [Fact]
+    public void Parse_SeparatesTheCommitHashFromTheVersion()
+    {
+        var build = BuildVersion.Parse("1.1.0+ff95e00a327536efa53e2af247b661ba9be5f744", new Version(1, 1, 0, 0));
+
+        Assert.Equal("1.1.0", build.Version);
+        Assert.Equal("ff95e00a327536efa53e2af247b661ba9be5f744", build.CommitHash);
+    }
+
+    /// <summary>
+    /// A pre-release label is part of the version, not of the metadata: the split is at the first
+    /// '+', so the '-' before it must not move it.
+    /// </summary>
+    [Fact]
+    public void Parse_KeepsAPreReleaseLabelWithTheVersion()
+    {
+        var build = BuildVersion.Parse("1.2.0-beta.1+ff95e00", new Version(1, 2, 0, 0));
+
+        Assert.Equal("1.2.0-beta.1", build.Version);
+        Assert.Equal("ff95e00", build.CommitHash);
+    }
+
+    /// <summary>
+    /// A build made outside a git checkout — a published tree, or a source archive — carries no
+    /// metadata, and the whole string is the version.
+    /// </summary>
+    [Fact]
+    public void Parse_ReportsNoCommitWhenTheBuildCarriedNoMetadata()
+    {
+        var build = BuildVersion.Parse("1.1.0", new Version(1, 1, 0, 0));
+
+        Assert.Equal("1.1.0", build.Version);
+        Assert.Null(build.CommitHash);
+    }
+
+    [Fact]
+    public void Parse_ReportsNoCommitWhenTheMetadataIsEmpty()
+    {
+        var build = BuildVersion.Parse("1.1.0+", new Version(1, 1, 0, 0));
+
+        Assert.Equal("1.1.0", build.Version);
+        Assert.Null(build.CommitHash);
+    }
+
+    /// <summary>
+    /// <c>AssemblyVersion</c> is always present, so a missing attribute still has an answer — the
+    /// same three numbers with a fourth appended.
+    /// </summary>
+    [Fact]
+    public void Parse_FallsBackToTheAssemblyVersionWhenTheAttributeIsAbsent()
+    {
+        var build = BuildVersion.Parse(null, new Version(1, 1, 0, 0));
+
+        Assert.Equal("1.1.0.0", build.Version);
+        Assert.Null(build.CommitHash);
+    }
+
+    [Fact]
+    public void Parse_ReportsUnknownWhenThereIsNothingToRead()
+    {
+        var build = BuildVersion.Parse(null, null);
+
+        Assert.Equal("unknown", build.Version);
+        Assert.Null(build.CommitHash);
+    }
+
+    /// <summary>
+    /// Reads a real assembly rather than a fabricated string, which is what proves the attribute
+    /// is actually there to read. It asserts the shape and not the number: the version moves with
+    /// every release, and a test that has to be edited to cut one would be edited without thought.
+    /// </summary>
+    [Fact]
+    public void Read_ReportsTheVersionStampedIntoABuiltAssembly()
+    {
+        var build = BuildVersion.Read(typeof(BuildVersion).Assembly);
+
+        Assert.True(Version.TryParse(build.Version, out _), $"'{build.Version}' is not a version number.");
+    }
+
+    /// <summary>
+    /// <see cref="BuildVersion.Current"/> is what both callers use, and it is computed from
+    /// <see cref="Assembly.GetEntryAssembly"/> — which under a test runner is the runner, not this
+    /// assembly. The fall-back is what has to hold here.
+    /// </summary>
+    [Fact]
+    public void Current_HasAnAnswerEvenWhenTheEntryAssemblyIsNotOurs()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(BuildVersion.Current.Version));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/RuntimeVersionExposureTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/RuntimeVersionExposureTests.cs
@@ -1,0 +1,112 @@
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That every deployed host actually exposes which build it is running (issue #218).
+/// </summary>
+/// <remarks>
+/// These read the source, like <see cref="ServiceHostPathAnchorTests"/> and
+/// <see cref="StartupGuardPlacementTests"/>, and for the same reason: the property is about how a
+/// host is wired, and four of the five wirings are in top-level statements that no test can build
+/// a container from. What they defend against is a sixth service being added, or one of these
+/// lines being dropped in a merge — either of which brings back the question #218 exists to
+/// answer, silently.
+/// </remarks>
+public class RuntimeVersionExposureTests
+{
+    /// <summary>
+    /// The four hosts <c>install-services.ps1</c> installs — the ones that run somewhere nobody
+    /// can read a file-properties dialog. <c>Affiliate.Api</c> and <c>TallaEgg.Api</c> are
+    /// deliberately absent: neither is deployed (see #69), so neither has the question to answer.
+    /// </summary>
+    public static TheoryData<string> DeployedHostEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+        "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Program.cs",
+    ];
+
+    /// <summary>
+    /// The three of those that serve HTTP. The bot is not among them — it has no endpoints, which
+    /// is exactly why the startup log line above is the whole of its answer.
+    /// </summary>
+    public static TheoryData<string> DeployedApiEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+    ];
+
+    private static string[] ReadLines(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+    }
+
+    private static bool IsCode(string line) =>
+        !line.TrimStart().StartsWith("//", StringComparison.Ordinal)
+        && !line.TrimStart().StartsWith("///", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The log line is the only answer available for a service that throws during startup, which
+    /// is when the question is asked most urgently — so it has to be reached before the
+    /// configuration guards, and it is asserted here for every deployed host including the bot.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DeployedHostEntryPoints))]
+    public void EveryDeployedHost_LogsWhichBuildItIsAtStartup(string relativePath)
+    {
+        Assert.Contains(
+            ReadLines(relativePath),
+            line => IsCode(line) && line.Contains("StartupLogging.LogBuildVersion();", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [MemberData(nameof(DeployedApiEntryPoints))]
+    public void EveryDeployedApi_AnswersTheVersionOverHttp(string relativePath)
+    {
+        Assert.Contains(
+            ReadLines(relativePath),
+            line => IsCode(line) && line.Contains("MapGet(\"/version\"", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The endpoint carries no <c>AllowAnonymous</c>, so Production's fallback authorization
+    /// policy applies and a caller needs the same <c>X-API-Key</c> as every other endpoint. That
+    /// is a decision, not an omission: the commit hash names an exact line of a public repository.
+    /// Adding it would be a one-word change with no visible effect outside Production, so it is
+    /// pinned here rather than left to the comment beside it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DeployedApiEntryPoints))]
+    public void TheVersionEndpoint_IsNotOpenedToUnauthenticatedCallers(string relativePath)
+    {
+        var lines = ReadLines(relativePath);
+
+        var endpoint = Array.FindIndex(
+            lines,
+            line => IsCode(line) && line.Contains("MapGet(\"/version\"", StringComparison.Ordinal));
+
+        Assert.True(endpoint >= 0, $"{relativePath} does not map /version.");
+
+        // The mapping and everything chained onto it, up to the statement's terminating ';'.
+        var statement = new List<string>();
+        for (var index = endpoint; index < lines.Length; index++)
+        {
+            statement.Add(lines[index]);
+
+            if (lines[index].TrimEnd().EndsWith(';'))
+            {
+                break;
+            }
+        }
+
+        Assert.DoesNotContain(statement, line => line.Contains("AllowAnonymous", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Description
`v1.1.0` shipped a version number that every assembly actually carries, and immediately left the
follow-up question: nothing running could be asked which build it is. This adds the two cheapest
answers — a startup log line in each of the four deployed hosts, and `GET /version` on the three
APIs. It exposes what the SDK already stamped into the assemblies; no package, no build step and
no generated file is involved.

## Linked Task / Finding
Closes #218 (follow-up to #217)

## Type
- [x] Feature

## Changes
- **`TallaEgg.Core.BuildVersion`** reads `AssemblyInformationalVersionAttribute` and splits it at
  the SemVer build-metadata `+` into `{ version, commitHash }` (`BuildVersionDto`). `Current` is
  computed once from the entry assembly — it is served from a request path, and an assembly's
  attributes cannot change while it is loaded.
- **`StartupLogging.LogBuildVersion()`** in all four deployed hosts — Users.Api, Wallet.Api,
  Orders.Api and the bot — placed beside the two calls already there, *before* the configuration
  guards can throw:
  ```
  [08:21:31 INF] Starting Users.Api, version 1.1.0, built from commit ff95e00a327536efa53e2af247b661ba9be5f744.
  ```
  It goes through Serilog's static `Log` because at that point there is no host and no
  `ILogger<T>` — the same reason `ReportUnhandledExceptionsToLog` does (#205). A service that dies
  during startup is when "which build is this?" matters most, and it is the only answer such a
  service can give.
- **`GET /version`** on the three APIs, returning the usual `ApiResponse<T>` envelope and tagged
  `Diagnostics`. The bot serves nothing, so its log line is the whole of its answer.
- **Runbook**: a "Which build is running" section in `docs/operations/WINDOWS_DEPLOYMENT.md`,
  after the redeploy step that raises the question.

## Two decisions worth reviewing

**`/version` is not anonymous.** It carries no `AllowAnonymous`, so Production's fallback
authorization policy applies and a caller needs the same `X-API-Key` as every other endpoint. This
repository is public, so the commit hash names an exact line of source; the operator asking the
question already holds the key, and there is no monitoring system that would need it open.
`RuntimeVersionExposureTests.TheVersionEndpoint_IsNotOpenedToUnauthenticatedCallers` pins it,
because adding one word would reverse the decision with no visible effect outside Production.

**`Affiliate.Api` and `TallaEgg.Api` are untouched.** Neither is deployed (#69), so neither has
the question to answer. #218 names four services and this changes exactly those four.

## What the hash does and does not mean
It is the commit checked out **on the machine that ran `publish-all.ps1`**, not anything about the
server, and it names the last commit rather than the working tree — uncommitted changes do not
move it. `commitHash` is `null` when the build could not see a `.git` directory, which is what
publishing from a source archive looks like. Both are stated in the runbook section.

## Testing

### Unit tests
```
dotnet build TallaEgg.sln --no-incremental
Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 808, Skipped: 0, Total: 808     (790 before this PR)
```
18 new: eight on the split itself — with metadata, without it, empty metadata, a pre-release label
that must not move the split, a missing attribute falling back to `AssemblyVersion`, and nothing to
read at all — and ten asserting the wiring is present in each host, in the manner of
`ServiceHostPathAnchorTests`. The split is tested through an `internal` `Parse` rather than by
fabricating an assembly per case, which would test reflection instead.

### End-to-end (`driver.ps1`, 2026-09-04)
```
driver.ps1 start   -> Build succeeded. 0 Warning(s) 0 Error(s). All services up after 2s.
driver.ps1 smoke   -> === Done in 00:00:08.49. Registered 5 (4 approved), trades attempted 10, errors 0 ===
                      Filled trades by symbol: BTC/IRT 4, MAUA/IRT 3, SEKE_BAHAR/IRT 3
                      Simulation completed with errors 0; 10 settlement(s) completed, no new failures.
```
The endpoint answered on all three APIs, and the hash matched the branch's `HEAD` exactly:
```
port 5136 (Users)  -> success=True version=1.1.0 commit=ff95e00a327536efa53e2af247b661ba9be5f744
port 60933 (Wallet)-> success=True version=1.1.0 commit=ff95e00a327536efa53e2af247b661ba9be5f744
port 5140 (Orders) -> success=True version=1.1.0 commit=ff95e00a327536efa53e2af247b661ba9be5f744
```
Each service's startup line was read out of `run-logs/*.out.log`, not assumed.

**The bot's line was not exercised at runtime, deliberately.** Starting the real bot would run
`NotifyUpdateToAllUsers`, which on the 1.0.0 → 1.1.0 bump broadcasts an "updated" message to every
registered user — a real, unrecallable side effect for a test. Its call site is identical to the
three APIs', goes through the same method, and is asserted by
`EveryDeployedHost_LogsWhichBuildItIsAtStartup`.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Follows naming conventions (STANDARDS.md)
- [x] Tests added in `tests/TallaEgg.AllServices.Tests`
- [x] Docs updated (`docs/operations/WINDOWS_DEPLOYMENT.md`)
- [ ] Peer reviewed

## Deployment Notes
No migration, no config change, no feature flag, no breaking change — one new read-only endpoint
and one extra log line per service. Post-deployment this is its own verification: the startup line
in each service's log, and `GET /version` with the API key. To roll back, revert the commit and
redeploy; nothing persists any state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
