### PR TITLE
[Hotfix][Critical] Depend on the SQL Server service so the stack survives a reboot — issue #228

### DIFF
--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -49,11 +49,14 @@ neither belongs in a deployment. Decision recorded on
 
    The three APIs are also made dependent on the local SQL Server service, so Windows cannot start
    them before the database (see Start order below). The default is SQL Server Express's
-   `MSSQL$SQLEXPRESS`; for any other instance pass `-SqlServiceName`, **in single quotes** — in a
-   double-quoted PowerShell string everything after the `$` is read as a variable name and the
-   dependency silently becomes `MSSQL`. Pass `-SqlServiceName ''` if the database is not a service
-   on this machine. The script fails up front if the name does not resolve, rather than leaving a
-   service that cannot start.
+   `MSSQL$SQLEXPRESS`; for any other instance pass `-SqlServiceName`, and note that **any name
+   containing `$` must be in single quotes** — in a double-quoted PowerShell string everything
+   after the `$` is read as a variable name and the dependency silently becomes `MSSQL`. A default
+   instance (`MSSQLSERVER`) has no `$` and is unaffected. Pass `-SqlServiceName ''` if the database
+   is not a service on this machine. It has to be the instance the connection strings in
+   `config\appsettings.global.json` actually use; nothing reconciles the two. The script rejects a
+   name that does not resolve exactly, and one belonging to a disabled service, rather than leaving
+   services that can never start.
 
 ## Redeploying a new version
 
@@ -64,6 +67,11 @@ neither belongs in a deployment. Decision recorded on
 
 `install-services.ps1` stops and recreates each service, so re-running it is the redeploy step —
 there's no separate update path to remember.
+
+Add `-SqlServiceName` if this host's SQL Server service is not Express's default
+`MSSQL$SQLEXPRESS` (see the one-time setup above). Since #228 the script resolves that name before
+it creates anything, so on such a host the redeploy now stops with an error rather than installing
+services that cannot start.
 
 ## Which build is running (issue #218)
 
@@ -133,8 +141,15 @@ the bot starts last.
 
 *Running* means the dependency's process started and reported ready. Nothing more. For SQL Server
 it does **not** mean the instance is accepting connections yet; for an API it does not mean its own
-migration or first outbound call has finished. A dependent can still log a handful of connection
-retries in the first seconds after boot — that's expected, and restart-on-crash absorbs it.
+migration or first outbound call has finished.
+
+**Do not expect the services to ride that out.** No `DbContext` here configures
+`EnableRetryOnFailure`, so the first failed connection throws straight out of `MigrateAsync()` and
+the process dies before the host ever starts. And restart-on-crash does not rescue the ones behind
+it: the `sc.exe failure` actions run when a service's own process terminates, so a service the SCM
+never launched — because its declared dependency failed — takes no recovery action at all and
+simply stays `Stopped`. That is why one service dying at boot took all four down in #228, and it is
+still how it would fail if the database is `Running` but not yet answering.
 
 So the dependency narrows the window, it does not close it. Closing it means the services waiting
 for their database instead of trusting Windows' start order, which is application code and is
@@ -148,7 +163,23 @@ start timeout, not a recovery.
 `install-services.ps1` only writes the dependency list when it creates a service, so an existing
 install keeps whatever it was given at install time. Either re-run the installer (it stops,
 deletes and recreates all four — the redeploy step above), or, with no downtime at all, set the
-three dependency lists directly from an elevated PowerShell session:
+three dependency lists directly.
+
+**First, confirm what the SQL Server service on this host is actually called.** sc.exe accepts a
+dependency on a service that does not exist and only fails at the *next boot*, so a wrong name here
+converts an intermittent outage into a permanent one. From an elevated PowerShell session:
+
+```powershell
+Get-Service -Name 'MSSQL*' | Format-Table Name, Status, StartType -AutoSize
+```
+
+`MSSQL$SQLEXPRESS` is SQL Server Express's default and is what these services expect; a default
+full instance is `MSSQLSERVER`, a named one `MSSQL$<INSTANCE>`. It has to be the instance the
+connection strings in `config\appsettings.global.json` actually point at — the two are configured
+separately and nothing reconciles them. If the database is not a service on this machine, stop
+here: the ordering cannot be expressed as an SCM dependency at all.
+
+Then, substituting that name for `MSSQL$SQLEXPRESS` if it differs:
 
 ```powershell
 sc.exe config TallaEggWalletApi depend= 'MSSQL$SQLEXPRESS/'
@@ -156,21 +187,32 @@ sc.exe config TallaEggUsersApi  depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
 sc.exe config TallaEggOrdersApi depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
 ```
 
-Three things to get right:
+Four things to get right:
 
-- **The single quotes are mandatory.** Unquoted or double-quoted, PowerShell expands
-  `$SQLEXPRESS` as an undefined variable, sc.exe receives `MSSQL/`, and the services then fail to
-  start with error 1075 (dependent service does not exist) — a worse outage than the one being
-  fixed.
+- **A name containing `$` must be in single quotes.** Double-quoted or unquoted, PowerShell reads
+  `$SQLEXPRESS` as an undefined variable and drops it: sc.exe receives `MSSQL/` from the first line
+  and `MSSQL/TallaEggWalletApi/` from the other two. All three services then fail at the next boot
+  with error 1075 — *the dependency service does not exist or has been marked for deletion* —
+  which is a worse outage than the one being fixed. (`MSSQLSERVER` has no `$` and is unaffected,
+  but quoting it costs nothing.)
 - **`depend=` replaces the whole list**, it does not append. That is why `TallaEggWalletApi` is
   repeated in the second and third lines.
 - **The space after `depend=` is part of sc.exe's syntax**, not a typo.
+- **Read each command's output.** sc.exe reports failure through its exit code, which PowerShell
+  will not raise as an error for you.
 
 `TallaEggBot` is unchanged: it opens no database and already depends on all three APIs.
 
-Nothing needs restarting for this to take effect — a dependency list is read when a service is
-next started, and the point of the change is what happens at the next boot. Confirm it landed with
-`sc.exe qc TallaEggWalletApi`, which should list `DEPENDENCIES : MSSQL$SQLEXPRESS`.
+Nothing needs restarting for this to take effect — a dependency list is read when a service is next
+started, and the point of the change is what happens at the next boot. Confirm it landed on all
+three:
+
+```powershell
+'TallaEggWalletApi','TallaEggUsersApi','TallaEggOrdersApi' | ForEach-Object { sc.exe qc $_ }
+```
+
+Each should show a `DEPENDENCIES` line naming the SQL service in full. A line reading `MSSQL` on
+its own is the quoting mistake above — fix it before rebooting.
 
 ## Logs
 

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -47,6 +47,14 @@ neither belongs in a deployment. Decision recorded on
    flag for this, so there is no other native way to hand a Windows service its own environment
    variables.
 
+   The three APIs are also made dependent on the local SQL Server service, so Windows cannot start
+   them before the database (see Start order below). The default is SQL Server Express's
+   `MSSQL$SQLEXPRESS`; for any other instance pass `-SqlServiceName`, **in single quotes** — in a
+   double-quoted PowerShell string everything after the `$` is read as a variable name and the
+   dependency silently becomes `MSSQL`. Pass `-SqlServiceName ''` if the database is not a service
+   on this machine. The script fails up front if the name does not resolve, rather than leaving a
+   service that cannot start.
+
 ## Redeploying a new version
 
 ```powershell
@@ -84,17 +92,85 @@ working tree.
 
 ## Start order — what's covered and what isn't
 
-`Orders.Api` and `Users.Api` call `Wallet.Api` on startup paths, and all three run
-`Database.MigrateAsync()` as the first thing they do. The service dependency graph
-(`Wallet.Api` before `Users.Api`/`Orders.Api`, all three before the bot) makes Windows wait for
-each dependency to reach the *Running* state first, which absorbs most of the simultaneous-boot
-noise the issue warns about.
+Two orderings decide whether this deployment comes back after a reboot. Before
+[#228](https://github.com/MohKardan/TallaEgg/issues/228) only the second one was declared, and the
+first is the one that mattered.
 
-What it does **not** guarantee: "Running" means the process started, not that its own migration
-or first outbound call has finished. A dependent service can still log a handful of connection
-retries in the first few seconds after boot. That's expected — restart-on-crash absorbs it — but
-if it's ever not just noise, tighten this with an explicit `Start-Sleep` between dependency tiers
-in `install-services.ps1` rather than assuming SCM ordering alone is sufficient.
+### Against the database
+
+`Wallet.Api`, `Users.Api` and `Orders.Api` each run `Database.MigrateAsync()` before their host
+starts, so none of them can get anywhere before SQL Server is up. **SQL Server Express installs
+itself as *delayed* auto-start** — its own default, roughly two minutes after boot. The four
+TallaEgg services were ordinary auto-start and declared no dependency on it, so at every
+unattended boot they ran first, blocked in `MigrateAsync()` against a database that was not
+listening, and the SCM killed `Wallet.Api` at its 45-second start timeout. The other three then
+failed on the dependency they declare on `Wallet.Api`, and nothing was running until a person
+logged in. That is #228, and it made every reboot an outage.
+
+`install-services.ps1` now names the SQL Server service in the dependency list of all three APIs
+(`-SqlServiceName`, default `MSSQL$SQLEXPRESS`). Windows permits an auto-start service to depend
+on a delayed auto-start one, and the SCM then has to start the delayed service at boot rather than
+after the delay — so declaring the dependency both orders the start *and* pulls SQL Server forward
+into the boot-time pass. From
+[SERVICE_DELAYED_AUTO_START_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_delayed_auto_start_info),
+Remarks:
+
+> An auto-start service can depend on a delayed auto-start service, but this is not generally
+> desirable as the SCM must start the dependent delayed auto-start service at boot.
+
+"Not generally desirable" there is about boot-time performance, which is the trade this machine
+wants: it exists to run these four services, and two minutes of downtime per reboot buys nothing.
+
+The bot is not given the dependency — it opens no database of its own, and it already waits on all
+three APIs.
+
+### Against each other
+
+`Orders.Api` and `Users.Api` call `Wallet.Api` on startup paths, so `Wallet.Api` starts first and
+the bot starts last.
+
+### What neither ordering buys
+
+*Running* means the dependency's process started and reported ready. Nothing more. For SQL Server
+it does **not** mean the instance is accepting connections yet; for an API it does not mean its own
+migration or first outbound call has finished. A dependent can still log a handful of connection
+retries in the first seconds after boot — that's expected, and restart-on-crash absorbs it.
+
+So the dependency narrows the window, it does not close it. Closing it means the services waiting
+for their database instead of trusting Windows' start order, which is application code and is
+tracked separately in [#230](https://github.com/MohKardan/TallaEgg/issues/230). Note the trap
+recorded there: retrying around `MigrateAsync()` where it currently stands would make this *worse*,
+because that code runs before the host connects to the SCM and a longer wait there is a longer
+start timeout, not a recovery.
+
+### Applying this to a machine installed before #228
+
+`install-services.ps1` only writes the dependency list when it creates a service, so an existing
+install keeps whatever it was given at install time. Either re-run the installer (it stops,
+deletes and recreates all four — the redeploy step above), or, with no downtime at all, set the
+three dependency lists directly from an elevated PowerShell session:
+
+```powershell
+sc.exe config TallaEggWalletApi depend= 'MSSQL$SQLEXPRESS/'
+sc.exe config TallaEggUsersApi  depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
+sc.exe config TallaEggOrdersApi depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
+```
+
+Three things to get right:
+
+- **The single quotes are mandatory.** Unquoted or double-quoted, PowerShell expands
+  `$SQLEXPRESS` as an undefined variable, sc.exe receives `MSSQL/`, and the services then fail to
+  start with error 1075 (dependent service does not exist) — a worse outage than the one being
+  fixed.
+- **`depend=` replaces the whole list**, it does not append. That is why `TallaEggWalletApi` is
+  repeated in the second and third lines.
+- **The space after `depend=` is part of sc.exe's syntax**, not a typo.
+
+`TallaEggBot` is unchanged: it opens no database and already depends on all three APIs.
+
+Nothing needs restarting for this to take effect — a dependency list is read when a service is
+next started, and the point of the change is what happens at the next boot. Confirm it landed with
+`sc.exe qc TallaEggWalletApi`, which should list `DEPENDENCIES : MSSQL$SQLEXPRESS`.
 
 ## Logs
 

--- a/scripts/windows-services/install-services.ps1
+++ b/scripts/windows-services/install-services.ps1
@@ -31,10 +31,12 @@
     .\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString)
 
 .EXAMPLE
-    Against a full SQL Server instance rather than Express. Quote the name in single quotes, or
-    PowerShell expands anything after the $ as a variable:
+    Against a named instance. Any service name containing a $ must be in SINGLE quotes: in a
+    double-quoted PowerShell string, $TALLAEGG below is read as an undefined variable and the
+    dependency silently becomes "MSSQL". A default instance ("MSSQLSERVER") has no $ and is not
+    affected, but single quotes are harmless there and worth the habit.
 
-    .\install-services.ps1 -TallaEggApiKey (Read-Host -AsSecureString) -SqlServiceName 'MSSQLSERVER'
+    .\install-services.ps1 -TallaEggApiKey (Read-Host -AsSecureString) -SqlServiceName 'MSSQL$TALLAEGG'
 
 .NOTES
     Run as Administrator. Re-running is safe: existing services are stopped and deleted first,
@@ -63,21 +65,36 @@ if (-not (Test-Path $configPath)) {
     throw "Missing $configPath. Create it from config\appsettings.global.example.json with production values before installing services."
 }
 
-$plainApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
-    [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($TallaEggApiKey))
-
-# sc.exe accepts a dependency on a service that does not exist and only fails at start time, with
-# a bare "error 1075" on the next boot. Resolve the name now, while there is someone to read it.
+# Resolve the database dependency before anything is created, and before the API key is
+# decrypted below — sc.exe accepts a dependency on a service that cannot start and only fails at
+# start time, as a bare error 1075 or 1058 on the next boot, with nobody watching.
 $sqlDependency = @()
 if ($SqlServiceName) {
-    if (-not (Get-Service -Name $SqlServiceName -ErrorAction SilentlyContinue)) {
-        throw ("No Windows service named '$SqlServiceName' on this machine. " +
+    # Get-Service -Name matches wildcards, so a value like 'MSSQL*' would satisfy a bare existence
+    # test and then be written verbatim as a dependency on a service literally named "MSSQL*".
+    # Require an exact name.
+    $sqlService = Get-Service -Name $SqlServiceName -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -eq $SqlServiceName }
+    if (-not $sqlService) {
+        throw ("No Windows service named exactly '$SqlServiceName' on this machine. " +
                "List the local SQL Server services with: Get-Service -Name 'MSSQL*' " +
-               "and pass the right one as -SqlServiceName, " +
-               "or pass -SqlServiceName '' if the database is not hosted here.")
+               "then pass one of the names it prints as -SqlServiceName " +
+               "(a wildcard is not a service name), " +
+               "or pass -SqlServiceName '' if the database is not hosted on this machine.")
+    }
+    # A disabled instance still resolves. Depending on one would stop all three APIs from ever
+    # starting, which is a worse outage than the one this dependency exists to fix. SQL Express
+    # gets installed and disabled by other products, so this is not hypothetical.
+    if ($sqlService.StartType -eq 'Disabled') {
+        throw ("The '$SqlServiceName' service is disabled, so nothing that depends on it can " +
+               "start. Enable it, or pass the instance the connection strings actually use as " +
+               "-SqlServiceName, or -SqlServiceName '' if the database is not hosted here.")
     }
     $sqlDependency = @($SqlServiceName)
 }
+
+$plainApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+    [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($TallaEggApiKey))
 
 # Two orderings decide whether this deployment survives a reboot, and only the second was
 # declared before issue #228.
@@ -130,7 +147,14 @@ foreach ($svc in $services) {
 
     if ($svc.DependsOn.Count -gt 0) {
         $dependString = ($svc.DependsOn -join "/") + "/"
-        sc.exe config $svc.Name depend= $dependString | Out-Null
+        # $ErrorActionPreference does not cover a native exit code, and this one write is the
+        # whole of issue #228's fix: swallowing a failure here means rebooting straight back into
+        # the outage while the script reports success.
+        $configOutput = sc.exe config $svc.Name depend= $dependString
+        if ($LASTEXITCODE -ne 0) {
+            throw ("Could not set the dependency list for $($svc.Name) " +
+                   "(sc.exe exit $LASTEXITCODE): $configOutput")
+        }
     }
 
     # Native services have no ASPNETCORE_ENVIRONMENT/TALLAEGG_API_KEY unless set here — sc.exe

--- a/scripts/windows-services/install-services.ps1
+++ b/scripts/windows-services/install-services.ps1
@@ -21,8 +21,20 @@
     The shared inter-service API key (see README's "Shared API key" section). Required — every
     service throws at startup in Production if this is missing, by design (issue #33).
 
+.PARAMETER SqlServiceName
+    Name of the local SQL Server service the three APIs migrate against, added to their SCM
+    dependency list so they cannot start before the database (issue #228). Defaults to SQL Server
+    Express's own default instance service. Pass an empty string when the database is not a
+    service on this machine.
+
 .EXAMPLE
     .\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString)
+
+.EXAMPLE
+    Against a full SQL Server instance rather than Express. Quote the name in single quotes, or
+    PowerShell expands anything after the $ as a variable:
+
+    .\install-services.ps1 -TallaEggApiKey (Read-Host -AsSecureString) -SqlServiceName 'MSSQLSERVER'
 
 .NOTES
     Run as Administrator. Re-running is safe: existing services are stopped and deleted first,
@@ -33,7 +45,11 @@ param(
     [string]$InstallRoot = "C:\TallaEgg",
 
     [Parameter(Mandatory = $true)]
-    [Security.SecureString]$TallaEggApiKey
+    [Security.SecureString]$TallaEggApiKey,
+
+    # Single-quoted on purpose: in a double-quoted string PowerShell reads $SQLEXPRESS as an
+    # undefined variable and silently hands sc.exe the name "MSSQL".
+    [string]$SqlServiceName = 'MSSQL$SQLEXPRESS'
 )
 
 $ErrorActionPreference = "Stop"
@@ -50,15 +66,41 @@ if (-not (Test-Path $configPath)) {
 $plainApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
     [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($TallaEggApiKey))
 
-# Order matters for the -DependsOn column: Orders.Api and Users.Api call Wallet.Api on startup
-# paths, and all three run MigrateAsync() as the first thing they do. sc.exe's service
-# dependency only guarantees the dependency reached "Running" before this one starts — not that
-# its own startup work (migration, first HTTP call) has finished — so this absorbs most of the
-# ordering risk the issue calls out, not all of it. See the runbook for the residual case.
+# sc.exe accepts a dependency on a service that does not exist and only fails at start time, with
+# a bare "error 1075" on the next boot. Resolve the name now, while there is someone to read it.
+$sqlDependency = @()
+if ($SqlServiceName) {
+    if (-not (Get-Service -Name $SqlServiceName -ErrorAction SilentlyContinue)) {
+        throw ("No Windows service named '$SqlServiceName' on this machine. " +
+               "List the local SQL Server services with: Get-Service -Name 'MSSQL*' " +
+               "and pass the right one as -SqlServiceName, " +
+               "or pass -SqlServiceName '' if the database is not hosted here.")
+    }
+    $sqlDependency = @($SqlServiceName)
+}
+
+# Two orderings decide whether this deployment survives a reboot, and only the second was
+# declared before issue #228.
+#
+# Against the database: Wallet.Api, Users.Api and Orders.Api each run MigrateAsync() before they
+# report Running, and SQL Server Express installs itself as *delayed* auto-start, roughly two
+# minutes after boot. Ordinary auto-start services therefore ran first, blocked in MigrateAsync()
+# against a database that was not listening, and the SCM killed them at its 45-second start
+# timeout. Naming the SQL service here fixes the order: an auto-start service is allowed to depend
+# on a delayed auto-start one, and the SCM then has to start the delayed service at boot instead
+# of after the delay (SERVICE_DELAYED_AUTO_START_INFO, Remarks).
+#
+# Against each other: Orders.Api and Users.Api call Wallet.Api on startup paths, so Wallet.Api
+# goes first and the bot, which opens no database of its own, goes last.
+#
+# Neither ordering waits for readiness. "Running" means the dependency's process started and
+# reported ready — for SQL Server, not that the instance accepts connections yet; for an API, not
+# that its own migration or first HTTP call has finished. This narrows the window rather than
+# closing it. See the runbook for the residual case.
 $services = @(
-    @{ Name = "TallaEggWalletApi"; Publish = "Wallet.Api";  Exe = "Wallet.Api.exe";                          DependsOn = @() }
-    @{ Name = "TallaEggUsersApi";  Publish = "Users.Api";   Exe = "Users.Api.exe";                           DependsOn = @("TallaEggWalletApi") }
-    @{ Name = "TallaEggOrdersApi"; Publish = "Orders.Api";  Exe = "Orders.Api.exe";                          DependsOn = @("TallaEggWalletApi") }
+    @{ Name = "TallaEggWalletApi"; Publish = "Wallet.Api";  Exe = "Wallet.Api.exe";                          DependsOn = $sqlDependency }
+    @{ Name = "TallaEggUsersApi";  Publish = "Users.Api";   Exe = "Users.Api.exe";                           DependsOn = $sqlDependency + @("TallaEggWalletApi") }
+    @{ Name = "TallaEggOrdersApi"; Publish = "Orders.Api";  Exe = "Orders.Api.exe";                          DependsOn = $sqlDependency + @("TallaEggWalletApi") }
     @{ Name = "TallaEggBot";       Publish = "Bot";         Exe = "TallaEgg.TelegramBot.Infrastructure.exe"; DependsOn = @("TallaEggWalletApi", "TallaEggUsersApi", "TallaEggOrdersApi") }
 )
 


### PR DESCRIPTION
**Branch Name**: `hotfix/boot-order-sql-dependency`
**Linked Issue**: closes #228

---

## Description

Every unattended reboot took the demo down. SQL Server Express installs itself as *delayed*
auto-start; the four TallaEgg services were ordinary auto-start and declared no dependency on it,
so they ran roughly two minutes ahead of the database, blocked in `Database.MigrateAsync()`, and
the SCM killed `Wallet.Api` at its 45-second start timeout — taking the other three down with it
on the dependency they declare.

This names the SQL Server service as an SCM dependency of the three APIs that migrate, and
rewrites the runbook claim that reality had already falsified.

---

## Type of Change

- [x] Hotfix (urgent bug fix)
- [x] Documentation (the runbook half)

---

## The assumption the issue asked to settle first

> Worth confirming that an SCM dependency on a delayed-auto-start service actually defers the
> dependent rather than failing it outright; if it does not, the fallback is marking the four
> services delayed-auto-start too.

**It defers — and does more than defer. Microsoft documents this explicitly**, in
[SERVICE_DELAYED_AUTO_START_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_delayed_auto_start_info),
Remarks:

> A delayed auto-start service cannot be a member of a load ordering group. It can depend on
> another auto-start service. **An auto-start service can depend on a delayed auto-start service,
> but this is not generally desirable as the SCM must start the dependent delayed auto-start
> service at boot.**

The last clause is the whole answer. Declaring the dependency does not merely make `Wallet.Api`
wait — it obliges the SCM to start SQL Server *during the boot-time pass* instead of after the
delay. The delay is not respected-and-waited-out; it is negated for that service.

[Automatically Starting Services](https://learn.microsoft.com/en-us/windows/win32/services/automatically-starting-services)
states the general rule that this is a special case of:

> During system boot, the SCM starts all auto-start services **and the services on which they
> depend**. For example, if an auto-start service depends on a demand-start service, the
> demand-start service is also started automatically.

Nothing in either page describes a dependent being failed because its dependency is delayed. The
only documented failure mode for a dependency is one that cannot start at all.

"Not generally desirable" is a boot-performance caveat — it gives back the boot speedup that
delayed start exists to provide. That is the correct trade here: the machine exists to run these
four services, and two minutes of downtime per reboot buys nothing.

**So the fallback is not needed, and on its own would not have worked.** Marking the four services
delayed-auto-start *without* also declaring the dependency fixes nothing: the SCM starts delayed
services "one at a time after the delay has passed, honoring dependencies" — with no dependency
declared there is nothing to honor, and the race just moves later. The dependency is what creates
the ordering, in either arrangement.

### What I could not verify by experiment, and why

The decisive experiment is a reboot of a machine with these services installed — that is the
server, and it is yours. See "Verification I need to run". Locally I have no elevation, so I could
not create throwaway services to reproduce the SCM path. What I did confirm locally, read-only:

- This dev machine has the same `MSSQL$SQLEXPRESS` configuration the issue reports on the VM —
  `Start=2` (Auto) with `DelayedAutoStart=1` — confirming this is SQL Express's own default rather
  than something set on the server:

  ```
  sc.exe qc 'MSSQL$SQLEXPRESS'
        START_TYPE         : 2   AUTO_START  (DELAYED)
  ```

- Scanning every auto-start service on this machine for an existing non-delayed service that
  depends on a delayed one turned up **no instance** — so there was no naturally occurring example
  here to observe either. That is a negative result, and it is why this rests on the documentation
  citation rather than on an observation.

---

## Changes Made

- `install-services.ps1`: the SQL Server service is added to `DependsOn` for `TallaEggWalletApi`,
  `TallaEggUsersApi` and `TallaEggOrdersApi`.
- New `-SqlServiceName` parameter, default `MSSQL$SQLEXPRESS`, so a non-Express instance is a
  parameter rather than an edit, and `-SqlServiceName ''` opts out when the database is not a
  service on the box.
- The script resolves that name **before creating any service, and before the API key is
  decrypted**, and throws with guidance if it does not resolve *exactly* (`Get-Service -Name`
  matches wildcards, so a pasted `MSSQL*` would otherwise pass) or if the service it names is
  disabled. Without this the change could make things strictly worse: `sc.exe` accepts a dependency
  on a service that cannot start and only fails at *start* time, as a bare error 1075 or 1058 on
  the next boot.
- The `sc.exe config ... depend=` write is checked for a non-zero exit code.
  `$ErrorActionPreference = "Stop"` does not cover native exit codes, and this one write is the
  entire payload of the fix — swallowing a failure would report success and reboot straight back
  into the outage.
- The comment at lines 53–57 is replaced. It described the API-to-API ordering as absorbing "most
  of the ordering risk"; it was silent on the database, which was all of the risk.
- `docs/operations/WINDOWS_DEPLOYMENT.md`: the "Start order" section is rewritten — the two
  orderings separated, the documented SCM behavior quoted, the residual readiness gap kept, and a
  new subsection giving the exact commands for a machine installed before this change.

### Two deliberate departures from the issue's stated fix shape

1. **The dependency goes on all three APIs, not only `Wallet.Api`.** `Wallet.Api` alone is enough
   to fix the observed boot cascade, since the other two reach the database transitively through
   it. But all three call `MigrateAsync()` before their host starts (`Wallet.Api:162`,
   `Users.Api:205`, `Orders.Api:257`), so all three genuinely depend on the database. Declaring it
   on one and relying on a chain that exists for an unrelated reason would break silently the day
   someone edits the graph — and it would not help an operator running `Start-Service
   TallaEggUsersApi` by hand with SQL stopped. One array element each.
2. **`TallaEggBot` is not given the dependency.** It opens no database — confirmed, no
   `AddDbContext` and no `MigrateAsync` anywhere in it — and it already waits on all three APIs.

---

## Testing Completed

### These tests prove nothing about this change — stated plainly

This PR contains **no product code**. The solution builds and the suite passes exactly as they did
before, because nothing they cover was touched. Green CI here means "this change did not break the
build", not "the fix works". The evidence for the fix is the documentation quoted above; the proof
is a reboot, which I cannot perform.

```
dotnet build TallaEgg.sln
Build succeeded.  0 Warning(s)  0 Error(s)

dotnet test TallaEgg.sln --no-build
Passed! - Failed: 0, Passed: 837, Skipped: 0, Total: 837

bash scripts/check-doc-paths.sh
395 tracked text file(s) checked, every reference resolves.
```

### What I *could* test about the script itself

**Syntax** — parsed clean by both the PowerShell AST parser and the tokenizer:

```
Parse: OK, 0 errors
Tokenize: OK, 0 errors
```

**Dependency-list logic** — rather than re-typing the table into a test, I pulled the three real
statements out of the shipped file by AST (`$sqlDependency = @()`, the `if` that validates the
name, and the `$services` table), evaluated them with `Get-Service` stubbed, and applied the file's
own `($_.DependsOn -join "/") + "/"` join. What sc.exe would actually receive:

```
=== default, SQL Express present ===
  TallaEggWalletApi  depend= MSSQL$SQLEXPRESS/
  TallaEggUsersApi   depend= MSSQL$SQLEXPRESS/TallaEggWalletApi/
  TallaEggOrdersApi  depend= MSSQL$SQLEXPRESS/TallaEggWalletApi/
  TallaEggBot        depend= TallaEggWalletApi/TallaEggUsersApi/TallaEggOrdersApi/

=== wildcard pasted in ===
  THREW: No Windows service named exactly 'MSSQL*' on this machine. ... (a wildcard is not a
  service name) ...

=== disabled instance ===
  THREW: The 'MSSQL$SQLEXPRESS' service is disabled, so nothing that depends on it can start. ...

=== name that does not resolve ===
  THREW: No Windows service named exactly 'MSSQL$TYPO' on this machine. ...

=== opt out: -SqlServiceName '' ===
  TallaEggWalletApi  (no dependencies)
  TallaEggUsersApi   depend= TallaEggWalletApi/
  TallaEggOrdersApi  depend= TallaEggWalletApi/
  TallaEggBot        depend= TallaEggWalletApi/TallaEggUsersApi/TallaEggOrdersApi/
```

**The `$` interpolation trap**, verified because it would silently produce a dependency on a
service named `MSSQL` and turn this fix into a worse outage:

```
PS> "MSSQL$SQLEXPRESS/"     # double-quoted
MSSQL/
PS> 'MSSQL$SQLEXPRESS/'     # single-quoted
MSSQL$SQLEXPRESS/
```

Hence the single quotes in the parameter default, in the runbook commands, and a comment saying
why.

**What none of this covered**: the SCM itself. No test here creates a Windows service, sets a real
dependency, or observes a boot. The behavior the fix depends on is asserted by Microsoft's
documentation and confirmed only by your reboot.

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No machine names, addresses, usernames or personal paths in the diff or in this PR
- [x] `config/appsettings.global.json` untouched
- [x] Code compiles without warnings

---

## Documentation

- [x] Runbook updated — it is half of this change, not a footnote to it
- [x] Comments in English, explaining why

---

## Breaking Changes?

- [x] No breaking changes to the product. One operational note: re-running `install-services.ps1`
  on a host whose SQL service is named something other than `MSSQL$SQLEXPRESS` now **fails up
  front** instead of installing services with no database dependency. That is intended — the
  alternative is a silent regression to today's behavior — but such a host now needs
  `-SqlServiceName` on the command line.

---

## Deployment Notes

`install-services.ps1` writes the dependency list only when it *creates* a service, so merging this
changes nothing on a running machine. The commands below are the whole deployment.

**Rollback**: `sc.exe config <service> depend= '<the old list>'` restores the previous state
exactly — `TallaEggWalletApi` had none, the other two had `TallaEggWalletApi/`. No files, data or
processes are involved.

---

## Verification I need to run

I cannot confirm this fix. The only proof is a full server reboot, and the server is yours. Below
is everything needed, in order.

### 1. Confirm the SQL Server service name on that host

From an **elevated PowerShell session** on the server:

```powershell
Get-Service -Name 'MSSQL*' | Format-Table Name, Status, StartType -AutoSize
```

Do not skip this. sc.exe accepts a dependency on a service that does not exist and only fails at
the **next boot**, so a wrong name here turns an intermittent outage into a permanent one. The
issue reports `MSSQL$SQLEXPRESS`, which is SQL Express's default and what step 2 assumes — but
confirm it, and substitute the real name below if it differs. It must also be the instance the
connection strings in `config\appsettings.global.json` point at; nothing reconciles the two.

Expected: `MSSQL$SQLEXPRESS`, `Running`, `Automatic` (the `(DELAYED)` part does not show in
`StartType` — `sc.exe qc 'MSSQL$SQLEXPRESS'` shows it).

### 2. Apply the change (no downtime, no restart)

```powershell
sc.exe config TallaEggWalletApi depend= 'MSSQL$SQLEXPRESS/'
sc.exe config TallaEggUsersApi  depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
sc.exe config TallaEggOrdersApi depend= 'MSSQL$SQLEXPRESS/TallaEggWalletApi/'
```

- **The single quotes are not optional.** Unquoted or double-quoted, PowerShell expands
  `$SQLEXPRESS` as an undefined variable and drops it — sc.exe receives `MSSQL/` from the first
  line and `MSSQL/TallaEggWalletApi/` from the other two. All three then fail at the next boot with
  error 1075 (*the dependency service does not exist or has been marked for deletion*), which is a
  *worse* outage than the current one. Verified above.
- **The space after `depend=` is sc.exe syntax**, not a typo.
- `depend=` **replaces** the list, it does not append — that is why `TallaEggWalletApi` is repeated
  on lines 2 and 3.
- **Read the output of each line.** sc.exe reports failure through its exit code, which PowerShell
  will not raise as an error for you. Each should print `[SC] ChangeServiceConfig SUCCESS`.
- Nothing is stopped or restarted. The demo keeps running; a dependency list is read at next start.

`TallaEggBot` is deliberately left alone.

Then confirm it landed on all three, **before** rebooting:

```powershell
'TallaEggWalletApi','TallaEggUsersApi','TallaEggOrdersApi' | ForEach-Object { sc.exe qc $_ }
```

Expected in each: a `DEPENDENCIES` line naming the SQL service in full. If any shows `MSSQL` on its
own, the quoting went wrong — re-run that line and do not reboot until all three read correctly.

(Re-running `install-services.ps1` achieves the same thing and is the right move at the next
redeploy, but it stops and recreates all four services, so it costs downtime that this does not.)

### 3. Reboot and wait

```powershell
Restart-Computer -Force
```

Wait **five minutes** before judging anything. Two of those are SQL Express's own delay budget —
the dependency should now pull it forward, but the point is not to call it a failure early.

### 4. Exactly what you should see

```powershell
Get-Service 'MSSQL$SQLEXPRESS','TallaEggWalletApi','TallaEggUsersApi','TallaEggOrdersApi','TallaEggBot' |
    Format-Table Status, Name, StartType -AutoSize
```

**Pass** is all five `Running`, with nobody having started anything by hand.

Then the System event log for that boot — this is where the fix shows up as an *absence*:

```powershell
Get-WinEvent -FilterHashtable @{ LogName='System'; ProviderName='Service Control Manager';
    StartTime=(Get-Date).AddMinutes(-10) } |
    Sort-Object TimeCreated | Format-List TimeCreated, Id, LevelDisplayName, Message
```

**None of these should appear:**

- `A timeout was reached (45000 milliseconds) while waiting for the TallaEggWalletApi service to connect.`
- `The TallaEggWalletApi service failed to start due to the following error: The service did not respond to the start or control request in a timely fashion.`
- any `The <service> service depends on the <service> service which failed to start`
- any Event ID 7000, 7009, 7022 or 7031 naming a `TallaEgg*` service

What you *may* see and can ignore: the services starting a minute or more apart, and a few
connection retries in each service's own Serilog file under
`C:\TallaEgg\publish\<Service>\logs\`. Ordering is what changed; instant startup is not.

### 5. If they still do not come up — what to collect

Please capture these before starting anything by hand, and reopen #228 with them:

1. **The dependency lists as the SCM actually holds them.** This separates "the fix did not work"
   from "the fix was not applied":
   ```powershell
   'TallaEggWalletApi','TallaEggUsersApi','TallaEggOrdersApi' | ForEach-Object { sc.exe qc $_ }
   ```
   A `DEPENDENCIES` line reading `MSSQL` rather than `MSSQL$SQLEXPRESS` means step 1's quoting was
   lost — that alone explains the failure.
2. **The whole SCM story for that boot**, not only the errors:
   ```powershell
   Get-WinEvent -FilterHashtable @{ LogName='System'; ProviderName='Service Control Manager' } -MaxEvents 60 |
       Sort-Object TimeCreated | Format-List TimeCreated, Id, Message
   ```
   Two things to read off it: **did `MSSQL$SQLEXPRESS` start before the TallaEgg services** (if
   not, the SCM is not honoring the dependency and my reading of the docs is wrong), and **what
   error each service actually got** — 1075 means the dependency name does not resolve, while a 45s
   connect timeout means it is still the original problem.
3. **Whether SQL was up but not ready** — the distinguishing case, and the one this fix explicitly
   does not cover:
   ```powershell
   Get-WinEvent -FilterHashtable @{ LogName='Application'; ProviderName='MSSQL$SQLEXPRESS' } -MaxEvents 40 |
       Sort-Object TimeCreated | Format-List TimeCreated, Id, Message
   ```
   Look for how long after service start `SQL Server is now ready for client connections` appears.
   If SQL reached `Running` first and the APIs *still* died, then the ordering worked and the
   readiness gap is the cause — that is #230, and this issue's fix is not at fault.
4. **Each service's own log** for that timestamp — `C:\TallaEgg\publish\<Service>\logs\` — which
   distinguishes "killed before it logged anything" from "logged a connection failure".

---

## Related Issues

- Closes #228
- Opens #230 — see below
- Builds on #70 (the services themselves) and #218 (`/version`, for confirming which build is up)

### Step 2: is application-level retry worth it? Yes, and it is not what it looks like

The issue is right that neither fix closes the window: *Running* for SQL Server means the service
started, not that it accepts connections. Microsoft says so on the same page that settles the
question above:

> If a client calls a delayed auto-start service before it is loaded, the call fails. Therefore,
> clients should be prepared to either retry the call or demand start the service.

So yes — worth doing. A service that waits for its database is independent of boot order; a service
that trusts boot order is one Windows Update away from the next incident.

**But the obvious version of it would make things worse, and that is the finding worth recording.**
All three APIs call `MigrateAsync()` between `builder.Build()` and `app.Run()`. With
`UseWindowsService()`, the process connects to the SCM dispatcher inside `app.Run()` — so every
second spent in `MigrateAsync()` is a second before the service has connected at all. Which is
exactly what the event log in #228 says:

```
A timeout was reached (45000 milliseconds) while waiting for the TallaEggWalletApi service to connect.
```

*to connect*, not *to report running*. A retry loop wrapped around `MigrateAsync()` where it stands
would extend precisely the window the SCM is timing — a longer wait, the same kill, a less obvious
cause. The migration has to move off the pre-start path first (an `IHostedService` with bounded
retry), so the host reports `Running` and *then* waits.

Filed as **#230** with that trap written down, since it is the first thing someone would reasonably
try. Not built here, per scope.

---

## Final note on approval

**This PR is merged but not verified.** Local build, tests and script checks are green; none of
them exercises the SCM. Confirmation is the reboot in "Verification I need to run", which only you
can perform. **If the services do not come back after that reboot, #228 should be reopened** — the
change is one `sc.exe config` line per service to revert, and the collection steps above are
written to say why it failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
