### PR TITLE
[Chore] Raise the product version to 1.2.0 and cut the release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          AssemblyVersion, FileVersion and InformationalVersion from this — none of them should
          set AssemblyVersion itself. Bump the third number for a bug fix, the second for a new
          capability that does not break an existing contract, the first for one that does. -->
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -916,6 +916,11 @@ namespace TallaEgg.TelegramBot.Infrastructure
     {
         private static readonly Dictionary<string, string[]> Notes = new()
         {
+            ["1.2.0"] = new[]
+            {
+                "ساخت مطمئن‌تر کیف‌پول‌ها هنگام ثبت‌نام",
+                "رفع چند خطای داخلی در ارتباط میان سرویس‌ها",
+            },
             ["1.1.0"] = new[]
             {
                 "امکان معامله سکه تمام بهار آزادی و بیت‌کوین، علاوه بر طلای آبشده",

--- a/tests/TallaEgg.AllServices.Tests/ReleaseNoteCoverageTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ReleaseNoteCoverageTests.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+using TallaEgg.TelegramBot.Infrastructure;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That the version in <c>Directory.Build.props</c> has an entry in <see cref="ReleaseNotes"/>.
+/// </summary>
+/// <remarks>
+/// Raising <c>VersionPrefix</c> is what makes <c>BotHandler.NotifyUpdateToAllUsers</c> treat the
+/// next startup as an update and broadcast to every registered user. With no entry for the new
+/// number, <see cref="ReleaseNotes.GetSummaryFor"/> returns an empty string and all of them get
+/// an "updated" push with no changelog in it — which is what the class's own doc comment tells
+/// the next person to avoid.
+///
+/// <para>
+/// That was caught by review on #219 and would not have been caught by anything else: the bump
+/// and the missing entry are in different files, the build does not connect them, and nothing
+/// fails until real users are already being messaged. It is a two-line omission with an
+/// unrecallable consequence, so it is asserted rather than remembered.
+/// </para>
+/// </remarks>
+public class ReleaseNoteCoverageTests
+{
+    [Fact]
+    public void TheCurrentVersion_HasSomethingToTellUsersAboutIt()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+
+        var props = File.ReadAllText(Path.Combine(directory.FullName, "Directory.Build.props"));
+        var match = Regex.Match(props, @"<VersionPrefix>(?<version>[^<]+)</VersionPrefix>");
+
+        Assert.True(match.Success, "Directory.Build.props declares no VersionPrefix.");
+
+        // IVersionService.GetCurrentVersion builds its key the same way — "Major.Minor.Build" —
+        // so the entry has to be keyed by exactly the string VersionPrefix holds.
+        var version = match.Groups["version"].Value.Trim();
+
+        Assert.False(
+            string.IsNullOrEmpty(ReleaseNotes.GetSummaryFor(version)),
+            $"Version {version} has no entry in ReleaseNotes, so deploying it would send every "
+            + "registered user an update message with an empty changelog.");
+    }
+}


### PR DESCRIPTION
## Description
Six changes have merged since `v1.1.0` and none raised `VersionPrefix`, so `main` still builds
assemblies reporting `1.1.0`. This bumps it to `1.2.0` and adds the bot release-note entry the
bump requires. The `v1.2.0` tag and the GitHub release are cut from `main` after merge, per the
tag-on-`main` rule in §11.

## Linked Task / Finding
No issue — this is the release step itself (`docs/process/STANDARDS.md` §11, "Cutting a release").

## Type
- [x] Chore (release)

## Why MINOR and not PATCH
`1.2.0`, not `1.1.1`. Five of the six changes are fixes or documentation, but #220 added a
capability — `GET /version` and the startup version log line — and §11 reserves MINOR for exactly
that: a new capability that breaks no existing contract.

What landed since `v1.1.0`:

| PR | Issue | |
|---|---|---|
| #220 | #218 | `GET /version` and a startup log line reporting the running build — **the capability** |
| #221 | #214 | Two clients used their injected `HttpClient`; the API-key guard moved to startup |
| #222 | #210 | `CreateDefaultWalletsAsync` reports the stored rows and stops flattening every failure |
| #224 | #223 | A wallet insert that lost the duplicate race is detached instead of left in the context |
| #225 | #200 | Two comments presented `Matching:MarketMakerUserId` as a deployment step; no code reads it |
| #226 | #191 | Every Wallet/Users endpoint described, and three removed that could not be |

#226 removes three endpoints (`/api/user/validate-invitation`, `/api/user/register-with-invitation`,
`/api/wallet/increaseBalance`). That is not MAJOR under §11: MAJOR is for breaking a contract
something else depends on, and this platform has no external consumer — it is a bot and its own
backend.

## Changes
- `<VersionPrefix>` 1.1.0 → 1.2.0 in `Directory.Build.props`, the one place it lives (#217).
- **`ReleaseNotes["1.2.0"]`** in the bot's `Constants.cs`. Raising `VersionPrefix` is what makes
  `BotHandler.NotifyUpdateToAllUsers` treat the next startup as an update and broadcast to every
  registered user; with no entry for the new number, `GetSummaryFor` returns an empty string and
  they all get an "updated" push with no changelog. The two lines describe what changed for a
  customer this round — wallet creation at registration (#210, #223) and a set of internal call
  failures (#214) — rather than restating 1.1.0's, which users have already been sent.

  ```
  🚀 ربات به نسخه جدید آپدیت شد!

  نسخه فعلی: 1.2.0

  🔹 مهم‌ترین تغییرات:
  • ساخت مطمئن‌تر کیف‌پول‌ها هنگام ثبت‌نام
  • رفع چند خطای داخلی در ارتباط میان سرویس‌ها

  اگر پیشنهاد یا مشکلی داشتید، لطفاً به ما اطلاع دهید 🙏
  ```

## One addition beyond the bump — say so if it should be its own PR
**`ReleaseNoteCoverageTests`** reads `VersionPrefix` out of `Directory.Build.props` and fails when
`ReleaseNotes` has no entry for it. The empty-changelog broadcast was caught by review on #219,
and nothing else would have caught it: the two files are unrelated as far as the build is
concerned, and the first sign of the mistake is real users receiving an empty announcement. It is
a two-line omission with an unrecallable consequence, so it seemed worth pinning in the PR that
does the bump rather than filing it and moving on. Easy to drop if you would rather it were
separate.

It was verified to actually fail, not just to pass — `VersionPrefix` was pointed at `9.9.9` and
the test reported:
```
Version 9.9.9 has no entry in ReleaseNotes, so deploying it would send every registered user an
update message with an empty changelog.
Failed! - Failed: 1, Passed: 0
```

## Testing

### Build and DLL metadata — read, not assumed (§11 step 3)
```
dotnet build TallaEgg.sln --no-incremental
Build succeeded. 0 Warning(s) 0 Error(s)
```
`AssemblyName.GetAssemblyName(...)` / `FileVersionInfo.GetVersionInfo(...)` on all five assemblies:
```
Users.Api.dll                             AssemblyVersion 1.2.0.0  FileVersion 1.2.0.0  InformationalVersion 1.2.0+5a9b36d6af50f746b8f1284f174ea5f552f158b5
Wallet.Api.dll                            AssemblyVersion 1.2.0.0  FileVersion 1.2.0.0  InformationalVersion 1.2.0+5a9b36d6af50f746b8f1284f174ea5f552f158b5
Orders.Api.dll                            AssemblyVersion 1.2.0.0  FileVersion 1.2.0.0  InformationalVersion 1.2.0+5a9b36d6af50f746b8f1284f174ea5f552f158b5
Affiliate.Api.dll                         AssemblyVersion 1.2.0.0  FileVersion 1.2.0.0  InformationalVersion 1.2.0+5a9b36d6af50f746b8f1284f174ea5f552f158b5
TallaEgg.TelegramBot.Infrastructure.dll   AssemblyVersion 1.2.0.0  FileVersion 1.2.0.0  InformationalVersion 1.2.0+5a9b36d6af50f746b8f1284f174ea5f552f158b5
```

### Unit tests
```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 837, Skipped: 0, Total: 837     (836 before the new test)
```

### End-to-end (`driver.ps1`, 2026-09-04)
```
driver.ps1 start   -> All services up after 2s.
driver.ps1 smoke   -> === Done in 00:00:07.01. Registered 5 (4 approved), trades attempted 10, errors 0 ===
                      Filled trades by symbol: BTC/IRT 4, MAUA/IRT 3, SEKE_BAHAR/IRT 3
                      Simulation completed with errors 0; 10 settlement(s) completed, no new failures.
```
`/version` on the running services reported the new number, which is the bump proving itself
through #220's own endpoint:
```
port 5136 (Users)   -> version=1.2.0 commit=5a9b36d6af50f746b8f1284f174ea5f552f158b5
port 60933 (Wallet) -> version=1.2.0 commit=5a9b36d6af50f746b8f1284f174ea5f552f158b5
port 5140 (Orders)  -> version=1.2.0 commit=5a9b36d6af50f746b8f1284f174ea5f552f158b5
```
The bot was not started: doing so broadcasts the announcement above to every registered user, and
that is a deployment decision, not a test.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Follows naming conventions (STANDARDS.md)
- [x] Tests added in `tests/TallaEgg.AllServices.Tests`
- [x] Docs updated — none needed; §11 already documents the procedure this follows
- [ ] Peer reviewed

## Deployment Notes
No migration, no config change, no feature flag. **One thing to plan for:** the first startup on
1.2.0 sends every registered user the message quoted above. To deploy without it — a staged
rollout, or an off-hours deploy — set `BOT_SUPPRESS_STARTUP_ANNOUNCEMENT=1` on the bot service;
the announced version is only recorded after a broadcast, so a later restart without the variable
still sends it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
