### PR TITLE
[Fix] Detach a wallet insert that lost the duplicate race — issue #223

### DIFF
--- a/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
+++ b/src/Wallet/Wallet.Infrastructure/WalletRepository.cs
@@ -65,6 +65,14 @@ public class WalletRepository : IWalletRepository
             _logger.LogWarning("Duplicate wallet creation attempted for user {UserId}, asset {Asset}. Returning existing wallet.",
                 wallet.UserId, wallet.Asset);
 
+            // Detach before re-reading. EF only calls AcceptAllChanges when SaveChangesAsync
+            // succeeds, so the rejected insert is still Added on this context — which is scoped
+            // per request and shared by every caller on it. Left behind, it is flushed again by
+            // the next SaveChangesAsync, fails on the same unique index, and rolls that whole
+            // batch back: the caller loses the row it was actually saving, and gets a duplicate
+            // error for an insert it never made (issue #223).
+            _context.Entry(wallet).State = EntityState.Detached;
+
             // Lost the race — return the wallet the other caller created.
             var existingWallet = await GetWalletAsync(wallet.UserId, wallet.Asset);
             if (existingWallet != null)
@@ -76,6 +84,11 @@ public class WalletRepository : IWalletRepository
         {
             _logger.LogError(ex, "Error creating wallet for user {UserId}, asset {Asset}",
                 wallet.UserId, wallet.Asset);
+
+            // Same reasoning as above, for every other way the insert can fail. This one is a
+            // no-op when the pre-check threw before the entity was ever added — Entry() on an
+            // untracked entity reports Detached already.
+            _context.Entry(wallet).State = EntityState.Detached;
             throw;
         }
     }

--- a/tests/TallaEgg.AllServices.Tests/FailedWalletInsertResidueTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/FailedWalletInsertResidueTests.cs
@@ -60,7 +60,7 @@ public class FailedWalletInsertResidueTests : IDisposable
     /// the first time the context under test is about to save. That is the window the pre-check in
     /// <c>CreateWalletAsync</c> cannot close: it has already run and found nothing.
     /// </summary>
-    private Action CompetitorWinsOnce(Guid userId, string asset, Action? onRun = null)
+    private Action CompetitorWinsOnce(Guid userId, string asset, Action<WalletEntity>? onRun = null)
     {
         var ran = false;
 
@@ -69,11 +69,13 @@ public class FailedWalletInsertResidueTests : IDisposable
             if (ran) return;
             ran = true;
 
+            var theirs = WalletEntity.Create(userId, asset);
+
             using var competitor = NewContext();
-            competitor.Wallets.Add(WalletEntity.Create(userId, asset));
+            competitor.Wallets.Add(theirs);
             competitor.SaveChanges();
 
-            onRun?.Invoke();
+            onRun?.Invoke(theirs);
         };
     }
 
@@ -90,7 +92,7 @@ public class FailedWalletInsertResidueTests : IDisposable
         var competitorRan = false;
 
         await using var context = new CollidingContext(Options());
-        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman, () => competitorRan = true);
+        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman, _ => competitorRan = true);
 
         var reported = (await NewService(context).CreateDefaultWalletsAsync(userId)).ToList();
 
@@ -139,20 +141,32 @@ public class FailedWalletInsertResidueTests : IDisposable
     /// missing wallet lazily and then writes to it through the very same context, so a lost race
     /// on the create took the collateral lock down with it — a refused trade rather than a
     /// half-seeded account.
+    ///
+    /// <para>
+    /// The lock is asserted against the winner's <b>row id</b>, not just against the balances. A
+    /// run in which no collision happened would create the wallet here and lock exactly the same
+    /// 10, so balances alone would leave this test green with nothing racing — and green is
+    /// precisely the wrong answer for a test whose whole subject is what a lost race leaves
+    /// behind.
+    /// </para>
     /// </summary>
     [Fact]
     public async Task LockBalanceAsync_LosesTheRaceCreatingTheWallet_StillLocksAgainstTheStoredRow()
     {
         var userId = Guid.NewGuid();
+        WalletEntity? winner = null;
 
         await using var context = new CollidingContext(Options());
-        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman);
+        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman, w => winner = w);
 
         await NewRepository(context).LockBalanceAsync(userId, CurrenciesConstant.Toman, 10m);
+
+        Assert.NotNull(winner);
 
         await using var verify = NewContext();
         var stored = await verify.Wallets.SingleAsync(w => w.UserId == userId);
 
+        Assert.Equal(winner.Id, stored.Id);
         Assert.Equal(10m, stored.LockedBalance);
         Assert.Equal(-10m, stored.Balance);
     }

--- a/tests/TallaEgg.AllServices.Tests/FailedWalletInsertResidueTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/FailedWalletInsertResidueTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core;
+using Wallet.Application;
+using Wallet.Application.Mappers;
+using Wallet.Core;
+using Wallet.Infrastructure;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// An insert that loses the duplicate race must not stay pending on the context.
+///
+/// <para>
+/// <c>WalletRepository.CreateWalletAsync</c> absorbs a lost race by catching, re-reading, and
+/// returning the row the winner wrote. EF only calls <c>AcceptAllChanges</c> when
+/// <c>SaveChangesAsync</c> succeeds, so the entity whose insert failed stayed in state
+/// <c>Added</c> on the <c>DbContext</c> — which is scoped per request and shared by all three
+/// creates <c>WalletService.CreateDefaultWalletsAsync</c> makes, and by the read-modify-write in
+/// <c>LockBalanceAsync</c>. The next <c>SaveChangesAsync</c> flushed the doomed insert alongside
+/// whatever it was actually for, the unique index on <c>(UserId, Asset)</c> rejected it again,
+/// and the whole batch rolled back — taking the good row with it (issue #223).
+/// </para>
+///
+/// <para>
+/// The collision is driven through a context that lets a competitor commit immediately before its
+/// own save, the same way <c>WalletConcurrencyTests</c> does it. Racing real threads would make
+/// the collision a matter of timing, so the test would become the flake rather than the proof.
+/// </para>
+/// </summary>
+public class FailedWalletInsertResidueTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public FailedWalletInsertResidueTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using var setup = NewContext();
+        setup.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private DbContextOptions<WalletDbContext> Options() =>
+        new DbContextOptionsBuilder<WalletDbContext>().UseSqlite(_connection).Options;
+
+    private WalletDbContext NewContext() => new(Options());
+
+    private static WalletRepository NewRepository(WalletDbContext context) =>
+        new(NullLogger<WalletRepository>.Instance, context);
+
+    private static WalletService NewService(WalletDbContext context) =>
+        new(NewRepository(context), new WalletMapper(), NullLogger<WalletService>.Instance);
+
+    /// <summary>
+    /// Commits <paramref name="asset"/> for <paramref name="userId"/> from another context, once,
+    /// the first time the context under test is about to save. That is the window the pre-check in
+    /// <c>CreateWalletAsync</c> cannot close: it has already run and found nothing.
+    /// </summary>
+    private Action CompetitorWinsOnce(Guid userId, string asset, Action? onRun = null)
+    {
+        var ran = false;
+
+        return () =>
+        {
+            if (ran) return;
+            ran = true;
+
+            using var competitor = NewContext();
+            competitor.Wallets.Add(WalletEntity.Create(userId, asset));
+            competitor.SaveChanges();
+
+            onRun?.Invoke();
+        };
+    }
+
+    /// <summary>
+    /// The defect itself, at the surface it was found on. Losing the race on the first of the
+    /// three default wallets must not cost the user the other two: before the fix the failed IRT
+    /// insert rode along with the MAUA insert, the batch rolled back, and the call ended in a 500
+    /// with one wallet on the account instead of three.
+    /// </summary>
+    [Fact]
+    public async Task CreateDefaultWalletsAsync_LosesTheRaceOnTheFirstWallet_StillCreatesTheOtherTwo()
+    {
+        var userId = Guid.NewGuid();
+        var competitorRan = false;
+
+        await using var context = new CollidingContext(Options());
+        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman, () => competitorRan = true);
+
+        var reported = (await NewService(context).CreateDefaultWalletsAsync(userId)).ToList();
+
+        Assert.True(competitorRan, "the competitor never ran, so no insert actually lost a race");
+
+        await using var verify = NewContext();
+        var stored = await verify.Wallets.Where(w => w.UserId == userId).Select(w => w.Asset).ToListAsync();
+
+        Assert.Equal(
+            Expected().OrderBy(a => a, StringComparer.Ordinal),
+            stored.OrderBy(a => a, StringComparer.Ordinal));
+
+        // And the caller is told about all three, including the one the competitor wrote.
+        Assert.Equal(Expected(), reported.Select(w => w.Asset));
+
+        static string[] Expected() =>
+            [CurrenciesConstant.Toman, CurrenciesConstant.Maua, CurrenciesConstant.Credit_MAUA];
+    }
+
+    /// <summary>
+    /// The mechanism underneath, pinned on its own so a future change that fixes the symptom some
+    /// other way still has to leave the context clean. A caller that gets a wallet back has no way
+    /// to know an insert failed, so it is the repository's job not to leave one behind.
+    /// </summary>
+    [Fact]
+    public async Task CreateWalletAsync_LosesTheDuplicateRace_LeavesNoPendingInsertBehind()
+    {
+        var userId = Guid.NewGuid();
+
+        await using var context = new CollidingContext(Options());
+        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman);
+
+        var mine = WalletEntity.Create(userId, CurrenciesConstant.Toman);
+        var returned = await NewRepository(context).CreateWalletAsync(mine);
+
+        // The winner's row came back, which is the behaviour the catch exists for.
+        Assert.NotEqual(mine.Id, returned.Id);
+        Assert.Equal(CurrenciesConstant.Toman, returned.Asset);
+
+        Assert.DoesNotContain(context.ChangeTracker.Entries<WalletEntity>(),
+            e => e.State == EntityState.Added);
+    }
+
+    /// <summary>
+    /// The same residue reaches trading, not just registration. <c>LockBalanceAsync</c> creates a
+    /// missing wallet lazily and then writes to it through the very same context, so a lost race
+    /// on the create took the collateral lock down with it — a refused trade rather than a
+    /// half-seeded account.
+    /// </summary>
+    [Fact]
+    public async Task LockBalanceAsync_LosesTheRaceCreatingTheWallet_StillLocksAgainstTheStoredRow()
+    {
+        var userId = Guid.NewGuid();
+
+        await using var context = new CollidingContext(Options());
+        context.BeforeSave = CompetitorWinsOnce(userId, CurrenciesConstant.Toman);
+
+        await NewRepository(context).LockBalanceAsync(userId, CurrenciesConstant.Toman, 10m);
+
+        await using var verify = NewContext();
+        var stored = await verify.Wallets.SingleAsync(w => w.UserId == userId);
+
+        Assert.Equal(10m, stored.LockedBalance);
+        Assert.Equal(-10m, stored.Balance);
+    }
+
+    /// <summary>
+    /// A context that runs a delegate immediately before its own SaveChanges, to open the window a
+    /// competing writer commits in. Deliberately a copy of the one in
+    /// <c>WalletConcurrencyTests</c> rather than an extraction of it: that file is about the
+    /// optimistic-concurrency token, this one is about change-tracker residue, and promoting a
+    /// ten-line test double into shared scaffolding is a refactor these tests do not need.
+    /// </summary>
+    private sealed class CollidingContext(DbContextOptions<WalletDbContext> options) : WalletDbContext(options)
+    {
+        public Action? BeforeSave { get; set; }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            BeforeSave?.Invoke();
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`WalletRepository.CreateWalletAsync` absorbed a lost duplicate race by catching, re-reading and
returning the row the winner wrote — but left the rejected entity in state `Added` on the
`DbContext`. That context is scoped per request and shared by every caller on it, so the doomed
insert was flushed again by the next `SaveChangesAsync`, failed on the same unique index, and
rolled that whole batch back. Two concurrent registrations for one user therefore ended in a 500
with an IRT wallet and no MAUA or CREDIT_MAUA row.

The issue's other two parts are answered without code: part 2 by measurement, part 3 by decision.

## Issue/Task Reference

Closes #223. Opened from #222's self-review (issue #210); none of the three was in that PR's
scope.

## Type of Change

- [x] Hotfix (urgent bug fix) — no
- [x] Bug fix, not urgent

Reachable only under concurrency on one user id, which the single caller
(`UserService.CreateDefaultWalletsAsync`, once per registration) does not do on its own. Nothing
in the deployed database is in this state — all 27 users hold all three default wallets.

## Verification of the reported defect

Confirmed against the tree, not taken from the issue.

| Claim | Confirmed at |
| --- | --- |
| The catch re-reads and returns, without detaching | `WalletRepository.cs:62-72` before this PR |
| Unique index on `(UserId, Asset)` makes it reachable | `WalletDbContext.cs:34` |
| One scoped context is shared by all three creates | `WalletService.cs:257-275` — one `IWalletRepository`, one `WalletDbContext` |
| `IncreaseBalanceForTradeAsync` / `LockBalanceAsync` create on a context with other pending work | `WalletRepository.cs:290`, `:327`, `:384` |

The chain, reproduced exactly as the issue describes it:

1. A's pre-check for IRT misses; B commits the IRT row first; A's insert trips the index. A's
   catch re-reads, finds B's row, returns it — and `irrWallet` is still `Added`.
2. A calls `CreateWalletAsync(mauaWallet)`. The pre-check passes, and `SaveChangesAsync` now
   flushes **both** pending entities in one transaction.
3. The IRT insert fails again, the whole batch rolls back — including the healthy MAUA insert —
   the catch looks for MAUA, does not find it, and `throw;` propagates.

The second test below prints the residue directly:

```
Collection: [WalletEntity {Id: 9d51eaef-…} Added, WalletEntity {Id: 289c4043-…} Unchanged]
```

The `Added` entry is A's rejected IRT insert; the `Unchanged` one is B's row that the catch just
returned.

## Changes Made

- `src/Wallet/Wallet.Infrastructure/WalletRepository.cs` — `CreateWalletAsync` detaches the
  rejected entity before re-reading, in the duplicate-race catch, and again in the general catch
  for every other way the insert can fail. A comment says why EF leaves it behind.
- `tests/TallaEgg.AllServices.Tests/FailedWalletInsertResidueTests.cs` — three new tests.

Both catches, not just the duplicate one. The duplicate catch is where it matters most, because
that is the path that **returns** — the caller has no way to know an insert failed and goes on
using the context. The general catch throws, so the residue usually dies with the request, but
`LockBalanceAsync`'s retry loop is a caller that survives a throw, and detaching there costs one
line. It is a no-op when the pre-check threw before the entity was ever added: `Entry()` on an
untracked entity reports `Detached` already.

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 835, Skipped: 0, Total: 835
```

832 before, three new:

| Test | What it pins |
| --- | --- |
| `CreateDefaultWalletsAsync_LosesTheRaceOnTheFirstWallet_StillCreatesTheOtherTwo` | the defect at the surface it was found on: losing the race on IRT must not cost the user MAUA and CREDIT_MAUA |
| `CreateWalletAsync_LosesTheDuplicateRace_LeavesNoPendingInsertBehind` | the mechanism underneath — nothing is left `Added` on the context |
| `LockBalanceAsync_LosesTheRaceCreatingTheWallet_StillLocksAgainstTheStoredRow` | the same residue reaching trading: a lazily created wallet whose insert lost the race took the collateral lock down with it |

The collision is driven through a `CollidingContext` that lets a competitor commit immediately
before its own save — the same pattern `WalletConcurrencyTests` uses, and for the same reason:
racing real threads would make the collision a matter of timing, and the test would become the
flake rather than the proof. In-memory SQLite throughout; no mocking library, per `STANDARDS.md`.

`CollidingContext` is deliberately copied rather than extracted from `WalletConcurrencyTests`.
That file is about the optimistic-concurrency token, this one is about change-tracker residue,
and promoting a ten-line test double into shared scaffolding is a refactor neither of them asked
for.

### The new tests were shown to fail first

Written before the fix, against the unmodified repository. All three red:

```
Failed CreateDefaultWalletsAsync_LosesTheRaceOnTheFirstWallet_StillCreatesTheOtherTwo
       Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while saving …
       ---- SqliteException : SQLite Error 19: 'UNIQUE constraint failed: Wallets.UserId, Wallets.Asset'
Failed CreateWalletAsync_LosesTheDuplicateRace_LeavesNoPendingInsertBehind
       Assert.DoesNotContain() Failure: Filter matched in collection
       Collection: [WalletEntity {Id: 9d51eaef-…} Added, WalletEntity {Id: 289c4043-…} Unchanged]
Failed LockBalanceAsync_LosesTheRaceCreatingTheWallet_StillLocksAgainstTheStoredRow
       Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while saving …

Failed! - Failed: 3, Passed: 0, Skipped: 0, Total: 3
```

The first failure is the issue's step 3 verbatim: the MAUA save carries the rejected IRT insert
with it and the batch dies on the index. No existing test broke, including
`DefaultWalletCreationResponseTests.…_CalledTwice_CreatesNoDuplicateRows`, which exercises the
pre-check path where no insert ever fails.

### End to end

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:42.3. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

All 20 registrations went through `CreateDefaultWalletsAsync`. Checked in the database rather
than inferred from the run:

```
RegisteredUsers  UsersWithAllThree  UsersMissingSome
             20                 20                 0
```

One of them, every wallet row it holds:

```
Asset              Balance          CreatedAt
IRT                6021030054.0     2026-09-04 11:35:42.8915608   <- the three defaults,
MAUA               121.54000000     2026-09-04 11:35:42.9419155      milliseconds apart
CREDIT_MAUA        120.00000000     2026-09-04 11:35:42.9676416      at registration
BTC                  .12000000      2026-09-04 11:35:50.1230354   <- lazily created during
CREDIT_BTC           .12000000      2026-09-04 11:35:50.1508659      the trading phase
SEKE_BAHAR          12.00000000     2026-09-04 11:35:50.2328163
CREDIT_SEKE_BAHAR   12.00000000     2026-09-04 11:35:50.2738217
```

### CI doc-path check (#207)

```
scripts/check-doc-paths.sh
check-doc-paths: 393 tracked text file(s) checked, every reference resolves.
```

### Environment

- [x] Tested locally — Windows + SQL Server Express, from a git worktree on this branch

## Part 2 — `GetWalletAsync`'s `ToUpper()`, measured and left alone

The issue asks for a measurement before assuming this matters. Measured; it does not.

**One correction to the issue.** It says the unique index "cannot be sought" and that every
lookup "scans the rows for that user". The second half is right, the first is not — the index
*is* sought, just on one column instead of two:

```
sargable:   Index Seek(IX_Wallets_UserId_Asset, SEEK:(UserId=@u AND Asset=@a))
as written: Index Seek(IX_Wallets_UserId_Asset, SEEK:(UserId=@u), WHERE:(upper(Asset)=upper(@a)))
```

What is lost is the second seek key, so the residual filter runs over one user's rows. That
matters, because it means the cost is bounded by **rows per user** and does not grow with the
table at all. Measured on a throwaway database at 700,000 rows / 100,000 users — 4,400× today's
table — both forms cost the same 3 logical reads, and:

| rows held by the user | sargable, 20,000 lookups | `UPPER()`, 20,000 lookups | per lookup |
| --- | --- | --- | --- |
| **7 (today's maximum)** | 204 ms | 263 ms | **+3 µs** |
| 100 | 210 ms | 702 ms | +25 µs |
| 1000 | 219 ms | 4130 ms | +196 µs |

The deployed wallet database holds 158 rows across 27 users, at most 7 each — three tradable
symbols plus their `CREDIT_` ledgers plus IRT. Reaching the 100-row column means roughly fifty
tradable symbols, and even there it is 25 µs against a 0.12 ms round trip.

**And removing it is not free, in two ways rather than one.** The issue names the SQLite one: the
test suite runs on SQLite, which is case-sensitive, so this needs a collation-aware fix rather
than a deletion. The second is larger and is about production, not tests —
`GET /api/wallet/balance/{userId}/{asset}` takes the asset straight from a route segment with no
normalization, and `WalletEntity.Create` does not normalize what it stores either. So the
`ToUpper()` is currently providing a real case-insensitivity guarantee at the HTTP boundary.
SQL Server's `Arabic_CI_AS` collation would keep that guarantee after the change; a
case-sensitive collation would not, and nothing pins which one is in use.

A change that risks an externally visible behavior regression to save 3 µs on a call whose round
trip costs 0.12 ms is worse than no change. Left as it is.

## Part 3 — still no transaction, and the reason it was reopened has been removed

The issue reopens #210's part 3 in the shape of a round-trip count, and is explicit that it is a
decision about atomicity first. Put back to the product owner, and the answer is unchanged:
**no batching, no transaction.** Nothing is built for it here. The reasoning, since the ground
did move:

**The premise that weakened is restored by part 1 of this PR.** #210's decision rested partly on
partial sets coming from failures that are rare. This issue's part 1 showed one could come from
an ordinary race instead — which is exactly what the fix above removes. After it, losing the race
produces a *complete* set; the first new test is that assertion. The only remaining way to get a
partial set is a genuine failure mid-sequence, which is the rare-failure category the decision
was built on in the first place.

**Batching would reopen from the other side what part 1 just closed.** `AddRange` plus one
`SaveChangesAsync` bypasses `CreateWalletAsync` entirely and inherits none of its duplicate-race
handling. If any one of the three collides, all three fail. Two concurrent registrations end with
all three wallets today; under a batch they would end in an exception until new recovery code is
written for it. That is a correctness surface, not a performance change.

**It moves the failure mode in the direction already rejected.** #210 decided a partial set is
better than an empty one, because `GetBalanceAsync` — the one surface that does not self-heal —
throws on a missing row, so a partial set still serves some reads. All-or-nothing makes the
failure the empty set.

**And the round-trip case is half a millisecond.** Measured on this machine: a loopback round
trip costs 0.120 ms, the endpoint's median across the 20 registrations in the run above is 60 ms,
and it runs once per user. Six round trips down to two saves roughly 0.5 ms of a 60 ms call —
under 1%, on a database with 27 users.

What would change the answer: narrowing lazy creation (`WalletLazyCreationTests`), which #206
decided against. A partial set would then be durable with no repair surface — but the answer to
that is a repair surface, not a batch insert.

Since all three parts are answered, this PR says "closes #223".

## Security Checklist

- [x] No hardcoded credentials
- [x] No TLS bypass in production code
- [x] No secrets/tokens in the diff — `config/appsettings.global.json` untouched and uncommitted
- [x] Code compiles without warnings
- [x] No personal identifiers, hostnames or server addresses in the diff

The measurement above used a throwaway database (`CREATE DATABASE`, seeded, dropped) rather than
the real one for anything that wrote; the queries against the real wallet database were
read-only. `sys.databases` was checked afterwards to confirm only the four real databases remain.

## Code Quality

- [x] Naming follows `STANDARDS.md` — new tests are `Method_Scenario_ExpectedResult`
- [x] Comments in English and explain the "why"
- [x] No large blocks of commented-out code
- [x] No new dependencies
- [x] No per-asset balance check introduced — this PR does not touch balance validation

## Documentation

No `.md` changes. Nothing in `docs/` documents this method, and the correction to part 2's index
claim belongs to the issue rather than to a document — `AGENT.md` does not describe query shapes.

## Breaking Changes?

- [x] No breaking changes

The endpoint's contract, status codes and response body are unchanged. What changes is that a
sequence which previously ended in a 500 now succeeds.

## Deployment Notes

No migrations, no new configuration, no schema change. `Wallet.Api` only.

**Post-deployment verification**: register a user and confirm three wallet rows appear, as for
#208 and #222.

**Rollback**: revert the commit. Nothing to unwind — the change only affects which entities the
change tracker holds within a single request.

## Related Issues

- Opened from #222's self-review (issue #210); this PR is cut from `main` at that merge
- Part 3 re-decides #210's part 3, and reaches the same answer for partly different reasons
- Rests on `WalletLazyCreationTests` and on #206's decision not to build a repair surface
- `CollidingContext` follows the pattern established for #174 in `WalletConcurrencyTests`

## Reviewer notes

Two things worth a second pair of eyes:

- **Detaching in the general catch as well as the duplicate one.** It is defensive rather than
  demanded by a failing test — the residue there normally dies with the request. The argument for
  it is `LockBalanceAsync`'s retry loop, which survives a throw; the argument against is that it
  is a line no test pins. Happy to drop it to the duplicate catch alone.
- **The copied `CollidingContext`.** Extracting it into `Fakes/` would remove the duplication and
  touch a file this issue is not about. Left copied under scope discipline; say the word if the
  call should go the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
