### PR TITLE
[Fix] Use the injected HttpClient, and read the API key at startup — issue #214

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ shared key sent via the `X-API-Key` header (`TallaEgg.Core.APIKeyConstant`). It 
 - **Development**: none of the four services enforce this — API-key authentication is only wired
   up when `ASPNETCORE_ENVIRONMENT=Production`. Leave the variable unset locally.
 - **Production**: set `TALLAEGG_API_KEY` before starting any service; each one throws at startup
-  if it is missing.
+  — before it binds its port — if it is missing.
 
 > **`ASPNETCORE_ENVIRONMENT` must be set explicitly on a server.** Locally `dotnet run` always
 > reports `Development` because of `launchSettings.json` — that file is not used by a published

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -24,10 +24,11 @@ public class OrderApiClient : IOrderApiClient
     {
         // The injected client, and no other. This assignment used to be undone twenty lines
         // below by `_httpClient = new HttpClient(handler)`, so every instance abandoned the
-        // factory's client — and with it the pooled, periodically rotated handler — for a
-        // private connection pool that nothing disposed (issue #214). Here the client is a
-        // singleton, so it was one abandoned pool per process rather than per request, but the
-        // discarded handler was the same waste and the same bypass of the factory.
+        // factory's client for a private connection pool that nothing disposed (issue #214).
+        // Both hosts that build this client register it as a singleton, so the cost was one
+        // leaked pool for the life of the process rather than the per-request leak #214 found
+        // in Orders.Api. A singleton pins the factory's handler too, so what is recovered here
+        // is the shared handler and the factory's pipeline, not its rotation.
         //
         // The handler that replaced it carried exactly one setting: a Debug-only callback
         // accepting any server certificate, added when local inter-service calls were expected

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -22,7 +22,19 @@ public class OrderApiClient : IOrderApiClient
 
     public OrderApiClient(HttpClient httpClient, IConfiguration configuration, ILogger<OrderApiClient> logger)
     {
-        _httpClient = httpClient;
+        // The injected client, and no other. This assignment used to be undone twenty lines
+        // below by `_httpClient = new HttpClient(handler)`, so every instance abandoned the
+        // factory's client — and with it the pooled, periodically rotated handler — for a
+        // private connection pool that nothing disposed (issue #214). Here the client is a
+        // singleton, so it was one abandoned pool per process rather than per request, but the
+        // discarded handler was the same waste and the same bypass of the factory.
+        //
+        // The handler that replaced it carried exactly one setting: a Debug-only callback
+        // accepting any server certificate, added when local inter-service calls were expected
+        // over self-signed HTTPS. No service in this system binds an HTTPS address, so it had
+        // nothing left to accept, and a Release build compiled it out and left a handler
+        // configured precisely like the one the factory supplies.
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
         // Guarded rather than defaulted: the old fallback pointed at 5135, which is TallaEgg.Api
         // — a host that starts, binds and maps no routes. Orders are on 5140, so taking that
@@ -36,12 +48,6 @@ public class OrderApiClient : IOrderApiClient
         _baseUrl = ConfigurationGuard.RequireUri(configuration, "OrderApiUrl").AbsoluteUri.TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        var handler = new HttpClientHandler();
-#if DEBUG
-        // DEV ONLY: accept self-signed certs for local inter-service calls.
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-#endif
-        _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }
 

--- a/src/Affiliate/Affiliate.Api/Program.cs
+++ b/src/Affiliate/Affiliate.Api/Program.cs
@@ -86,10 +86,18 @@ builder.Services.AddDbContext<AffiliateDbContext>(options =>
 // فقط در production محافظت فعال شود
 if (builder.Environment.IsProduction())
 {
+    // Read here, not inside the AddScheme delegate below: that delegate is an options
+    // configuration action, so it does not run when the host is built but the first time
+    // IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>.Get is called — inside
+    // AuthenticationHandler<T>.InitializeAsync, on a request. An unset TALLAEGG_API_KEY
+    // therefore let the service start, bind its port and look healthy under sc.exe while
+    // answering 500 to every request, one environment variable away from working (issue #214).
+    var apiKey = APIKeyConstant.RequireTallaEggApiKey();
+
     builder.Services.AddAuthentication("ApiKey")
         .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", options =>
         {
-            options.ApiKey = APIKeyConstant.RequireTallaEggApiKey();
+            options.ApiKey = apiKey;
         });
 
     // Authorization Policy سراسری فقط برای production

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -106,10 +106,18 @@ builder.Services.AddDbContext<OrdersDbContext>(options =>
 // Protection is only wired up in Production.
 if (builder.Environment.IsProduction())
 {
+    // Read here, not inside the AddScheme delegate below: that delegate is an options
+    // configuration action, so it does not run when the host is built but the first time
+    // IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>.Get is called — inside
+    // AuthenticationHandler<T>.InitializeAsync, on a request. An unset TALLAEGG_API_KEY
+    // therefore let the service start, bind its port and look healthy under sc.exe while
+    // answering 500 to every request, one environment variable away from working (issue #214).
+    var apiKey = APIKeyConstant.RequireTallaEggApiKey();
+
     builder.Services.AddAuthentication("ApiKey")
         .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", options =>
         {
-            options.ApiKey = APIKeyConstant.RequireTallaEggApiKey();
+            options.ApiKey = apiKey;
         });
 
     // Global authorization policy, Production only.

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -24,9 +24,12 @@ public class UsersApiClient : IUsersApiClient
     {
         // The injected client, and no other. This assignment used to be undone twenty lines
         // below by `_httpClient = new HttpClient(handler)`, so every instance abandoned the
-        // factory's client — and with it the pooled, periodically rotated handler — for a
-        // private connection pool that nothing disposed. Orders.Api registers this client
-        // Scoped, so that was one abandoned pool per inbound request (issue #214).
+        // factory's client for a private connection pool that nothing disposed. Orders.Api
+        // registers this client Scoped, so that was one such pool per inbound request, and the
+        // one place in this system where the factory's handler rotation was being bypassed —
+        // the bot and the simulator hold the client as a singleton, which pins the handler for
+        // the life of the process either way, so there the cost was one leaked pool and the
+        // loss of the factory's shared handler, not the rotation (issue #214).
         //
         // The handler that replaced it carried exactly one setting: a Debug-only callback
         // accepting any server certificate, added when local inter-service calls were expected

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -22,7 +22,18 @@ public class UsersApiClient : IUsersApiClient
 
     public UsersApiClient(HttpClient httpClient, IConfiguration configuration, ILogger<UsersApiClient> logger)
     {
-        _httpClient = httpClient;
+        // The injected client, and no other. This assignment used to be undone twenty lines
+        // below by `_httpClient = new HttpClient(handler)`, so every instance abandoned the
+        // factory's client — and with it the pooled, periodically rotated handler — for a
+        // private connection pool that nothing disposed. Orders.Api registers this client
+        // Scoped, so that was one abandoned pool per inbound request (issue #214).
+        //
+        // The handler that replaced it carried exactly one setting: a Debug-only callback
+        // accepting any server certificate, added when local inter-service calls were expected
+        // over self-signed HTTPS. No service in this system binds an HTTPS address, so it had
+        // nothing left to accept, and a Release build compiled it out and left a handler
+        // configured precisely like the one the factory supplies.
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
         // Read from this host's own section and nowhere else. It used to fall through to a scan
         // of every key in the merged configuration for anything ending in "UsersApiUrl", which
@@ -38,12 +49,6 @@ public class UsersApiClient : IUsersApiClient
         _baseUrl = ConfigurationGuard.RequireUri(configuration, "UsersApiUrl").AbsoluteUri.TrimEnd('/');
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-        var handler = new HttpClientHandler();
-#if DEBUG
-        // DEV ONLY: accept self-signed certs for local inter-service calls.
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-#endif
-        _httpClient = new HttpClient(handler);
         _httpClient.DefaultRequestHeaders.Add("X-API-Key", APIKeyConstant.TallaEggApiKey);
     }
 

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -102,10 +102,18 @@ builder.Services.AddDbContext<UsersDbContext>(options =>
 // Protection is only wired up in Production.
 if (builder.Environment.IsProduction())
 {
+    // Read here, not inside the AddScheme delegate below: that delegate is an options
+    // configuration action, so it does not run when the host is built but the first time
+    // IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>.Get is called — inside
+    // AuthenticationHandler<T>.InitializeAsync, on a request. An unset TALLAEGG_API_KEY
+    // therefore let the service start, bind its port and look healthy under sc.exe while
+    // answering 500 to every request, one environment variable away from working (issue #214).
+    var apiKey = APIKeyConstant.RequireTallaEggApiKey();
+
     builder.Services.AddAuthentication("ApiKey")
         .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", options =>
         {
-            options.ApiKey = APIKeyConstant.RequireTallaEggApiKey();
+            options.ApiKey = apiKey;
         });
 
     // Global authorization policy, Production only.

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -99,10 +99,18 @@ builder.Services.AddDbContext<WalletDbContext>(options =>
 // Protection is only wired up in Production.
 if (builder.Environment.IsProduction())
 {
+    // Read here, not inside the AddScheme delegate below: that delegate is an options
+    // configuration action, so it does not run when the host is built but the first time
+    // IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>.Get is called — inside
+    // AuthenticationHandler<T>.InitializeAsync, on a request. An unset TALLAEGG_API_KEY
+    // therefore let the service start, bind its port and look healthy under sc.exe while
+    // answering 500 to every request, one environment variable away from working (issue #214).
+    var apiKey = APIKeyConstant.RequireTallaEggApiKey();
+
     builder.Services.AddAuthentication("ApiKey")
         .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", options =>
         {
-            options.ApiKey = APIKeyConstant.RequireTallaEggApiKey();
+            options.ApiKey = apiKey;
         });
 
     // Global authorization policy, Production only.

--- a/tests/TallaEgg.AllServices.Tests/ApiKeyStartupReadTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ApiKeyStartupReadTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -37,6 +38,15 @@ public class ApiKeyStartupReadTests
     public static TheoryData<string> ServiceEntryPoints => [.. AuthenticatingServices];
 
     private const string GuardCall = "APIKeyConstant.RequireTallaEggApiKey()";
+    private const string SchemeOptions = "ApiKeyAuthenticationSchemeOptions";
+
+    /// <summary>The scheme's key, assigned from a bare local rather than an expression.</summary>
+    private static readonly Regex ApiKeyAssignment =
+        new(@"^\s*options\.ApiKey\s*=\s*(?<local>[A-Za-z_][A-Za-z0-9_]*)\s*;\s*$", RegexOptions.Compiled);
+
+    /// <summary>That local, read from the guard at startup.</summary>
+    private static Regex GuardedLocal(string name) =>
+        new($@"^\s*var\s+{Regex.Escape(name)}\s*=\s*APIKeyConstant\.RequireTallaEggApiKey\(\)\s*;\s*$");
 
     private static string[] ReadLines(string relativePath)
     {
@@ -51,7 +61,23 @@ public class ApiKeyStartupReadTests
     }
 
     /// <summary>
-    /// The mechanism the two rules below exist to protect against, demonstrated rather than
+    /// The <c>AddScheme</c> call's line range: from the call to the <c>});</c> that closes both
+    /// it and the delegate it is passed.
+    /// </summary>
+    private static (int Start, int End) AddSchemeCall(string[] lines, string relativePath)
+    {
+        var start = Array.FindIndex(lines, line =>
+            line.Contains($".AddScheme<{SchemeOptions}", StringComparison.Ordinal));
+        Assert.True(start >= 0, $"{relativePath} registers no {SchemeOptions} scheme.");
+
+        var end = Array.FindIndex(lines, start, line => line.Trim() == "});");
+        Assert.True(end >= start, $"{relativePath}: could not find the end of the AddScheme call.");
+
+        return (start, end);
+    }
+
+    /// <summary>
+    /// The mechanism the source rules below exist to protect against, demonstrated rather than
     /// asserted from the shape of the source: an <c>AddScheme</c> configure delegate does not
     /// run when the container is built. Nothing about registering it, or about resolving the
     /// provider, forces the read — only asking for the options does.
@@ -99,19 +125,10 @@ public class ApiKeyStartupReadTests
     public void TheApiKeyIsNotRead_InsideTheAddSchemeConfigureDelegate(string relativePath)
     {
         var lines = ReadLines(relativePath);
+        var (start, end) = AddSchemeCall(lines, relativePath);
 
-        var delegateStart = Array.FindIndex(lines, line =>
-            line.Contains(".AddScheme<ApiKeyAuthenticationSchemeOptions", StringComparison.Ordinal));
-        Assert.InRange(delegateStart, 0, lines.Length - 1);
-
-        // The delegate is the argument of that call, so it ends where the call does: the first
-        // line closing both, written "});" on its own.
-        var delegateEnd = Array.FindIndex(lines, delegateStart, line =>
-            line.Trim() == "});");
-        Assert.InRange(delegateEnd, delegateStart, lines.Length - 1);
-
-        var inside = lines[delegateStart..(delegateEnd + 1)]
-            .Select((line, offset) => (Line: line, Number: delegateStart + offset + 1))
+        var inside = lines[start..(end + 1)]
+            .Select((line, offset) => (Line: line, Number: start + offset + 1))
             .Where(entry => entry.Line.Contains(GuardCall, StringComparison.Ordinal))
             .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
             .ToList();
@@ -120,15 +137,71 @@ public class ApiKeyStartupReadTests
     }
 
     /// <summary>
-    /// And the read still happens. Deleting it would satisfy the rule above while putting the
-    /// Production hole — a service authenticating against the local-dev placeholder — back.
+    /// The key the scheme ends up holding is the one the guard returned, read before the
+    /// registration that consumes it.
+    ///
+    /// <para>
+    /// Asserting only that the file mentions the guard somewhere is not enough, and was not:
+    /// <c>Users.Api</c> calls it a second time further down, for the API key its outgoing wallet
+    /// client sends. That call satisfied a whole-file search on its own, so the Production auth
+    /// read could have been swapped for <c>APIKeyConstant.TallaEggApiKey</c> — the local-dev
+    /// placeholder, which is exactly the hole the guard exists to close — with every test still
+    /// green.
+    /// </para>
+    ///
+    /// <para>
+    /// So this follows the value instead: the delegate must assign a bare local, and that local
+    /// must have been assigned from the guard above the <c>AddScheme</c> call. An expression in
+    /// the assignment fails the first half; a different source for the local fails the second.
+    /// </para>
     /// </summary>
     [Theory]
     [MemberData(nameof(ServiceEntryPoints))]
-    public void EveryAuthenticatingService_StillRequiresTheKey(string relativePath)
+    public void TheSchemesKey_ComesFromTheGuardReadAboveTheRegistration(string relativePath)
     {
-        Assert.Contains(ReadLines(relativePath), line =>
-            line.Contains(GuardCall, StringComparison.Ordinal)
-            && !line.TrimStart().StartsWith("//", StringComparison.Ordinal));
+        var lines = ReadLines(relativePath);
+        var (start, end) = AddSchemeCall(lines, relativePath);
+
+        var assignment = lines[start..(end + 1)]
+            .Select(line => ApiKeyAssignment.Match(line))
+            .FirstOrDefault(match => match.Success);
+
+        Assert.True(assignment is not null,
+            $"{relativePath}: the AddScheme delegate does not assign options.ApiKey from a local. " +
+            "It has to, or the value cannot have been read at startup.");
+
+        var local = assignment!.Groups["local"].Value;
+        var guarded = GuardedLocal(local);
+
+        var readAt = Array.FindIndex(lines, 0, start, line => guarded.IsMatch(line));
+        Assert.True(readAt >= 0,
+            $"{relativePath}: options.ApiKey is assigned from '{local}', but no " +
+            $"'var {local} = {GuardCall};' appears above the AddScheme call.");
+    }
+
+    /// <summary>
+    /// One place configures the scheme's options, and it is the delegate the rules above check.
+    ///
+    /// <para>
+    /// Without this, the read could be moved into a
+    /// <c>PostConfigure&lt;ApiKeyAuthenticationSchemeOptions&gt;</c> further down the file and be
+    /// exactly as lazy as before — a different options configuration action, run at the same
+    /// moment, out of reach of a rule that only looks between <c>AddScheme</c> and its closing
+    /// brace.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void TheSchemesOptions_AreConfiguredInExactlyOnePlace(string relativePath)
+    {
+        var configuring = ReadLines(relativePath)
+            .Select((line, index) => (Line: line, Number: index + 1))
+            .Where(entry => entry.Line.Contains(SchemeOptions, StringComparison.Ordinal)
+                            && !entry.Line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+            .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
+            .ToList();
+
+        var registration = Assert.Single(configuring);
+        Assert.Contains($".AddScheme<{SchemeOptions}", registration, StringComparison.Ordinal);
     }
 }

--- a/tests/TallaEgg.AllServices.Tests/ApiKeyStartupReadTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ApiKeyStartupReadTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TallaEgg.Core;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// Production's API key is read while the host is being built, not while a request is being
+/// served (issue #214).
+///
+/// <para>
+/// All four authenticating services called <c>APIKeyConstant.RequireTallaEggApiKey()</c> from
+/// inside the <c>AddScheme</c> options delegate. That delegate is an options configuration
+/// action: it runs the first time the scheme's options are resolved, which is inside
+/// <c>AuthenticationHandler&lt;T&gt;.InitializeAsync</c> — on a request. With
+/// <c>TALLAEGG_API_KEY</c> unset the service started, bound its port, reported healthy to
+/// <c>sc.exe</c>, and answered 500 to everything.
+/// </para>
+///
+/// <para>
+/// Not a security hole — the request failed closed. The cost was diagnosis, and
+/// <c>README.md</c> had promised the opposite ("each one throws at startup if it is missing")
+/// since the guard was introduced.
+/// </para>
+/// </summary>
+public class ApiKeyStartupReadTests
+{
+    private static readonly string[] AuthenticatingServices =
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+        "src/Affiliate/Affiliate.Api/Program.cs",
+    ];
+
+    public static TheoryData<string> ServiceEntryPoints => [.. AuthenticatingServices];
+
+    private const string GuardCall = "APIKeyConstant.RequireTallaEggApiKey()";
+
+    private static string[] ReadLines(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+    }
+
+    /// <summary>
+    /// The mechanism the two rules below exist to protect against, demonstrated rather than
+    /// asserted from the shape of the source: an <c>AddScheme</c> configure delegate does not
+    /// run when the container is built. Nothing about registering it, or about resolving the
+    /// provider, forces the read — only asking for the options does.
+    /// </summary>
+    [Fact]
+    public void AnAddSchemeConfigureDelegate_DoesNotRunUntilTheOptionsAreResolved()
+    {
+        var ran = false;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthentication("ApiKey")
+            .AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", options =>
+            {
+                ran = true;
+                options.ApiKey = "whatever the guard would have returned";
+            });
+
+        var provider = services.BuildServiceProvider();
+        Assert.False(ran);
+
+        var monitor = provider.GetRequiredService<IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>>();
+        Assert.False(ran);
+
+        _ = monitor.Get("ApiKey");
+        Assert.True(ran);
+    }
+
+    /// <summary>
+    /// Source inspection, for the reason <see cref="StartupGuardPlacementTests"/> gives: there is
+    /// no host-level startup harness to hang a behavioural assertion on, and moving the read back
+    /// inside the delegate would leave every other test green.
+    ///
+    /// <para>
+    /// This rule is narrower than that file's column-zero one, and deliberately so. The read
+    /// belongs inside <c>if (builder.Environment.IsProduction())</c> — outside Production no
+    /// service registers API-key authentication, and requiring the variable there would stop
+    /// every clone and CI job that has no reason to hold it — so it is legitimately indented and
+    /// the blunt rule cannot express it. What has to hold is only that the read is not inside the
+    /// <c>AddScheme</c> delegate, which is what this checks.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void TheApiKeyIsNotRead_InsideTheAddSchemeConfigureDelegate(string relativePath)
+    {
+        var lines = ReadLines(relativePath);
+
+        var delegateStart = Array.FindIndex(lines, line =>
+            line.Contains(".AddScheme<ApiKeyAuthenticationSchemeOptions", StringComparison.Ordinal));
+        Assert.InRange(delegateStart, 0, lines.Length - 1);
+
+        // The delegate is the argument of that call, so it ends where the call does: the first
+        // line closing both, written "});" on its own.
+        var delegateEnd = Array.FindIndex(lines, delegateStart, line =>
+            line.Trim() == "});");
+        Assert.InRange(delegateEnd, delegateStart, lines.Length - 1);
+
+        var inside = lines[delegateStart..(delegateEnd + 1)]
+            .Select((line, offset) => (Line: line, Number: delegateStart + offset + 1))
+            .Where(entry => entry.Line.Contains(GuardCall, StringComparison.Ordinal))
+            .Select(entry => $"{relativePath}:{entry.Number}: {entry.Line.Trim()}")
+            .ToList();
+
+        Assert.Empty(inside);
+    }
+
+    /// <summary>
+    /// And the read still happens. Deleting it would satisfy the rule above while putting the
+    /// Production hole — a service authenticating against the local-dev placeholder — back.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ServiceEntryPoints))]
+    public void EveryAuthenticatingService_StillRequiresTheKey(string relativePath)
+    {
+        Assert.Contains(ReadLines(relativePath), line =>
+            line.Contains(GuardCall, StringComparison.Ordinal)
+            && !line.TrimStart().StartsWith("//", StringComparison.Ordinal));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/InjectedHttpClientTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/InjectedHttpClientTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// The two clients that take an <see cref="HttpClient"/> from the container send their requests
+/// through that client, and not through one of their own (issue #214).
+///
+/// <para>
+/// Both constructors assigned the injected client and then, twenty lines later, replaced it with
+/// <c>new HttpClient(handler)</c> over a freshly built <c>HttpClientHandler</c>. Nothing disposed
+/// either object, so each instance leaked a connection pool and bypassed
+/// <c>IHttpClientFactory</c>'s handler rotation. <c>Orders.Api</c> registers
+/// <see cref="TallaEgg.TelegramBot.Infrastructure.Clients.UsersApiClient"/> <c>Scoped</c>, which
+/// made that one pool per inbound request.
+/// </para>
+///
+/// <para>
+/// Reading the diff is not proof that the injected client is the one that carries traffic, so
+/// these tests hand each client an <see cref="HttpClient"/> over a handler that records what it
+/// is asked to send. If the client builds its own, the recorder sees nothing — and the request
+/// goes to a host that does not resolve, which the clients swallow into a failed
+/// <c>ApiResponse</c>, exactly the shape of a green test proving nothing.
+/// </para>
+/// </summary>
+public class InjectedHttpClientTests
+{
+    /// <summary>Records every request and answers each one the same way.</summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"success\":true,\"message\":\"ok\",\"data\":null}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private static IConfiguration Configuration(string key, string value) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { [key] = value })
+            .Build();
+
+    [Fact]
+    public async Task UsersApiClient_SendsThroughTheInjectedHttpClient()
+    {
+        var recorder = new RecordingHandler();
+        var client = new UsersApiClient(
+            new HttpClient(recorder),
+            Configuration("UsersApiUrl", "http://users.test/api"),
+            NullLogger<UsersApiClient>.Instance);
+
+        await client.GetUsersAsync(pageNumber: 1, pageSize: 10);
+
+        var sent = Assert.Single(recorder.Requests);
+        Assert.StartsWith("http://users.test/api/users/list", sent.RequestUri!.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task OrderApiClient_SendsThroughTheInjectedHttpClient()
+    {
+        var recorder = new RecordingHandler();
+        var client = new OrderApiClient(
+            new HttpClient(recorder),
+            Configuration("OrderApiUrl", "http://orders.test/api"),
+            NullLogger<OrderApiClient>.Instance);
+
+        await client.GetUserOrdersAsync(Guid.NewGuid(), pageNumber: 1, pageSize: 10);
+
+        var sent = Assert.Single(recorder.Requests);
+        Assert.StartsWith("http://orders.test/api/orders/user/", sent.RequestUri!.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The header the discarded client used to carry. It is set on the injected instance now, so
+    /// it has to still reach the wire — <c>Wallet.Api</c>, <c>Users.Api</c> and <c>Orders.Api</c>
+    /// reject a Production request without it.
+    /// </summary>
+    [Theory]
+    [InlineData("users")]
+    [InlineData("orders")]
+    public async Task BothClients_StillSendTheApiKeyHeader(string which)
+    {
+        var recorder = new RecordingHandler();
+
+        if (which == "users")
+        {
+            var client = new UsersApiClient(
+                new HttpClient(recorder),
+                Configuration("UsersApiUrl", "http://users.test/api"),
+                NullLogger<UsersApiClient>.Instance);
+
+            await client.GetUsersAsync(pageNumber: 1, pageSize: 10);
+        }
+        else
+        {
+            var client = new OrderApiClient(
+                new HttpClient(recorder),
+                Configuration("OrderApiUrl", "http://orders.test/api"),
+                NullLogger<OrderApiClient>.Instance);
+
+            await client.GetUserOrdersAsync(Guid.NewGuid(), pageNumber: 1, pageSize: 10);
+        }
+
+        var sent = Assert.Single(recorder.Requests);
+        Assert.True(sent.Headers.Contains("X-API-Key"));
+    }
+
+    /// <summary>
+    /// A null client used to be harmless, because the constructor threw it away and built its
+    /// own. It is load-bearing now, so it is rejected where the mistake is made rather than at
+    /// the first call.
+    /// </summary>
+    [Fact]
+    public void UsersApiClient_WithoutAnHttpClient_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new UsersApiClient(
+            null!, Configuration("UsersApiUrl", "http://users.test/api"), NullLogger<UsersApiClient>.Instance));
+    }
+
+    [Fact]
+    public void OrderApiClient_WithoutAnHttpClient_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new OrderApiClient(
+            null!, Configuration("OrderApiUrl", "http://orders.test/api"), NullLogger<OrderApiClient>.Instance));
+    }
+}


### PR DESCRIPTION
## Description

Both halves of #214. They sit in the same wiring and share nothing else — no common fix, no
common file — so each is treated on its own terms and each carries its own proof.

**Section 1.** `UsersApiClient` and `OrderApiClient` assigned the `HttpClient` they were given and
then, twenty lines later, replaced it with one they built. The injected client is now the one that
carries traffic.

**Section 2.** The four authenticating services read `TALLAEGG_API_KEY` from inside the `AddScheme`
options delegate, which does not run until a request arrives. The read moves to startup, where
`README.md` has always said it was.

## Issue/Task Reference

Closes #214

## Type of Change

- [x] Refactor (code organization, no behavior change **when configuration is complete**)
- [x] Hotfix-adjacent: in Production with `TALLAEGG_API_KEY` unset, behaviour changes from
      "starts, then 500s" to "does not start". That is the point.

---

# Section 1 — the discarded `HttpClient`

## The question the issue asked first: why was the handler built by hand?

Answered from history before anything was deleted. The block arrived in the bot's first commit
(`abf75cf`, 2025-08-01) under a comment that translates as "to solve the SSL problem in the
development environment", and `3e3d66a` (#103) later wrapped its one statement in `#if DEBUG`:

```
-        // <Farsi comment: to solve the SSL problem in the development environment>
         var handler = new HttpClientHandler();
+#if DEBUG
+        // DEV ONLY: accept self-signed certs for local inter-service calls.
         handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+#endif
         _httpClient = new HttpClient(handler);
```

So the handler existed for exactly one reason: a Debug-only certificate-validation bypass. No
proxy, no timeout, no client certificate, no cookie or redirect policy — nothing that would have
had to be re-applied at registration.

**And that one reason has nothing left to do.** No service in this system binds an HTTPS address
(`AGENT.md` ports table); every service URL in `config/appsettings.global.example.json` is `http`,
including the two these clients read. There is no certificate to validate, self-signed or
otherwise. In a Release build it is stronger than that: the callback is compiled out, so the
hand-built handler was configured *identically* to the one `IHttpClientFactory` supplies — pure
waste with no behavioural difference at all. So the line came out rather than being re-applied at
registration.

## What it cost

Nothing disposed either the client or the handler, and the handler is a fresh connection pool
every time. Both clients are singletons in the bot and the simulator — bounded waste. In
`Orders.Api`, `UsersApiClient` is registered `Scoped` (`Program.cs:139`), so it was one abandoned
`HttpClient` and one new socket pool **per inbound request**, plus a complete bypass of the
factory's handler rotation.

Per the issue's note: `Program.cs:135` explains why it is Scoped, and the scoping is not the
problem — a Scoped client over the factory's pooled handler is fine. Discarding the factory's
client is the problem. Nothing about the lifetime was changed.

## Proof: the injected client is the one that is used

**`InjectedHttpClientTests`** hands each client an `HttpClient` over a handler that records what it
is asked to send, then calls a method on it. Reading the diff is not proof; a recorder that sees
the request is. If the client builds its own, the recorder stays empty *and* the request goes to a
host that does not resolve — which both clients swallow into a failed `ApiResponse`, i.e. exactly
the shape of a green test that proves nothing.

Verified by putting the defect back on purpose (`_httpClient = new HttpClient(handler)` restored in
`UsersApiClient`, the key read moved back into the delegate in `Orders.Api`) and running only the
two new classes:

```
Failed InjectedHttpClientTests.UsersApiClient_SendsThroughTheInjectedHttpClient [2 s]
   Assert.Single() Failure: The collection was empty
Failed InjectedHttpClientTests.BothClients_StillSendTheApiKeyHeader(which: "users") [1 s]
   Assert.Single() Failure: The collection was empty
Failed ApiKeyStartupReadTests.TheApiKeyIsNotRead_InsideTheAddSchemeConfigureDelegate
       (relativePath: "src/Order/Orders.Api/Program.cs") [11 ms]
   Assert.Empty() Failure: Collection was not empty
Failed!  - Failed: 3, Passed: 12, Skipped: 0, Total: 15
```

Both defects restored, both caught, and nothing else. The files were then restored from backup and
the full suite re-run.

The tests also pin the `X-API-Key` header, which used to be set on the discarded client and is now
set on the injected one — `Wallet.Api`, `Users.Api` and `Orders.Api` reject a Production request
without it. The header is safe to set there: `AddHttpClient()` registers `HttpClient` as
**transient** (probed in #213: `bareHttpClient=registered`), so every resolution is its own
`HttpClient` instance over the shared, rotated handler, and `DefaultRequestHeaders` cannot leak
between clients.

## Proof: the socket count

Socket counting was possible. `Orders.Api` was driven with 40 identical `POST /api/orders`
requests (a userId nobody owns — the wallet reads and the user lookup both run, the order is
refused on balance, nothing is written), and the connections the `Orders.Api` process holds were
counted immediately afterwards.

**Each of those requests makes 4 calls to `Wallet.Api` through `WalletApiClient` — which already
used its injected client — and 1 call to `Users.Api` through `UsersApiClient`. Same process, same
request: the wallet side is the control.**

Release build, `driver.ps1 start`, same script both times:

```
BEFORE : 40 requests in 6s, responses: 400 x40
  Users.Api  (5136): 40 connection(s)  [Established=40]     <- UsersApiClient
  Wallet.Api (60933): 2 connection(s)  [Established=2]      <- WalletApiClient (control)

AFTER  : 40 requests in 4.4s, responses: 400 x40
  Users.Api  (5136): 1 connection(s)   [Established=1]      <- UsersApiClient
  Wallet.Api (60933): 1 connection(s)  [Established=1]      <- WalletApiClient (control)
```

**40 → 1**, and the Users side now matches the control it should always have matched. One request
one socket is the shape the issue predicted would end in ephemeral-port exhaustion under sustained
load; there is nothing left of it.

A second, independent sign: after the change the simulator's log carries `IHttpClientFactory`'s own
request logging for the Users calls —

```
info: System.Net.Http.HttpClient.Default.LogicalHandler[100]
      Start processing HTTP request GET http://localhost:5136/api/user/-999999981
info: System.Net.Http.HttpClient.Default.ClientHandler[101]
      Received HTTP response headers after 23.4141ms - 200
```

Those categories are emitted only by the factory's pipeline. A hand-constructed
`new HttpClient(handler)` cannot produce them, so their presence is the factory's client being the
one that sends.

---

# Section 2 — the API-key guard

## (a) Before the change — reproduced, not assumed

Published-configuration path — the built DLL run directly, **not** `dotnet run`, whose
`launchSettings.json` forces `Development` and never reaches this wiring.
`ASPNETCORE_ENVIRONMENT=Production`, `TALLAEGG_API_KEY` unset:

```
[10:51:18 INF] Now listening on: http://localhost:5240
[10:51:18 INF] Application started. Press Ctrl+C to shut down.
[10:51:18 INF] Hosting environment: Production
```

It starts. It binds. Then the first request:

```
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:5240/api/symbols/active
HTTP 500
```

```
[10:51:40 INF] Request starting HTTP/1.1 GET http://localhost:5240/api/symbols/active - null null
[10:51:40 ERR] HTTP GET /api/symbols/active responded 500 in 7.7078 ms
System.InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set. Production
requires the shared API key to be supplied out-of-band; it is no longer read from source.
   at TallaEgg.Core.APIKeyConstant.RequireTallaEggApiKey() in src/TallaEgg/TallaEgg.Core/APIKeyConstant.cs:line 35
   at Program.<>c.<<Main>$>b__0_6(ApiKeyAuthenticationSchemeOptions options) in src/Order/Orders.Api/Program.cs:line 112
   at Microsoft.Extensions.Options.OptionsFactory`1.Create(String name)
   at Microsoft.Extensions.Options.OptionsCache`1.GetOrAdd[TArg](String name, Func`3 createOptions, TArg factoryArgument)
   at Microsoft.Extensions.Options.OptionsMonitor`1.Get(String name)
   at Microsoft.AspNetCore.Authentication.AuthenticationHandler`1.InitializeAsync(AuthenticationScheme scheme, HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationHandlerProvider.GetHandlerAsync(HttpContext context, String authenticationScheme)
   at Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync(HttpContext context, String scheme)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
```

The `Program.<>c.<<Main>$>b__0_6` frame is the point of the whole issue: the read is a compiler-
generated closure invoked from `OptionsFactory`, not a startup statement.

## (b) After the change — it fails at startup, in all four services

Same conditions, same published-DLL path, each service given its own port so nothing was shadowed
by an already-bound one:

```
Users.Api:     exit=127  'Now listening' lines=0  -> InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set...
Wallet.Api:    exit=127  'Now listening' lines=0  -> InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set...
Orders.Api:    exit=127  'Now listening' lines=0  -> InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set...
Affiliate.Api: exit=127  'Now listening' lines=0  -> InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set...
```

`'Now listening' lines=0` is the part that matters: no port is bound, so a service in this state
cannot look healthy. The message reaches the log file through Serilog, which #213 moved above
everything that can throw:

```
[11:09:34 FTL] The service is terminating on an unhandled exception.
System.InvalidOperationException: Environment variable 'TALLAEGG_API_KEY' is not set. Production
requires the shared API key to be supplied out-of-band; it is no longer read from source.
   at Program.<Main>$(String[] args) in src/Order/Orders.Api/Program.cs:line 115
```

`Program.<Main>$` — a startup statement, no closure in the frame.

## (c) With the key set, and in Development, nothing changes

Production, `TALLAEGG_API_KEY` set to a throwaway value generated locally for the run (never
printed, never written anywhere that is committed):

```
[11:10:21 INF] Now listening on: http://localhost:5240
[11:10:21 INF] Hosting environment: Production

with the correct X-API-Key : HTTP 200
with no X-API-Key          : HTTP 401
with a wrong X-API-Key     : HTTP 401
500s in the log            : 0
key occurrences in the log : 0
```

Authentication still does exactly what it did — accepts the key, rejects everything else — and the
value does not appear in the log.

Development is untouched: the whole block is inside `if (builder.Environment.IsProduction())`, so
outside Production no service registers API-key authentication and none requires the variable.
Proven by the full stack coming up and running end to end with the variable unset — see Testing
below.

## Code or doc? Code.

`README.md:190` promised behaviour the code did not have:

> **Production**: set `TALLAEGG_API_KEY` before starting any service; each one throws at startup
> if it is missing.

**The code was changed to match the doc, not the other way round**, because the doc was describing
the behaviour an operator needs and the code was the thing that was wrong. Nothing else in the
repository depends on the lazy read, the four call sites are identical, and the fix is five lines
per service inside a conditional that already existed. Weakening the sentence to describe a service
that starts broken would have documented a defect instead of fixing it.

The line keeps its meaning and gains the fact that matters operationally:

```diff
 - **Production**: set `TALLAEGG_API_KEY` before starting any service; each one throws at startup
-  if it is missing.
+  — before it binds its port — if it is missing.
```

## The test trap: `StartupGuardPlacementTests` was **not** relaxed, and did not need to be

Its rule — every `ConfigurationGuard.Require*` call at column zero — is intact and untouched. The
new read is indented (it belongs inside `if (builder.Environment.IsProduction())`) but does not
trip it, because it is not a `ConfigurationGuard` call.

That is not a technicality dodging the rule. **It should not be a `ConfigurationGuard` call.**
`ConfigurationGuard` reads keys out of `appsettings.global.json`, and every message it throws says
so: *"Add it under this service's own section, `Services:{ApplicationName}`, in
appsettings.global.json."* `TALLAEGG_API_KEY` is an environment variable, deliberately not in that
file and deliberately not in this repository (#33). Routing it through `ConfigurationGuard` would
have told an operator to fix a file that must not contain the value, and would have forced a
relaxation of a rule that is doing useful work — a worse outcome in both directions. Its own guard,
`APIKeyConstant.RequireTallaEggApiKey()`, already says the right thing, and `Users.Api:145` already
read the key this way for its outgoing wallet calls, so this is the established shape rather than a
new one.

The rule that *was* needed is a different rule, so it is a different test.

## Pinning it: `ApiKeyStartupReadTests`

Three parts, in the spirit of `StartupGuardPlacementTests` but narrower:

1. **`AnAddSchemeConfigureDelegate_DoesNotRunUntilTheOptionsAreResolved`** — behavioural, not source
   inspection. Registers an `AddScheme` delegate that sets a flag, builds the provider, asserts the
   flag is still false, resolves `IOptionsMonitor<...>`, asserts it is *still* false, then calls
   `Get("ApiKey")` and asserts it is true. This is the mechanism the whole issue rests on,
   demonstrated rather than argued.
2. **`TheApiKeyIsNotRead_InsideTheAddSchemeConfigureDelegate`** — source inspection over the four
   services, for the reason `StartupGuardPlacementTests` gives: there is no host-level startup
   harness to hang a behavioural assertion on. It bounds the delegate (from the `.AddScheme<...>`
   line to the `});` that closes the call) and asserts no guard call sits inside it. Deliberately
   narrower than the column-zero rule, which cannot express "indented, but not in a lambda".
3. **`EveryAuthenticatingService_StillRequiresTheKey`** — deleting the read would satisfy (2) while
   putting back the Production hole of authenticating against the local-dev placeholder.

---

## Changes Made

- `UsersApiClient` and `OrderApiClient`: keep the injected `HttpClient`; delete the hand-built
  `HttpClientHandler` and the `new HttpClient(handler)` that replaced it. The `X-API-Key` default
  header moves to the injected instance. A null client is now rejected in the constructor — it used
  to be harmless because it was thrown away, and it is load-bearing now.
- `Users.Api`, `Wallet.Api`, `Orders.Api`, `Affiliate.Api`: `APIKeyConstant.RequireTallaEggApiKey()`
  hoisted out of the `AddScheme` options delegate to a local inside the existing
  `if (builder.Environment.IsProduction())`, closed over by the delegate. Five lines per service,
  identical in all four.
- `README.md:190`: the "throws at startup" sentence gains "before it binds its port".
- New `tests/TallaEgg.AllServices.Tests/InjectedHttpClientTests.cs` (6 tests) and
  `ApiKeyStartupReadTests.cs` (9 tests).

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

`TreatWarningsAsErrors` is on (`Directory.Build.props:19`), so zero warnings is enforced, not
observed.

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 827, Skipped: 0, Total: 827
```

808 on `main`; 19 new. No existing test changed.

### End-to-end (`/run-tallaegg`), Development, `TALLAEGG_API_KEY` unset

```
driver.ps1 start
All services up after 2s.

driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:37.2. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Identical to the run taken on the same worktree before the change (same seed, same counts,
0 errors, 50 settlements) — so both clients still work against the real stack, and Development
still requires no key. Date/time run: 2026-09-04.

### Doc-link check (#207)

```
scripts/check-doc-paths.sh
check-doc-paths: 390 tracked text file(s) checked, every reference resolves.
```

## Security Checklist

- [x] No hardcoded credentials. The API key is still read only from the environment.
- [x] **No key value printed, logged or committed**, in whole or in part. The Production run used a
      throwaway value generated locally; it was grepped for in the service's log and appears 0
      times, and the file holding it was deleted after the run.
- [x] No TLS bypass added. One is *removed* — a Debug-only
      `ServerCertificateCustomValidationCallback` that had nothing left to validate. Release builds
      never contained it.
- [x] `config/appsettings.global.json` untouched and uncommitted.
- [x] No name, email, identifier, personal path or server address in the diff. Absolute paths in
      the log excerpts above were replaced with repository-relative ones.
- [x] Code compiles without warnings.
- [ ] Authentication behaviour changed — see below. It fails **earlier**, never later.

**Does this weaken authentication?** No, in either direction. With the key set, the scheme is
registered and behaves exactly as before (200 with the key, 401 without — measured above). With the
key unset, the service previously started and 500'd every request; it now does not start. A host
that cannot authenticate has gone from serving nothing badly to serving nothing at all, which is
the same security posture and a far better operational one.

## Reported, deliberately not fixed

- **`AffiliateApiClient` has the same shape** — `TelegramBot/…/Clients/AffiliateApiClient.cs:17`
  takes an `HttpClient` and ignores the parameter outright, building its own over a handler with
  the same Debug-only bypass. It is a third instance of section 1's defect, found while fixing the
  two the issue names. Left alone under `STANDARDS.md` scope discipline: #214 names two clients, and
  `Affiliate.Api` is not deployed (it ships zero migrations, `AGENT.md`). Worth a one-line issue,
  and the fix here is the template for it.
- **Registering both clients through `AddHttpClient<T>`**, which the issue mentions as a follow-on
  ("would then also give them the configured `BaseAddress`"). Not done. Both clients concatenate
  `{_baseUrl}/users/list` rather than resolving relative URIs, and moving to `BaseAddress` changes
  how the `/api` suffix combines with each path — a behaviour change across every method on both
  clients, and #205/#213 showed exactly how that suffix decides between working and 404. It needs
  its own issue and its own end-to-end run.

## Not in scope, untouched

Both items #214 lists under "Not included" are decisions rather than defects, and neither was
touched:

- `IWalletApiClient` in `Orders.Api` remains **Transient** — intended, recorded in #213.
- Configuration is still not re-validated on `reloadOnChange`. Separate question.

#210 touches the same area and is a separate issue; nothing here reaches into it.

## Breaking Changes?

- [x] No breaking changes to any API contract.

One behaviour change a reader should not have to discover: **a Production host with
`TALLAEGG_API_KEY` unset now fails to start instead of starting and returning 500.** That is the
fix, not a side effect, and `README.md` already documented the new behaviour as the existing one.

## Deployment Notes

**Pre-deployment**: none beyond what was already required. `TALLAEGG_API_KEY` must be set on any
Production host — it always had to be, or every request was already failing. A host that has it set
sees no difference; a host that does not will now fail loudly at start rather than quietly at every
request, which is the intended change and is worth checking for before rolling out.

No migrations, no new configuration keys, no change to `config/appsettings.global.example.json`.

**Post-deployment verification**: the service starts and binds (previously not a useful signal — it
did that either way); one authenticated request returns 200 and one unauthenticated returns 401.

**Rollback**: revert the commit. Nothing persisted, nothing migrated.

---

## Self-review (`/code-review high 221`) — three findings, all answered

The review cleared the production code — both client constructors, the removal of the cert
bypass, the header on the injected instance, the scope-disposal path in `Orders.Api`, and the
four hoisted reads. Every finding was about whether the **new tests actually hold the fix in
place**, plus one inaccurate comment. All three were real. Fixed in `2e6a109`.

### 1. `EveryAuthenticatingService_StillRequiresTheKey` was vacuous for `Users.Api`

`Users.Api` calls `RequireTallaEggApiKey()` a **second** time at `Program.cs:154`, for the key its
outgoing wallet client sends. A whole-file substring search was satisfied by that call on its own,
so the Production auth read could be swapped for `APIKeyConstant.TallaEggApiKey` — the local-dev
placeholder, precisely the hole the guard exists to close — with all nine tests green.

Replaced by **`TheSchemesKey_ComesFromTheGuardReadAboveTheRegistration`**, which follows the value
instead of grepping for the guard: the delegate must assign `options.ApiKey` from a **bare local**,
and that local must have a `var <local> = APIKeyConstant.RequireTallaEggApiKey();` **above** the
`AddScheme` call. An expression in the assignment fails the first half; a different source for the
local fails the second.

### 2. `PostConfigure` escaped the delegate-span rule

The placement rule only scanned between `.AddScheme<` and its closing `});`, so moving the read
into `PostConfigure<ApiKeyAuthenticationSchemeOptions>` further down reintroduced #214 exactly —
a different options configuration action, run at the same moment, out of reach of the rule.

Closed by **`TheSchemesOptions_AreConfiguredInExactlyOnePlace`**: the scheme's options are
configured in one place, and that place is the delegate the other rules check.

### Both mutations reproduced, and both now fail

Each mutation applied to one file, then the class run:

```
Failed TheSchemesKey_ComesFromTheGuardReadAboveTheRegistration(relativePath: "src/User/Users.Api/Program.cs")
   src/User/Users.Api/Program.cs: the AddScheme delegate does not assign options.ApiKey from a
   local. It has to, or the value cannot have been read at startup.

Failed TheSchemesOptions_AreConfiguredInExactlyOnePlace(relativePath: "src/Order/Orders.Api/Program.cs")
   Assert.Single() Failure: The collection contained 2 items
   Collection: ["src/Order/Orders.Api/Program.cs:118: .AddScheme<Ap"···,
                "src/Order/Orders.Api/Program.cs:123: builder.Servi"···]

Failed TheSchemesKey_ComesFromTheGuardReadAboveTheRegistration(relativePath: "src/Order/Orders.Api/Program.cs")
   src/Order/Orders.Api/Program.cs: options.ApiKey is assigned from 'apiKey', but no
   'var apiKey = APIKeyConstant.RequireTallaEggApiKey();' appears above the AddScheme call.

Failed! - Failed: 3, Passed: 10, Skipped: 0, Total: 13
```

Each fails only on the file the mutation was applied to, and each message names the fix. The files
were restored from backup afterwards and the full suite re-run.

### 3. The comments overclaimed "periodically rotated handler"

They said the fix restores the factory's rotated handler. That holds in `Orders.Api`, where the
client is Scoped and takes a fresh one from the factory per request. It does **not** hold in the
bot or the simulator, which register both clients as singletons — and a singleton pins the handler
chain for the life of the process whoever built it. Reworded in both files to say what is actually
recovered in each case: the rotation in `Orders.Api`, and the shared handler plus the factory's
pipeline everywhere else. The socket numbers above are `Orders.Api`, so they are unaffected.

### Test count after the fixes

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 827, Skipped: 0, Total: 827

dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)

scripts/check-doc-paths.sh
check-doc-paths: 392 tracked text file(s) checked, every reference resolves.
```

808 on `main`; 19 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
