### PR TITLE
[Fix] Answer in camelCase like the other two services — issue #229

### DIFF
--- a/.claude/skills/run-tallaegg/SKILL.md
+++ b/.claude/skills/run-tallaegg/SKILL.md
@@ -198,7 +198,7 @@ it. Confirmed via:
 
 ```powershell
 Invoke-RestMethod http://localhost:5140/api/orders/MAUA/IRT/best-prices
-# -> {"Success":true,"Message":"...","Data":{"Symbol":"MAUA/IRT","BestBidPrice":...,"BestAskPrice":...}}
+# -> {"success":true,"message":"...","data":{"symbol":"MAUA/IRT","bestBidPrice":...,"bestAskPrice":...}}
 ```
 
 ## Direct invocation (no bot layer)
@@ -209,7 +209,7 @@ that, skip the Simulator and hit the running API directly — the three Swagger 
 
 ```powershell
 Invoke-RestMethod http://localhost:5140/api/symbols/active
-# -> {"Success":true,"Message":null,"Data":["MAUA/IRT","SEKE_BAHAR/IRT","BTC/IRT"]}
+# -> {"success":true,"message":null,"data":["MAUA/IRT","SEKE_BAHAR/IRT","BTC/IRT"]}
 ```
 
 ## Run (human path)

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -213,17 +213,24 @@ builder.Services.AddScoped<Orders.Core.IReferencePriceProvider>(sp => new Orders
 builder.Services.AddScoped<Orders.Application.Services.ReferencePriceProviderChain>();
 builder.Services.AddHostedService<Orders.Application.Services.AutoQuotePublisherService>();
 
-// Read request bodies case-insensitively, but write responses in the ASP.NET Core default
-// camelCase — the same shape Wallet.Api and Users.Api produce, neither of which configures
-// anything here. Until #229 this block also set PropertyNamingPolicy = null, which made this one
-// service answer in PascalCase; every caller happened to deserialize case-insensitively, so the
-// divergence stayed invisible. Do not set PropertyNamingPolicy again: a browser client (#97)
+// Leave PropertyNamingPolicy alone. The ASP.NET Core default is camelCase, which is what
+// Wallet.Api and Users.Api produce by configuring nothing at all. Until #229 this block set it
+// to null, and the result was not a second consistent shape but an inconsistent one: responses
+// built from ApiResponse<T> went out PascalCase, while the hand-written anonymous responses
+// below (new { success = ..., message = ... }) stayed lowercase, so a single endpoint could
+// answer {"Success":...} on 200 and {"success":...} on 400. Every caller deserializes
+// case-insensitively, so none of it was visible. Do not set it again: a browser client (#97)
 // cannot absorb a per-service wire format for free, and changing it once a client ships is a
 // breaking change.
 //
+// PropertyNameCaseInsensitive restates a default rather than establishing one — Http.Json's
+// options are built from JsonSerializerDefaults.Web, which already sets it. It is kept as an
+// explicit statement that lenient request reading is intended here, not an accident of the
+// default that a future edit could drop without noticing.
+//
 // This configures the HTTP pipeline only. The outbox settlement payload is written and read by
-// bare JsonSerializer calls that use JsonSerializerOptions.Default, so it stays PascalCase on
-// both ends and is unaffected by anything set here.
+// bare JsonSerializer calls, which bind JsonSerializerOptions.Default — case-sensitive, no
+// naming policy — so it is PascalCase on both ends and nothing set here reaches it.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.PropertyNameCaseInsensitive = true;

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -213,11 +213,20 @@ builder.Services.AddScoped<Orders.Core.IReferencePriceProvider>(sp => new Orders
 builder.Services.AddScoped<Orders.Application.Services.ReferencePriceProviderChain>();
 builder.Services.AddHostedService<Orders.Application.Services.AutoQuotePublisherService>();
 
-// Configure JSON serialization
+// Read request bodies case-insensitively, but write responses in the ASP.NET Core default
+// camelCase — the same shape Wallet.Api and Users.Api produce, neither of which configures
+// anything here. Until #229 this block also set PropertyNamingPolicy = null, which made this one
+// service answer in PascalCase; every caller happened to deserialize case-insensitively, so the
+// divergence stayed invisible. Do not set PropertyNamingPolicy again: a browser client (#97)
+// cannot absorb a per-service wire format for free, and changing it once a client ships is a
+// breaking change.
+//
+// This configures the HTTP pipeline only. The outbox settlement payload is written and read by
+// bare JsonSerializer calls that use JsonSerializerOptions.Default, so it stays PascalCase on
+// both ends and is unaffected by anything set here.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.PropertyNameCaseInsensitive = true;
-    options.SerializerOptions.PropertyNamingPolicy = null;
 });
 
 // Add Swagger/OpenAPI support

--- a/tests/TallaEgg.AllServices.Tests/JsonNamingPolicyConsistencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/JsonNamingPolicyConsistencyTests.cs
@@ -1,0 +1,55 @@
+﻿namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That the three deployed APIs agree on one JSON wire format (issue #229).
+/// </summary>
+/// <remarks>
+/// Source-scanning, like <see cref="RuntimeVersionExposureTests"/> and
+/// <see cref="ServiceHostPathAnchorTests"/>, and for the same reason: these are top-level
+/// statements no test can build a container from. What it defends against is exactly how #229
+/// happened — one service quietly setting a naming policy the other two do not, staying invisible
+/// because every caller deserializes case-insensitively, and only becoming expensive once a
+/// browser client (#97) has shipped against one of the two shapes.
+/// </remarks>
+public class JsonNamingPolicyConsistencyTests
+{
+    /// <summary>
+    /// The three hosts that serve HTTP. <c>Affiliate.Api</c> and <c>TallaEgg.Api</c> are absent
+    /// for the reason given in <see cref="RuntimeVersionExposureTests"/>: neither is deployed.
+    /// </summary>
+    public static TheoryData<string> DeployedApiEntryPoints =>
+    [
+        "src/User/Users.Api/Program.cs",
+        "src/Wallet/Wallet.Api/Program.cs",
+        "src/Order/Orders.Api/Program.cs",
+    ];
+
+    private static string[] ReadLines(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+    }
+
+    private static bool IsCode(string line) =>
+        !line.TrimStart().StartsWith("//", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Leaving <c>PropertyNamingPolicy</c> alone is what makes all three answer in the ASP.NET
+    /// Core default camelCase. Setting it to anything — including <c>null</c>, which is what
+    /// #229 was — opts one service out of the shape the other two produce.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DeployedApiEntryPoints))]
+    public void NoDeployedApi_OverridesThePropertyNamingPolicy(string relativePath)
+    {
+        Assert.DoesNotContain(
+            ReadLines(relativePath),
+            line => IsCode(line) && line.Contains("PropertyNamingPolicy", StringComparison.Ordinal));
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/JsonNamingPolicyConsistencyTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/JsonNamingPolicyConsistencyTests.cs
@@ -1,30 +1,50 @@
 ﻿namespace TallaEgg.AllServices.Tests;
 
 /// <summary>
-/// That the three deployed APIs agree on one JSON wire format (issue #229).
+/// That the three deployed APIs agree on one JSON wire format for their responses (issue #229).
 /// </summary>
 /// <remarks>
 /// Source-scanning, like <see cref="RuntimeVersionExposureTests"/> and
 /// <see cref="ServiceHostPathAnchorTests"/>, and for the same reason: these are top-level
-/// statements no test can build a container from. What it defends against is exactly how #229
-/// happened — one service quietly setting a naming policy the other two do not, staying invisible
-/// because every caller deserializes case-insensitively, and only becoming expensive once a
-/// browser client (#97) has shipped against one of the two shapes.
+/// statements no test can build a container from.
+///
+/// It sweeps whole project trees rather than the three <c>Program.cs</c> files, and looks for
+/// every spelling of the override rather than the one #229 happened to use. A guard that only
+/// reads <c>Program.cs</c> would go quiet the moment this wiring is hoisted into a shared helper
+/// — which is this repository's established habit for cross-service startup concerns
+/// (<c>Cors/</c>, <c>ErrorHandling/</c>, <c>StartupLogging</c>), so <c>TallaEgg.Core</c> is swept
+/// too. Passing vacuously after a refactor is the failure mode a guard like this is most prone
+/// to, and refactoring is one of the two cases the guard exists for.
 /// </remarks>
 public class JsonNamingPolicyConsistencyTests
 {
     /// <summary>
-    /// The three hosts that serve HTTP. <c>Affiliate.Api</c> and <c>TallaEgg.Api</c> are absent
-    /// for the reason given in <see cref="RuntimeVersionExposureTests"/>: neither is deployed.
+    /// The three hosts that serve HTTP, plus the shared kernel any common startup helper would
+    /// live in. <c>Affiliate.Api</c> and <c>TallaEgg.Api</c> are absent for the reason given in
+    /// <see cref="RuntimeVersionExposureTests"/>: neither is deployed.
     /// </summary>
-    public static TheoryData<string> DeployedApiEntryPoints =>
+    public static TheoryData<string> JsonWiringRoots =>
     [
-        "src/User/Users.Api/Program.cs",
-        "src/Wallet/Wallet.Api/Program.cs",
-        "src/Order/Orders.Api/Program.cs",
+        "src/User/Users.Api",
+        "src/Wallet/Wallet.Api",
+        "src/Order/Orders.Api",
+        "src/TallaEgg/TallaEgg.Core",
     ];
 
-    private static string[] ReadLines(string relativePath)
+    /// <summary>
+    /// Every way an ASP.NET Core host can move its responses off the default camelCase.
+    /// <c>PropertyNamingPolicy</c> covers <c>ConfigureHttpJsonOptions</c> and
+    /// <c>Configure&lt;JsonOptions&gt;</c> alike; the other two swap the serializer wholesale and
+    /// would take the naming policy with them without ever naming it.
+    /// </summary>
+    private static readonly string[] NamingPolicyOverrides =
+    [
+        "PropertyNamingPolicy",
+        "AddJsonOptions",
+        "AddNewtonsoftJson",
+    ];
+
+    private static string RepoRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
@@ -33,23 +53,61 @@ public class JsonNamingPolicyConsistencyTests
         }
 
         Assert.NotNull(directory);
-        return File.ReadAllLines(Path.Combine(directory.FullName, relativePath));
+        return directory.FullName;
     }
 
     private static bool IsCode(string line) =>
         !line.TrimStart().StartsWith("//", StringComparison.Ordinal);
 
     /// <summary>
-    /// Leaving <c>PropertyNamingPolicy</c> alone is what makes all three answer in the ASP.NET
-    /// Core default camelCase. Setting it to anything — including <c>null</c>, which is what
-    /// #229 was — opts one service out of the shape the other two produce.
+    /// Leaving the naming policy alone is what makes all three answer in the ASP.NET Core default
+    /// camelCase. Setting it to anything — including <c>null</c>, which is what #229 was — opts one
+    /// service out of the shape the other two produce, invisibly, because every current caller
+    /// deserializes case-insensitively. It only becomes expensive once a browser client (#97) has
+    /// shipped against one of the two shapes.
     /// </summary>
     [Theory]
-    [MemberData(nameof(DeployedApiEntryPoints))]
-    public void NoDeployedApi_OverridesThePropertyNamingPolicy(string relativePath)
+    [MemberData(nameof(JsonWiringRoots))]
+    public void ResponseNamingPolicy_InAnyDeployedApi_IsLeftAtTheFrameworkDefault(string relativeRoot)
     {
-        Assert.DoesNotContain(
-            ReadLines(relativePath),
-            line => IsCode(line) && line.Contains("PropertyNamingPolicy", StringComparison.Ordinal));
+        var root = Path.Combine(RepoRoot(), relativeRoot);
+        Assert.True(Directory.Exists(root), $"{relativeRoot} does not exist; update JsonWiringRoots.");
+
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            // Build output carries copies of source-generated and referenced code.
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (!IsCode(lines[index]))
+                {
+                    continue;
+                }
+
+                foreach (var token in NamingPolicyOverrides)
+                {
+                    if (lines[index].Contains(token, StringComparison.Ordinal))
+                    {
+                        offenders.Add(
+                            $"{Path.GetRelativePath(RepoRoot(), file)}:{index + 1}: {lines[index].Trim()}");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "A deployed API overrides the JSON response naming policy, which is how #229 happened. "
+                + "Leave it at the framework default so all three services answer in one shape:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
     }
 }


### PR DESCRIPTION
**Branch Name**: `fix/orders-api-camelcase-json`
**Linked Issue**: closes #229

> Updated after review. Two claims in the first version were wrong and are corrected below — see
> [the review response](https://github.com/MohKardan/TallaEgg/pull/234#issuecomment-5568323572).
> The defect was worse than the issue described, and the fix is correspondingly slightly more
> valuable.

---

## Description

`Orders.Api` set `PropertyNamingPolicy = null`, disabling the ASP.NET Core camelCase default. This removes that one line. `PropertyNameCaseInsensitive = true` stays — it governs *reading* request bodies, and it is not the setting that diverged.

**The divergence was not only between services — `Orders.Api` also disagreed with itself.** The issue frames this as "PascalCase here, camelCase there", and that is how I first wrote it up. It is not accurate. Twelve endpoints in `Orders.Api` return hand-written anonymous types whose C# members are *already lowercase* (`new { success = false, message = ... }`), so with the naming policy off they emitted `{"success":...}` while everything built from `ApiResponse<T>` emitted `{"Success":...}`. Single endpoints contradicted themselves — `/api/orders/user/{userId}` answered `{"Success":...}` on 200 and `{"success":...}` on 400. Removing the line settles both the cross-service and the within-service inconsistency.

I took option (a) from the issue. The evidence for it over "make all three PascalCase": nothing in the repo asks for PascalCase on the wire. The block carried no reason, no consumer depends on the shape, the other two services get camelCase by doing nothing at all, and — as above — a third of `Orders.Api`'s own responses were already camelCase. Matching the default deletes code instead of adding it to two more services *and* rewriting twelve anonymous types.

---

## Type of Change
- [x] Hotfix (urgent bug fix) — not urgent; closest available box for a defect fix
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## Changes Made

- Removed `options.SerializerOptions.PropertyNamingPolicy = null;` from `src/Order/Orders.Api/Program.cs`.
- Replaced the comment above the block. The old one said only "Configure JSON serialization" — recording no reason is what made this issue unanswerable from the code. The new one states what the defect actually was, why the policy is left alone, that `PropertyNameCaseInsensitive` restates a framework default and is kept as a statement of intent, and that none of it reaches the outbox.
- Added `tests/TallaEgg.AllServices.Tests/JsonNamingPolicyConsistencyTests.cs` — sweeps the three deployed API project trees plus `TallaEgg.Core` for `PropertyNamingPolicy`, `AddJsonOptions` and `AddNewtonsoftJson`.
- Updated the two `run-tallaegg/SKILL.md` response examples that printed the old shape.

---

## Every consumer of an Orders.Api response, and why each tolerates the change

The issue's list was incomplete — it named seven System.Text.Json sites and missed nine Newtonsoft ones **in the same file**.

### 1. `OrderApiClient` — System.Text.Json, explicit flag (7 sites)

Lines 543, 609, 652, 692, 747, 762, 846, each passing `new JsonSerializerOptions { PropertyNameCaseInsensitive = true }`. Read all seven rather than trusting the issue. Tolerant.

### 2. `OrderApiClient` — Newtonsoft (9 sites) — *missing from the issue*

Lines 91, 141, 188, 233, 331, 360, 816, 824, 876 use `JsonConvert.DeserializeObject`. Newtonsoft matches case-insensitively by default (`JsonPropertyCollection.GetClosestMatchProperty` tries exact, then case-insensitive). That is overridable only via a contract resolver or `JsonConvert.DefaultSettings`, and **the repo configures neither** — grepping all `.cs` for `JsonConvert.DefaultSettings`, `DefaultContractResolver` and `CamelCasePropertyNames` returns nothing. Tolerant.

So `OrderApiClient` alone uses two serialization libraries, and the issue's list covered less than half of that one file.

### 3. `UsersApiClient` — Newtonsoft (~11 sites) — *also missing from the issue*

Lines 83, 140, 193, 235, 286, 339, 394, 457, 575 use `JsonConvert`; 494 and 531 use STJ with the flag. Tolerant for the same reason — and **out of the blast radius entirely**: it calls `Users.Api`, untouched here.

### 4. `OutboxProcessorService:250,271` — bare STJ, no options — *the risky one*

`JsonSerializer.Deserialize<TradeDto>(message.Payload)` with no options is **case-sensitive**. If `ConfigureHttpJsonOptions` reached it, this change would break settlement. It does not:

- **Structurally**: `ConfigureHttpJsonOptions` writes into `Microsoft.AspNetCore.Http.Json.JsonOptions` in DI; a bare static `JsonSerializer` call binds `JsonSerializerOptions.Default` and never consults DI. Different objects, and `Default` is frozen on first use.
- **Symmetrically**: the write side, `OrderMatchingRepository.cs:207`, is also a bare `JsonSerializer.Serialize(...)`. Both ends bind the same `Default`, so both are PascalCase and agree with each other regardless of `Program.cs`.
- **Measured on net9.0**, not assumed:
  ```
  Http.Json.JsonOptions defaults -> CaseInsensitive=True,  NamingPolicy=JsonCamelCaseNamingPolicy
  JsonSerializerOptions.Default  -> CaseInsensitive=False, NamingPolicy=null
  ```
  Different objects with different values, which is the whole argument.
- **Empirically**: a settlement payload written by the post-change build is still PascalCase and reached `Status=1`. See Testing.

### 5. Nothing else calls Orders.Api

`Users.Api` builds one `HttpClient`, for `Wallet.Api`. `Wallet.Api` builds none. `Orders.Api`'s outbound calls to Wallet/Users are unaffected — they serialize with bare `JsonSerializer`, and `Wallet.Api` reads case-insensitively via the ASP.NET Core `Web` defaults. `driver.ps1` makes one Orders call and pipes it to `Out-Null`, and PowerShell property access is case-insensitive anyway. The Simulator holds no HTTP client of its own — it drives the real handlers, which is what makes it a real test here.

**Conclusion**: no consumer, internal or external, depends on the PascalCase shape.

---

## Flagged, not fixed: `OrderDto` crossed aliases

Surfaced during review and **deliberately left alone** — `[JsonPropertyName]` overrides the naming policy in both directions, so these are byte-for-byte identical before and after this PR:

| C# property | wire name |
|---|---|
| `Asset` | `"symbol"` |
| `Symbol` (alias → `Asset`) | `"asset"` |
| `Quantity` (alias → `Amount`) | `"Amount"` |
| `Amount` | `"quantity"` |

Two values presented as four fields with the names swapped, and `"Amount"` is the one explicit PascalCase name left on the wire. Changing them is a breaking change to the request contract of `POST /api/orders` — the opposite of the free change this PR is — so per `STANDARDS.md` scope discipline it is flagged for the owner rather than fixed inline. Worth its own issue, and worth doing before #97 reads that Swagger schema.

---

## Testing Completed

### Unit Tests
- [x] New unit tests written
- [x] All unit tests pass

```
dotnet build TallaEgg.sln
Build succeeded.  0 Warning(s)  0 Error(s)

dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 841, Skipped: 0, Total: 841
```

The new test is a guard, so I checked it guards — in both directions:

```
# the original line restored
ResponseNamingPolicy_InAnyDeployedApi_IsLeftAtTheFrameworkDefault
  (relativeRoot: "src/Order/Orders.Api") [FAIL]
  src\Order\Orders.Api\Program.cs:237: options.SerializerOptions.PropertyNamingPolicy = null;

# a shared helper in TallaEgg.Core — the refactor that would hide it from a Program.cs-only scan
  (relativeRoot: "src/TallaEgg/TallaEgg.Core") [FAIL]
  src\TallaEgg\TallaEgg.Core\TempEvasionProbe.cs:7: options.PropertyNamingPolicy = null;
```

### (a) All three services now answer in one shape

Live, on the final commit (`commitHash` confirms which build answered):

```
Users.Api    {"success":true,"message":null,"data":{"version":"1.2.0","commitHash":"375fbb5..."}}
Wallet.Api   {"success":true,"message":null,"data":{"version":"1.2.0","commitHash":"375fbb5..."}}
Orders.Api   {"success":true,"message":null,"data":{"version":"1.2.0","commitHash":"375fbb5..."}}
```

Nested DTO properties too:

```
GET :5140/api/symbols/active
{"success":true,"message":null,"data":["MAUA/IRT","SEKE_BAHAR/IRT","BTC/IRT"]}

GET :5140/api/orders/MAUA/IRT/best-prices
{"success":true,"message":"...","data":{"tradingType":0,"orderType":0,"symbol":"MAUA/IRT",
 "bestBidPrice":23056745.93,"bestAskPrice":23102905.49,"spread":46159.56,...}}
```

And the within-service inconsistency, on one endpoint's two paths — the 400 is a hand-written anonymous type, the 200 is `ApiResponse<T>`, and they now agree:

```
HTTP 400 -> {"success":false,"message":"شماره صفحه باید بیشتر از صفر باشد"}
HTTP 200 -> {"success":true,"message":"سفارشات دریافت شد","data":{"items":[],"totalCount":0,...}}
```

### (b) End-to-end — the bot still reads what Orders.Api gives

- [x] Exercised against the running stack — 2026-09-07, re-run on the final commit

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:28.43. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Every registration, quote publish, quote fill, balance read, trade history and position lookup went through the real `OrderApiClient` against the new camelCase responses. If any consumer had been intolerant, this is where it would have shown.

### (c) Database after the run

Deltas, not absolutes — these databases carry pre-existing residue belonging to nobody's current change:

| | before | after | delta |
|---|---|---|---|
| Outbox Pending | 0 | 0 | 0 |
| Outbox Completed | 8301 | 8351 | **+50** |
| Outbox Failed | 101 | 101 | **+0** |
| Outbox Abandoned | 609 | 609 | **+0** |

+50 Completed for 50 trades, no new failures. Trades with no settlement message queued: **0**.

And the consumer-4 proof, a payload written *by this build*:

```
Status=1 (Completed)
{"Id":"7817d86f-...","BuyOrderId":"3e8f8678-...","SellOrderId":"5be4f219-...", ...}
```

Still `Id`/`BuyOrderId`, not `id`/`buyOrderId`, and it settled. Had `ConfigureHttpJsonOptions` reached the outbox, this row would be camelCase.

### Environment
- [x] Tested locally (Windows + SQL Server Express)

---

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `config/appsettings.global.json` untouched and still untracked
- [x] Code compiles without warnings

---

## Code Quality
- [x] Follows `STANDARDS.md`, including `Method_Scenario_ExpectedResult` for the new test
- [x] Comments in English, explaining the "why"
- [x] No large blocks of commented-out code

---

## Documentation
- [x] `run-tallaegg/SKILL.md` — the two response examples the change makes stale, corrected against real output
- [x] `scripts/check-doc-paths.sh` — 396 files checked, every reference resolves

Swagger needs no update: it generates from the live serializer settings.

---

## Breaking Changes?

- [x] No breaking changes

The wire format changes, but no consumer distinguishes the two shapes — that is the inventory above. This is precisely the window the issue identifies: free today, breaking once a browser client (#97) ships against one of the shapes.

---

## Deployment Notes

**Pre-Deployment**: no migrations, no configuration, no feature flag.

**Post-Deployment Verification**: call `/version` on Orders.Api and confirm lowercase `success`.

**Rollback**: revert and restart `Orders.Api`. No data migration either way — nothing persists the HTTP shape, and the outbox payload format is unaffected in both directions.

---

## Related Issues
- Closes #229
- Related to #97 (web UI) — the client that would otherwise inherit the divergence
- Not #228 (boot ordering), which is separate work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
