### PR TITLE
[Hotfix][Critical] Migrate after the host starts, so a slow database is waited for — issue #230

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -88,6 +88,14 @@ minutes, so a human can drive the bot over real Telegram. It asserts nothing, an
   truth and always wrong; a `.sql` under `scripts/` that *migrates data* — like
   `migrate-irr-to-irt.sql`, which relabels an asset without touching amounts — is a different
   thing and belongs there.
+- **Migration runs *after* the host starts, not before it (issue #230).** Users, Wallet and Orders
+  register it through `AddDatabaseMigrationAtStartup` in `TallaEgg.Core.Startup`, which retries a
+  database that is not answering yet and gives up loudly after ten attempts. Until it succeeds
+  every request is answered `503` by `UseDatabaseReadinessGate()`, `GET /version` excepted. Putting
+  a migration back between `builder.Build()` and `app.Run()` reopens the outage in #228: under
+  `UseWindowsService()` nothing is connected to the SCM until `app.Run()`, so time spent there is
+  time the SCM counts against its 45-second start timeout. Wrapping the old call site in a retry
+  loop makes it worse, not better.
 
 ## Business rules that look like bugs
 

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -137,26 +137,59 @@ three APIs.
 `Orders.Api` and `Users.Api` call `Wallet.Api` on startup paths, so `Wallet.Api` starts first and
 the bot starts last.
 
-### What neither ordering buys
+### What neither ordering buys, and what waits it out anyway
 
 *Running* means the dependency's process started and reported ready. Nothing more. For SQL Server
 it does **not** mean the instance is accepting connections yet; for an API it does not mean its own
-migration or first outbound call has finished.
+migration has finished.
 
-**Do not expect the services to ride that out.** No `DbContext` here configures
-`EnableRetryOnFailure`, so the first failed connection throws straight out of `MigrateAsync()` and
-the process dies before the host ever starts. And restart-on-crash does not rescue the ones behind
-it: the `sc.exe failure` actions run when a service's own process terminates, so a service the SCM
-never launched — because its declared dependency failed — takes no recovery action at all and
-simply stays `Stopped`. That is why one service dying at boot took all four down in #228, and it is
-still how it would fail if the database is `Running` but not yet answering.
+So the dependency narrows the window, it does not close it. What closes it is the services waiting
+for their database instead of trusting Windows' start order, and since
+[#230](https://github.com/MohKardan/TallaEgg/issues/230) they do.
 
-So the dependency narrows the window, it does not close it. Closing it means the services waiting
-for their database instead of trusting Windows' start order, which is application code and is
-tracked separately in [#230](https://github.com/MohKardan/TallaEgg/issues/230). Note the trap
-recorded there: retrying around `MigrateAsync()` where it currently stands would make this *worse*,
-because that code runs before the host connects to the SCM and a longer wait there is a longer
-start timeout, not a recovery.
+Until then they could not. `Wallet.Api`, `Users.Api` and `Orders.Api` each ran `MigrateAsync()`
+between `builder.Build()` and `app.Run()`, and `WindowsServiceLifetime` does not connect to the SCM
+dispatcher until `app.Run()` — so every second spent migrating was a second the SCM counted against
+its 45-second start timeout with nothing connected yet. No `DbContext` here configures
+`EnableRetryOnFailure`, so a database that was not answering did not fail fast either: the call
+blocked, the process was killed, and the service never reported anything. Restart-on-crash did not
+rescue the ones behind it, and still does not — the `sc.exe failure` actions run when a service's
+own process terminates, so a service the SCM never launched, because its declared dependency
+failed, takes no recovery action at all and simply stays `Stopped`.
+
+### How a service waits for its database now (issue #230)
+
+Each of the three APIs registers its migration as a hosted service instead, so the host starts and
+the service reports `Running` within a second or two whether or not the database is up. What
+follows is visible in the service's own log under `C:\TallaEgg\publish\<Service>\logs\`:
+
+- **The database is up.** One line, and the service is serving:
+  ```
+  [18:53:20 INF] Application started. Press Ctrl+C to shut down.
+  [18:53:21 INF] Database migration succeeded on attempt 1 of 10. The service is now answering requests.
+  ```
+- **The database arrives late.** Each attempt is logged and the backoff doubles from five seconds
+  to a minute. No restart is needed — the same process recovers:
+  ```
+  [18:53:35 WRN] Database migration attempt 1 of 10 failed. Retrying in 5s; requests are answered 503 until it succeeds.
+  [18:53:55 WRN] Database migration attempt 2 of 10 failed. Retrying in 10s; requests are answered 503 until it succeeds.
+  [18:54:40 INF] Database migration succeeded on attempt 4 of 10. The service is now answering requests.
+  ```
+- **The database never comes.** After ten attempts — roughly six minutes of waiting plus each
+  attempt's own connection timeout — the service logs the last exception at `Fatal` and **stops
+  itself** rather than staying `Running` and useless. Expect it in `Get-Service` as `Stopped`, with
+  this in its log:
+  ```
+  [FTL] Database migration failed on all 10 attempts. The service cannot serve a request without
+        its schema, so it is stopping rather than staying up and answering 503 forever.
+  ```
+
+**While the migration has not succeeded, every request is answered `503 Service Unavailable`** with
+a Persian message saying the service is still starting. `GET /version` is the one exception, so
+"which build is this?" still has an answer while a service is degraded. A `503` from these services
+during the first minute after a boot is the expected shape of a slow database, not a fault.
+
+The bot is unchanged: it opens no database of its own.
 
 ### Applying this to a machine installed before #228
 

--- a/scripts/windows-services/install-services.ps1
+++ b/scripts/windows-services/install-services.ps1
@@ -113,7 +113,9 @@ $plainApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
 # Neither ordering waits for readiness. "Running" means the dependency's process started and
 # reported ready — for SQL Server, not that the instance accepts connections yet; for an API, not
 # that its own migration or first HTTP call has finished. This narrows the window rather than
-# closing it. See the runbook for the residual case.
+# closing it. What covers the remainder is application code, not this file: since issue #230 the
+# three APIs migrate from a hosted service after their host has started, so they report Running
+# promptly and retry a database that is not answering yet. See the runbook.
 $services = @(
     @{ Name = "TallaEggWalletApi"; Publish = "Wallet.Api";  Exe = "Wallet.Api.exe";                          DependsOn = $sqlDependency }
     @{ Name = "TallaEggUsersApi";  Publish = "Users.Api";   Exe = "Users.Api.exe";                           DependsOn = $sqlDependency + @("TallaEggWalletApi") }

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -19,6 +19,7 @@ using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
 using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Responses.Order;
+using TallaEgg.Core.Startup;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
 using CancelActiveOrdersResponseDto = TallaEgg.Core.DTOs.Order.CancelActiveOrdersResponseDto;
@@ -261,30 +262,38 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
-var app = builder.Build();
-
-app.UseTallaEggErrorHandling();
-
-// --- Migrations and initial seed ---
-using (var scope = app.Services.CreateScope())
+// --- Migrations and startup validation ---
+// Registered to run from a hosted service once the host has started, rather than between
+// Build() and Run() where it used to sit: under UseWindowsService() nothing is connected to the
+// SCM until Run(), so a database that was not answering yet blocked here until the SCM killed
+// the process (issue #230).
+builder.Services.AddDatabaseMigrationAtStartup(async (services, cancellationToken) =>
 {
-    var services = scope.ServiceProvider;
     var context = services.GetRequiredService<OrdersDbContext>();
-    await context.Database.MigrateAsync(); // اجرای مایگریشن‌ها
-
-    // Says who this instance is before anything it writes to the database carries that name
-    // (issue #160). Running a second Orders.Api is supported now, but it is rarely intended here:
-    // this line and the follower warnings from the background loops are what make it visible
-    // instead of leaving the constraint in a code comment nobody deploying will read.
-    Log.Information("Orders.Api instance identity is {InstanceId}. Background loops coordinate through the ServiceLeases table.",
-        services.GetRequiredService<InstanceIdentity>().Value);
+    await context.Database.MigrateAsync(cancellationToken);
 
     // A symbol with an active quote but not in dealer mode means the admin's published price and
     // the configuration disagree. Logged only; it does not stop the service (issue #73).
     var marketModeValidator = services.GetRequiredService<Orders.Application.Services.MarketModeStartupValidator>();
     await marketModeValidator.ValidateAsync();
-}
+});
 
+var app = builder.Build();
+
+app.UseTallaEggErrorHandling();
+
+// Requests are refused with 503 until the migration above has succeeded, so this service never
+// answers against a schema it has not migrated (issue #230).
+app.UseDatabaseReadinessGate();
+
+// Says who this instance is before anything it writes to the database carries that name
+// (issue #160). Running a second Orders.Api is supported now, but it is rarely intended here:
+// this line and the follower warnings from the background loops are what make it visible
+// instead of leaving the constraint in a code comment nobody deploying will read. It reads a
+// singleton and touches no database, so it stays out of the retrying migration above and is
+// logged here, ahead of every loop that could write (issue #230).
+Log.Information("Orders.Api instance identity is {InstanceId}. Background loops coordinate through the ServiceLeases table.",
+    app.Services.GetRequiredService<InstanceIdentity>().Value);
 
 // Authentication and authorization, Production only.
 if (app.Environment.IsProduction())

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -274,8 +274,20 @@ builder.Services.AddDatabaseMigrationAtStartup(async (services, cancellationToke
 
     // A symbol with an active quote but not in dealer mode means the admin's published price and
     // the configuration disagree. Logged only; it does not stop the service (issue #73).
-    var marketModeValidator = services.GetRequiredService<Orders.Application.Services.MarketModeStartupValidator>();
-    await marketModeValidator.ValidateAsync();
+    //
+    // It reads the database, so it has to run after the migration — but it is a check, not a
+    // precondition. Letting it throw out of here would count against the migration's retry budget
+    // and hold every request at 503 over a configuration report, which is the opposite of what
+    // #73 decided. Hence its own catch.
+    try
+    {
+        var marketModeValidator = services.GetRequiredService<Orders.Application.Services.MarketModeStartupValidator>();
+        await marketModeValidator.ValidateAsync();
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "The market-mode startup check could not run. The service is unaffected (issue #73).");
+    }
 });
 
 var app = builder.Build();

--- a/src/Order/Orders.Application/MatchingEngineRegistration.cs
+++ b/src/Order/Orders.Application/MatchingEngineRegistration.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orders.Application.Services;
+using TallaEgg.Core.Startup;
 
 namespace Orders.Application;
 
@@ -28,6 +30,10 @@ public static class MatchingEngineRegistration
     /// </summary>
     public static IServiceCollection AddMatchingEngine(this IServiceCollection services)
     {
+        // The loop waits for the migration before it sweeps the order book (issue #230).
+        // TryAdd so this composes with AddDatabaseMigrationAtStartup in either order.
+        services.TryAddSingleton<DatabaseReadiness>();
+
         services.AddSingleton<MatchingEngineService>();
         services.AddSingleton<IMatchingEngine>(sp => sp.GetRequiredService<MatchingEngineService>());
         services.AddHostedService(sp => sp.GetRequiredService<MatchingEngineService>());

--- a/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
+++ b/src/Order/Orders.Application/Services/AutoQuotePublisherService.cs
@@ -1,6 +1,7 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TallaEgg.Core.Startup;
 using Orders.Core;
 using TallaEgg.Core;
 using TallaEgg.Core.ErrorHandling;
@@ -39,16 +40,19 @@ public class AutoQuotePublisherService : BackgroundService
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<AutoQuotePublisherService> _logger;
+    private readonly DatabaseReadiness _readiness;
     private readonly LeaderGate _leaderGate;
 
     public AutoQuotePublisherService(
         IServiceScopeFactory scopeFactory,
         ILogger<AutoQuotePublisherService> logger,
-        ILeaderLease leaderLease)
+        ILeaderLease leaderLease,
+        DatabaseReadiness readiness)
     {
         _scopeFactory = scopeFactory;
         _logger = logger;
         _leaderGate = new LeaderGate(ServiceLeaseRoles.AutoQuotePublisher, LeaseDuration, leaderLease, logger);
+        _readiness = readiness;
     }
 
     /// <summary>internal so a test can ask the gate directly, without driving the loop's timing.</summary>
@@ -70,6 +74,14 @@ public class AutoQuotePublisherService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("AutoQuotePublisherService started (poll every {Minutes}m).", PollInterval.TotalMinutes);
+        // Nothing below may touch the database before the migration has applied it. Since #230 the
+        // migration runs alongside the host instead of ahead of it, and the readiness gate only
+        // covers HTTP — a loop reaches the database without a request.
+        if (!await _readiness.WaitUntilReadyAsync(stoppingToken))
+        {
+            return;
+        }
+
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/src/Order/Orders.Application/Services/MatchingEngineService.cs
+++ b/src/Order/Orders.Application/Services/MatchingEngineService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TallaEgg.Core.Startup;
 using Orders.Application;
 using Orders.Core;
 using Orders.Infrastructure;
@@ -26,6 +27,7 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     private readonly IServiceScopeFactory _scopeFactory;
 
     private readonly ILogger<MatchingEngineService> _logger;
+    private readonly DatabaseReadiness _readiness;
     private readonly IServiceProvider _serviceProvider;
     private readonly TimeSpan _processingInterval = TimeSpan.FromSeconds(1);
     private readonly SemaphoreSlim _processingSemaphore = new(1, 1); // Prevent concurrent processing
@@ -63,7 +65,8 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         ILogger<MatchingEngineService> logger,
         IServiceProvider serviceProvider,
         IConfiguration configuration,
-        ILeaderLease leaderLease)
+        ILeaderLease leaderLease,
+        DatabaseReadiness readiness)
     {
         _scopeFactory = scopeFactory;
 
@@ -71,6 +74,7 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
         _serviceProvider = serviceProvider;
 
         _leaderGate = new LeaderGate(ServiceLeaseRoles.MatchingEngine, LeaseDuration, leaderLease, logger);
+        _readiness = readiness;
     }
 
     /// <summary>internal so a test can ask the gate directly, without driving the loop's timing.</summary>
@@ -80,6 +84,14 @@ public class MatchingEngineService : BackgroundService, IMatchingEngine
     {
         _logger.LogInformation("🚀 Matching Engine Service is starting...");
         _isRunning = true;
+        // Nothing below may touch the database before the migration has applied it. Since #230 the
+        // migration runs alongside the host instead of ahead of it, and the readiness gate only
+        // covers HTTP — a loop reaches the database without a request.
+        if (!await _readiness.WaitUntilReadyAsync(stoppingToken))
+        {
+            return;
+        }
+
 
         try
         {

--- a/src/Order/Orders.Application/Services/OutboxProcessorService.cs
+++ b/src/Order/Orders.Application/Services/OutboxProcessorService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orders.Core;
 using Orders.Infrastructure;
+using TallaEgg.Core.Startup;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Infrastructure.Clients;
 
@@ -27,6 +28,7 @@ public class OutboxProcessorService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly InstanceIdentity _identity;
     private readonly ILogger<OutboxProcessorService> _logger;
+    private readonly DatabaseReadiness _readiness;
 
     private readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(5);
     private const int BatchSize = 20;
@@ -43,16 +45,26 @@ public class OutboxProcessorService : BackgroundService
     public OutboxProcessorService(
         IServiceScopeFactory scopeFactory,
         InstanceIdentity identity,
-        ILogger<OutboxProcessorService> logger)
+        ILogger<OutboxProcessorService> logger,
+        DatabaseReadiness readiness)
     {
         _scopeFactory = scopeFactory;
         _identity = identity;
         _logger = logger;
+        _readiness = readiness;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("OutboxProcessorService started (poll every {Seconds}s).", _pollInterval.TotalSeconds);
+        // Nothing below may touch the database before the migration has applied it. Since #230 the
+        // migration runs alongside the host instead of ahead of it, and the readiness gate only
+        // covers HTTP — a loop reaches the database without a request.
+        if (!await _readiness.WaitUntilReadyAsync(stoppingToken))
+        {
+            return;
+        }
+
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/src/TallaEgg/TallaEgg.Core/Startup/DatabaseMigrationHostedService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Startup/DatabaseMigrationHostedService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -49,8 +50,16 @@ public sealed class DatabaseMigrationHostedService : BackgroundService
     private const int MAX_ATTEMPTS = 10;
 
     /// <summary>
-    /// Exit code when the migration is abandoned, so this is distinguishable from a clean stop.
+    /// Process exit code when the migration is abandoned.
     /// </summary>
+    /// <remarks>
+    /// This is the <i>process</i> exit code, which is what a console run, CI, or any supervisor
+    /// reading it sees. Under <c>UseWindowsService()</c> the SCM reports what
+    /// <c>ServiceBase.ExitCode</c> holds, which is a different value and not reachable from here
+    /// without taking a Windows-only dependency into the shared kernel — so do not assume the
+    /// <c>sc.exe failure</c> restart actions fire on this. The <c>Fatal</c> log line below and the
+    /// service reaching <c>Stopped</c> are the signal that is guaranteed either way.
+    /// </remarks>
     private const int MIGRATION_FAILED_EXIT_CODE = 1;
 
     private static readonly TimeSpan FirstRetryDelay = TimeSpan.FromSeconds(5);
@@ -185,7 +194,9 @@ public static class DatabaseMigrationRegistration
         this IServiceCollection services,
         DatabaseMigrationStep migrate)
     {
-        services.AddSingleton<DatabaseReadiness>();
+        // TryAdd, because anything that depends on readiness registers it the same way — see
+        // MatchingEngineRegistration. Whichever runs first, there is one flag per service.
+        services.TryAddSingleton<DatabaseReadiness>();
         services.AddSingleton(migrate);
         services.AddHostedService<DatabaseMigrationHostedService>();
 

--- a/src/TallaEgg/TallaEgg.Core/Startup/DatabaseMigrationHostedService.cs
+++ b/src/TallaEgg/TallaEgg.Core/Startup/DatabaseMigrationHostedService.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TallaEgg.Core.Startup;
+
+/// <summary>
+/// The database work a service has to complete before it can answer a request: its EF Core
+/// migration, and whatever seed that migration makes possible.
+/// </summary>
+/// <param name="services">A scope created fresh for each attempt.</param>
+/// <param name="cancellationToken">Fires when the host is shutting down.</param>
+public delegate Task DatabaseMigrationStep(IServiceProvider services, CancellationToken cancellationToken);
+
+/// <summary>
+/// Applies a service's database migration <b>after</b> the host has started, retrying with
+/// backoff while the database is not answering yet (issue #230).
+/// </summary>
+/// <remarks>
+/// The three deployed APIs used to migrate in top-level statements, between
+/// <c>builder.Build()</c> and <c>app.Run()</c>. Under <c>UseWindowsService()</c> the process does
+/// not connect to the SCM dispatcher until <c>app.Run()</c>, so every second spent migrating was a
+/// second the SCM counted against its 45-second start timeout with nothing connected yet. A
+/// database that was not listening did not fail fast either — it blocked, the SCM killed the
+/// process, and the service never reported anything. That is the outage in issue #228, whose
+/// deployment fix orders SQL Server ahead of these services but cannot make <i>Running</i> mean
+/// <i>accepting connections</i>.
+///
+/// <para>
+/// Retrying around the old call site would have made this worse rather than better: the loop
+/// still runs before <c>app.Run()</c>, so it lengthens precisely the window the SCM is timing —
+/// the same kill, later, with a less obvious cause. The migration has to leave the pre-start path
+/// first, which is what this class is for.
+/// </para>
+///
+/// <para>
+/// The retry budget is bounded on purpose. A database that never comes back has to end in a
+/// logged failure and a stopped service, not in one that reports <i>Running</i> and is useless.
+/// </para>
+/// </remarks>
+public sealed class DatabaseMigrationHostedService : BackgroundService
+{
+    /// <summary>
+    /// Attempts before the service gives up. With the backoff below this spends roughly six
+    /// minutes waiting, plus whatever each failed attempt takes to time out — comfortably longer
+    /// than SQL Server Express's own two-minute delayed start (issue #228), and short enough that
+    /// a database which is genuinely gone is reported rather than waited on forever.
+    /// </summary>
+    private const int MAX_ATTEMPTS = 10;
+
+    /// <summary>
+    /// Exit code when the migration is abandoned, so this is distinguishable from a clean stop.
+    /// </summary>
+    private const int MIGRATION_FAILED_EXIT_CODE = 1;
+
+    private static readonly TimeSpan FirstRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(60);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly DatabaseMigrationStep _migrate;
+    private readonly DatabaseReadiness _readiness;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<DatabaseMigrationHostedService> _logger;
+
+    private readonly int _maxAttempts;
+    private readonly TimeSpan _firstRetryDelay;
+    private readonly TimeSpan _maxRetryDelay;
+
+    public DatabaseMigrationHostedService(
+        IServiceScopeFactory scopeFactory,
+        DatabaseMigrationStep migrate,
+        DatabaseReadiness readiness,
+        IHostApplicationLifetime lifetime,
+        ILogger<DatabaseMigrationHostedService> logger)
+        : this(scopeFactory, migrate, readiness, lifetime, logger, MAX_ATTEMPTS, FirstRetryDelay, MaxRetryDelay)
+    {
+    }
+
+    /// <summary>
+    /// Takes the retry schedule so a test can exercise give-up and recovery without waiting out
+    /// the real backoff. DI always uses the public constructor above and the constants beside it.
+    /// </summary>
+    internal DatabaseMigrationHostedService(
+        IServiceScopeFactory scopeFactory,
+        DatabaseMigrationStep migrate,
+        DatabaseReadiness readiness,
+        IHostApplicationLifetime lifetime,
+        ILogger<DatabaseMigrationHostedService> logger,
+        int maxAttempts,
+        TimeSpan firstRetryDelay,
+        TimeSpan maxRetryDelay)
+    {
+        _scopeFactory = scopeFactory;
+        _migrate = migrate;
+        _readiness = readiness;
+        _lifetime = lifetime;
+        _logger = logger;
+        _maxAttempts = maxAttempts;
+        _firstRetryDelay = firstRetryDelay;
+        _maxRetryDelay = maxRetryDelay;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Yield before touching the database. The host awaits StartAsync of every hosted service
+        // before it reports started, and BackgroundService.StartAsync returns only once
+        // ExecuteAsync reaches its first incomplete await — so anything run synchronously above
+        // this line would land back in the pre-start window this class exists to leave.
+        await Task.Yield();
+
+        var delay = _firstRetryDelay;
+
+        for (var attempt = 1; attempt <= _maxAttempts; attempt++)
+        {
+            try
+            {
+                // A fresh scope per attempt: a DbContext that failed to connect is not reused.
+                using var scope = _scopeFactory.CreateScope();
+                await _migrate(scope.ServiceProvider, stoppingToken);
+
+                _readiness.MarkReady();
+                _logger.LogInformation(
+                    "Database migration succeeded on attempt {Attempt} of {MaxAttempts}. The service is now answering requests.",
+                    attempt,
+                    _maxAttempts);
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Database migration abandoned on attempt {Attempt}: the service is shutting down.", attempt);
+                return;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == _maxAttempts)
+                {
+                    _logger.LogCritical(
+                        ex,
+                        "Database migration failed on all {MaxAttempts} attempts. The service cannot serve a request without its schema, so it is stopping rather than staying up and answering 503 forever.",
+                        _maxAttempts);
+
+                    Environment.ExitCode = MIGRATION_FAILED_EXIT_CODE;
+                    _lifetime.StopApplication();
+                    return;
+                }
+
+                _logger.LogWarning(
+                    ex,
+                    "Database migration attempt {Attempt} of {MaxAttempts} failed. Retrying in {DelaySeconds}s; requests are answered 503 until it succeeds.",
+                    attempt,
+                    _maxAttempts,
+                    delay.TotalSeconds);
+            }
+
+            try
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            delay = delay * 2 < _maxRetryDelay ? delay * 2 : _maxRetryDelay;
+        }
+    }
+}
+
+/// <summary>
+/// Registers the migration host and the readiness flag it writes.
+/// </summary>
+public static class DatabaseMigrationRegistration
+{
+    /// <summary>
+    /// Runs <paramref name="migrate"/> once the host has started, retrying while the database is
+    /// unreachable, and opens <see cref="DatabaseReadiness"/> when it succeeds (issue #230).
+    /// </summary>
+    /// <remarks>
+    /// Pair this with <c>UseDatabaseReadinessGate()</c> on the application, or the service will
+    /// answer requests against a schema that has not been migrated yet.
+    /// </remarks>
+    /// <param name="services">The service collection being built.</param>
+    /// <param name="migrate">The migration, and any seed that depends on it.</param>
+    public static IServiceCollection AddDatabaseMigrationAtStartup(
+        this IServiceCollection services,
+        DatabaseMigrationStep migrate)
+    {
+        services.AddSingleton<DatabaseReadiness>();
+        services.AddSingleton(migrate);
+        services.AddHostedService<DatabaseMigrationHostedService>();
+
+        return services;
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadiness.cs
+++ b/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadiness.cs
@@ -11,6 +11,8 @@ namespace TallaEgg.Core.Startup;
 /// </remarks>
 public sealed class DatabaseReadiness
 {
+    private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     private volatile bool _isReady;
 
     /// <summary>
@@ -21,5 +23,36 @@ public sealed class DatabaseReadiness
     /// <summary>
     /// Records that the migration succeeded, which opens the readiness gate.
     /// </summary>
-    public void MarkReady() => _isReady = true;
+    public void MarkReady()
+    {
+        // The flag first, so a loop woken by the task below never observes a stale false.
+        _isReady = true;
+        _ready.TrySetResult();
+    }
+
+    /// <summary>
+    /// Waits for the migration to succeed. Returns <c>false</c> instead of throwing when the host
+    /// shuts down first, so a caller in a <c>BackgroundService</c> can simply stop.
+    /// </summary>
+    /// <remarks>
+    /// For in-process work that the readiness gate cannot cover: the gate turns away HTTP
+    /// requests, but a background loop reaches the database without one. Since the migration runs
+    /// alongside the host rather than ahead of it (issue #230), a loop that queried straight away
+    /// could read a schema mid-migration — and an exception escaping a <c>BackgroundService</c>
+    /// stops the whole host under the default
+    /// <c>BackgroundServiceExceptionBehavior.StopHost</c>, which is the outage this issue exists
+    /// to remove.
+    /// </remarks>
+    public async Task<bool> WaitUntilReadyAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _ready.Task.WaitAsync(cancellationToken);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadiness.cs
+++ b/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadiness.cs
@@ -1,0 +1,25 @@
+namespace TallaEgg.Core.Startup;
+
+/// <summary>
+/// Whether this service's database migration has finished (issue #230).
+/// </summary>
+/// <remarks>
+/// One instance per service, registered as a singleton. It is written exactly once, by
+/// <see cref="DatabaseMigrationHostedService"/>, and read on every request by the readiness gate
+/// — so the flag is <c>volatile</c> rather than locked: the writer never clears it, and a reader
+/// that observes the old value merely answers one more 503 before it sees the new one.
+/// </remarks>
+public sealed class DatabaseReadiness
+{
+    private volatile bool _isReady;
+
+    /// <summary>
+    /// True once the migration has succeeded, false from process start until then.
+    /// </summary>
+    public bool IsReady => _isReady;
+
+    /// <summary>
+    /// Records that the migration succeeded, which opens the readiness gate.
+    /// </summary>
+    public void MarkReady() => _isReady = true;
+}

--- a/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadinessGate.cs
+++ b/src/TallaEgg/TallaEgg.Core/Startup/DatabaseReadinessGate.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using TallaEgg.Core.DTOs;
+
+namespace TallaEgg.Core.Startup;
+
+/// <summary>
+/// Refuses requests until the database migration has succeeded (issue #230).
+/// </summary>
+public static class DatabaseReadinessGate
+{
+    /// <summary>
+    /// Shown to a caller, so Persian like every other message this platform returns.
+    /// </summary>
+    private const string NOT_READY_MESSAGE = "سرویس هنوز آماده نیست: مهاجرت پایگاه داده کامل نشده است. لطفاً چند لحظه دیگر دوباره تلاش کنید.";
+
+    /// <summary>
+    /// Seconds to suggest before retrying. The migration backoff starts at five seconds and
+    /// grows, so this is a hint rather than a promise.
+    /// </summary>
+    private const string RETRY_AFTER_SECONDS = "10";
+
+    /// <summary>
+    /// Answers <c>503 Service Unavailable</c> to every request until
+    /// <see cref="DatabaseReadiness"/> opens, so the service never serves against a schema that
+    /// has not been migrated yet.
+    /// </summary>
+    /// <remarks>
+    /// Since the migration moved off the pre-start path, the host reports <i>Running</i> before
+    /// the database has necessarily answered. Something has to say what happens in that window,
+    /// and the alternative — serving — turns a startup delay into whatever error the missing
+    /// schema happens to raise, reported as a 500 with a stack trace in the log.
+    ///
+    /// <para>
+    /// Register it directly after the error handler, ahead of authentication, CORS, Swagger and
+    /// the endpoints: none of those can do anything useful without the database either, and a
+    /// caller learning that a service is still starting is not information worth protecting.
+    /// </para>
+    ///
+    /// <para>
+    /// <c>GET /version</c> is exempt. Answering "which build is this?" while a service is
+    /// degraded is the whole reason it exists (issue #218), and it reads nothing from the
+    /// database.
+    /// </para>
+    /// </remarks>
+    public static IApplicationBuilder UseDatabaseReadinessGate(this IApplicationBuilder app)
+    {
+        // Resolved once here rather than per request, and deliberately not optional: a service
+        // that gates on readiness without registering the migration host would refuse every
+        // request forever, so it should fail at startup instead.
+        var readiness = app.ApplicationServices.GetRequiredService<DatabaseReadiness>();
+
+        return app.Use(async (context, next) =>
+        {
+            if (readiness.IsReady || IsExempt(context.Request.Path))
+            {
+                await next(context);
+                return;
+            }
+
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.Headers.RetryAfter = RETRY_AFTER_SECONDS;
+            await context.Response.WriteAsJsonAsync(
+                ApiResponse<object>.Fail(NOT_READY_MESSAGE),
+                context.RequestAborted);
+        });
+    }
+
+    private static bool IsExempt(PathString path) =>
+        path.StartsWithSegments("/version", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -16,6 +16,7 @@ using TallaEgg.Core.DTOs.User;
 using TallaEgg.Core.Enums.User;
 using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Requests.User;
+using TallaEgg.Core.Startup;
 using Users.Api;
 using Users.Application;
 using Users.Application.Mappers;
@@ -191,55 +192,53 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
+// --- Migrations and initial seed ---
+// Registered to run from a hosted service once the host has started, rather than between
+// Build() and Run() where it used to sit: under UseWindowsService() nothing is connected to the
+// SCM until Run(), so a database that was not answering yet blocked here until the SCM killed
+// the process (issue #230). The retry loop there logs every failed attempt with its exception,
+// which is what the try/catch here used to do before rethrowing.
+builder.Services.AddDatabaseMigrationAtStartup(async (services, cancellationToken) =>
+{
+    var context = services.GetRequiredService<UsersDbContext>();
+
+    await context.Database.MigrateAsync(cancellationToken);
+
+    var adminId = TallaEgg.Core.BootstrapConstant.RootAdminUserId;
+    var existingAdmin = await context.Users.FirstOrDefaultAsync(u => u.Id == adminId, cancellationToken);
+
+    if (existingAdmin == null)
+    {
+        User user = new User()
+        {
+            Id = adminId,
+            FirstName = "مدیر",
+            LastName = "کل",
+            // Shared with the bot's fallback referral code. Registration rejects any code
+            // that belongs to no user, so on an empty database this row's code is the only
+            // one that can ever work — and the two sides had drifted apart.
+            InvitationCode = TallaEgg.Core.BootstrapConstant.RootInvitationCode,
+            IsActive = true,
+            CreatedAt = DateTime.Parse("2025-08-04T08:43:43.1234567Z"),
+            Role = UserRole.SuperAdmin
+        };
+        context.Users.Add(user);
+        await context.SaveChangesAsync(cancellationToken);
+        Log.Information("Root administrator seeded.");
+    }
+    else
+    {
+        Log.Information("Root administrator already exists; nothing seeded.");
+    }
+});
+
 var app = builder.Build();
 
 app.UseTallaEggErrorHandling();
 
-// --- Migrations and initial seed ---
-using (var scope = app.Services.CreateScope())
-{
-    var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<UsersDbContext>();
-    try
-    {
-        await context.Database.MigrateAsync(); // اجرای مایگریشن‌ها
-
-        var adminId = TallaEgg.Core.BootstrapConstant.RootAdminUserId;
-        var existingAdmin = await context.Users.FirstOrDefaultAsync(u => u.Id == adminId);
-
-        if (existingAdmin == null)
-        {
-            User user = new User()
-            {
-                Id = adminId,
-                FirstName = "مدیر",
-                LastName = "کل",
-                // Shared with the bot's fallback referral code. Registration rejects any code
-                // that belongs to no user, so on an empty database this row's code is the only
-                // one that can ever work — and the two sides had drifted apart.
-                InvitationCode = TallaEgg.Core.BootstrapConstant.RootInvitationCode,
-                IsActive = true,
-                CreatedAt = DateTime.Parse("2025-08-04T08:43:43.1234567Z"),
-                Role = UserRole.SuperAdmin
-            };
-            context.Users.Add(user);
-            await context.SaveChangesAsync();
-            Log.Information("مدیر کل با موفقیت ایجاد شد.");
-        }
-        else
-        {
-            Log.Information("مدیر کل قبلاً وجود دارد. برنامه بدون خطا اجرا می‌شود.");
-        }
-    }
-    catch (Exception ex)
-    {
-        Log.Error(ex, "خطا در مایگریشن یا سیید اولیه مدیر کل");
-        throw;
-    }
-}
-
-
-
+// Requests are refused with 503 until the migration above has succeeded, so this service never
+// answers against a schema it has not migrated (issue #230).
+app.UseDatabaseReadinessGate();
 
 
 // Authentication and authorization, Production only.

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -13,6 +13,7 @@ using TallaEgg.Core.DTOs.Wallet;
 using TallaEgg.Core.ErrorHandling;
 using TallaEgg.Core.Requests.Trade;
 using TallaEgg.Core.Requests.Wallet;
+using TallaEgg.Core.Startup;
 using Wallet.Application;
 using Wallet.Application.Mappers;
 using Wallet.Core;
@@ -150,17 +151,24 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
+// --- Migrations ---
+// Registered to run from a hosted service once the host has started, rather than between
+// Build() and Run() where it used to sit: under UseWindowsService() nothing is connected to the
+// SCM until Run(), so a database that was not answering yet blocked here until the SCM killed
+// the process (issue #230).
+builder.Services.AddDatabaseMigrationAtStartup(async (services, cancellationToken) =>
+{
+    var context = services.GetRequiredService<WalletDbContext>();
+    await context.Database.MigrateAsync(cancellationToken);
+});
+
 var app = builder.Build();
 
 app.UseTallaEggErrorHandling();
 
-// --- Migrations and initial seed ---
-using (var scope = app.Services.CreateScope())
-{
-    var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<WalletDbContext>();
-    await context.Database.MigrateAsync();
-}
+// Requests are refused with 503 until the migration above has succeeded, so this service never
+// answers against a schema it has not migrated (issue #230).
+app.UseDatabaseReadinessGate();
 
 // Authentication and authorization, Production only.
 if (app.Environment.IsProduction())

--- a/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AutoQuotePublisherServiceTests.cs
@@ -75,7 +75,7 @@ public class AutoQuotePublisherServiceTests : IDisposable
     // These tests drive PublishIfDueAsync directly, so the leader gate never runs; the lease is
     // stubbed to "yes" purely to satisfy the constructor.
     private AutoQuotePublisherService NewService() => new(
-        _provider.GetRequiredService<IServiceScopeFactory>(), _logger, new AlwaysLeaderLease());
+        _provider.GetRequiredService<IServiceScopeFactory>(), _logger, new AlwaysLeaderLease(), MigratedDatabase.Readiness());
 
     private AutoQuotePublisherService? _service;
 

--- a/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -103,7 +103,8 @@ public class BackgroundLeaderGateTests : IDisposable
         var publisher = new AutoQuotePublisherService(
             provider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<AutoQuotePublisherService>.Instance,
-            new AlwaysLeaderLease());
+            new AlwaysLeaderLease(),
+            MigratedDatabase.Readiness());
 
         Assert.True(await publisher.TryLeadAsync());
     }
@@ -115,7 +116,8 @@ public class BackgroundLeaderGateTests : IDisposable
         var publisher = new AutoQuotePublisherService(
             provider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<AutoQuotePublisherService>.Instance,
-            new HeldElsewhereLease());
+            new HeldElsewhereLease(),
+            MigratedDatabase.Readiness());
 
         Assert.False(await publisher.TryLeadAsync());
     }

--- a/tests/TallaEgg.AllServices.Tests/BackgroundLoopsWaitForMigrationTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BackgroundLoopsWaitForMigrationTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using TallaEgg.AllServices.Tests.Fakes;
+using TallaEgg.Core.Startup;
+
+namespace TallaEgg.AllServices.Tests;
+
+// Orders.Api's three background loops used to be guaranteed to start after the migration, because
+// the migration ran before app.Run(). Since issue #230 it runs alongside the host, so each loop
+// waits on DatabaseReadiness instead. The readiness gate cannot cover them — it turns away HTTP
+// requests, and a loop reaches the database without one.
+//
+// This matters beyond log noise: AutoQuotePublisherService.ExecuteAsync calls ActiveSymbolsAsync
+// outside any try/catch, and an exception escaping a BackgroundService stops the entire host under
+// the default BackgroundServiceExceptionBehavior.StopHost — the outage #230 exists to remove,
+// re-entered through the back door on any deploy that carries a pending migration.
+public class BackgroundLoopsWaitForMigrationTests
+{
+    /// <summary>
+    /// Long enough for a loop that does not wait to reach its first query — each of the three
+    /// starts working immediately, before its first poll delay.
+    /// </summary>
+    private static readonly TimeSpan GraceWindow = TimeSpan.FromMilliseconds(500);
+
+    [Fact]
+    public async Task OutboxProcessor_MigrationHasNotSucceeded_DoesNotReachTheDatabase()
+    {
+        var scopeFactory = new ForbiddenScopeFactory();
+
+        var service = new OutboxProcessorService(
+            scopeFactory,
+            new InstanceIdentity("waits-for-migration-tests"),
+            NullLogger<OutboxProcessorService>.Instance,
+            new DatabaseReadiness());
+
+        await RunBrieflyAsync(service);
+
+        Assert.False(scopeFactory.WasUsed, scopeFactory.Explanation);
+    }
+
+    [Fact]
+    public async Task AutoQuotePublisher_MigrationHasNotSucceeded_DoesNotReachTheDatabase()
+    {
+        var scopeFactory = new ForbiddenScopeFactory();
+
+        var service = new AutoQuotePublisherService(
+            scopeFactory,
+            NullLogger<AutoQuotePublisherService>.Instance,
+            new AlwaysLeaderLease(),
+            new DatabaseReadiness());
+
+        await RunBrieflyAsync(service);
+
+        Assert.False(scopeFactory.WasUsed, scopeFactory.Explanation);
+    }
+
+    [Fact]
+    public async Task MatchingEngine_MigrationHasNotSucceeded_DoesNotReachTheDatabase()
+    {
+        var scopeFactory = new ForbiddenScopeFactory();
+
+        var service = new MatchingEngineService(
+            scopeFactory,
+            NullLogger<MatchingEngineService>.Instance,
+            new ServiceCollection().BuildServiceProvider(),
+            new ConfigurationBuilder().Build(),
+            new AlwaysLeaderLease(),
+            new DatabaseReadiness());
+
+        await RunBrieflyAsync(service);
+
+        Assert.False(scopeFactory.WasUsed, scopeFactory.Explanation);
+    }
+
+    [Fact]
+    public async Task WaitUntilReadyAsync_MigrationSucceeds_ReleasesTheWaiter()
+    {
+        var readiness = new DatabaseReadiness();
+        var waiting = readiness.WaitUntilReadyAsync(CancellationToken.None);
+
+        Assert.False(waiting.IsCompleted);
+
+        readiness.MarkReady();
+
+        Assert.True(await waiting);
+    }
+
+    [Fact]
+    public async Task WaitUntilReadyAsync_HostShutsDownFirst_ReturnsFalseRatherThanThrowing()
+    {
+        var readiness = new DatabaseReadiness();
+        using var shutdown = new CancellationTokenSource();
+
+        var waiting = readiness.WaitUntilReadyAsync(shutdown.Token);
+        shutdown.Cancel();
+
+        // A loop that has to catch here is a loop that will one day forget to.
+        Assert.False(await waiting);
+    }
+
+    private static async Task RunBrieflyAsync(Microsoft.Extensions.Hosting.BackgroundService service)
+    {
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(GraceWindow);
+
+        // Rethrows anything the loop threw, so a loop that fell over rather than waiting fails
+        // here rather than passing quietly.
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private sealed class ForbiddenScopeFactory : IServiceScopeFactory
+    {
+        public bool WasUsed { get; private set; }
+
+        public string Explanation =>
+            "The loop opened a scope before the migration had succeeded, so it would have queried a " +
+            "schema that may still be changing (issue #230).";
+
+        public IServiceScope CreateScope()
+        {
+            WasUsed = true;
+            throw new InvalidOperationException(Explanation);
+        }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/DatabaseMigrationHostedServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DatabaseMigrationHostedServiceTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using TallaEgg.Core.Startup;
+
+namespace TallaEgg.AllServices.Tests;
+
+// The retry half of issue #230: what the migration host does when the database is not answering
+// yet. Constructed through the internal constructor so the real backoff — five seconds growing to
+// sixty, ten attempts — does not have to be waited out; the schedule itself is a constant and is
+// not what these assert.
+public class DatabaseMigrationHostedServiceTests
+{
+    private static readonly TimeSpan NoDelay = TimeSpan.FromMilliseconds(1);
+
+    [Fact]
+    public async Task ExecuteAsync_MigrationSucceedsImmediately_OpensReadinessAndLeavesTheHostRunning()
+    {
+        var readiness = new DatabaseReadiness();
+        var lifetime = new RecordingHostApplicationLifetime();
+        var attempts = 0;
+
+        var service = Create(readiness, lifetime, (_, _) =>
+        {
+            attempts++;
+            return Task.CompletedTask;
+        });
+
+        await RunToCompletionAsync(service);
+
+        Assert.Equal(1, attempts);
+        Assert.True(readiness.IsReady);
+        Assert.False(lifetime.StopRequested);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DatabaseArrivesLate_RetriesUntilItSucceeds()
+    {
+        var readiness = new DatabaseReadiness();
+        var lifetime = new RecordingHostApplicationLifetime();
+        var attempts = 0;
+
+        var service = Create(readiness, lifetime, (_, _) =>
+        {
+            attempts++;
+
+            // Stands in for a SQL Server that is Running but not yet accepting connections.
+            if (attempts < 3)
+            {
+                throw new InvalidOperationException("the database is not answering yet");
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await RunToCompletionAsync(service);
+
+        Assert.Equal(3, attempts);
+        Assert.True(readiness.IsReady);
+
+        // The recovery is what matters: no restart was needed, and the host was never stopped.
+        Assert.False(lifetime.StopRequested);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MigrationNeverSucceeds_StopsTheHostAndLeavesReadinessClosed()
+    {
+        var readiness = new DatabaseReadiness();
+        var lifetime = new RecordingHostApplicationLifetime();
+        var attempts = 0;
+
+        var service = Create(readiness, lifetime, (_, _) => throw new InvalidOperationException($"attempt {++attempts} failed"));
+
+        // The service under test sets the process exit code so a supervisor can tell an abandoned
+        // migration from a clean stop. Left set, it would be the exit code of this test run.
+        var exitCodeBeforeTest = Environment.ExitCode;
+        try
+        {
+            await RunToCompletionAsync(service);
+
+            Assert.Equal(MaxAttemptsUnderTest, attempts);
+            Assert.NotEqual(0, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = exitCodeBeforeTest;
+        }
+
+        // A database that never comes up has to end in a stopped service, not one that reports
+        // Running and answers 503 to everything for the rest of the day.
+        Assert.True(lifetime.StopRequested);
+        Assert.False(readiness.IsReady);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HostShutsDownWhileRetrying_StopsWithoutStoppingTheHostAgain()
+    {
+        var readiness = new DatabaseReadiness();
+        var lifetime = new RecordingHostApplicationLifetime();
+
+        // Long enough that the loop is certainly waiting out its backoff when the host stops,
+        // rather than racing to exhaust the budget first.
+        var service = Create(
+            readiness,
+            lifetime,
+            (_, _) => throw new InvalidOperationException("the database is not answering yet"),
+            retryDelay: TimeSpan.FromMinutes(1));
+
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.False(readiness.IsReady);
+
+        // Shutting down is not the same as giving up: the retry budget was never exhausted, so
+        // nothing here should look like a failed migration.
+        Assert.False(lifetime.StopRequested);
+    }
+
+    private const int MaxAttemptsUnderTest = 3;
+
+    private static DatabaseMigrationHostedService Create(
+        DatabaseReadiness readiness,
+        IHostApplicationLifetime lifetime,
+        DatabaseMigrationStep migrate,
+        TimeSpan? retryDelay = null)
+    {
+        var scopeFactory = new ServiceCollection()
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+        return new DatabaseMigrationHostedService(
+            scopeFactory,
+            migrate,
+            readiness,
+            lifetime,
+            NullLogger<DatabaseMigrationHostedService>.Instance,
+            MaxAttemptsUnderTest,
+            retryDelay ?? NoDelay,
+            retryDelay ?? NoDelay);
+    }
+
+    private static async Task RunToCompletionAsync(DatabaseMigrationHostedService service)
+    {
+        await service.StartAsync(CancellationToken.None);
+
+        // StartAsync returns as soon as ExecuteAsync yields, which is the behaviour the fix
+        // depends on; ExecuteTask is the loop that carries on behind it.
+        await service.ExecuteTask!;
+    }
+
+    private sealed class RecordingHostApplicationLifetime : IHostApplicationLifetime
+    {
+        public bool StopRequested { get; private set; }
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => StopRequested = true;
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/DatabaseMigrationStartupTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DatabaseMigrationStartupTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TallaEgg.Core.Startup;
+
+namespace TallaEgg.AllServices.Tests;
+
+// The startup half of issue #230, wired the way Wallet.Api, Users.Api and Orders.Api wire it:
+// AddDatabaseMigrationAtStartup on the services, UseDatabaseReadinessGate on the application.
+// Against a bare TestServer rather than any service's Program, because none of them can boot
+// here without a live SQL Server (issue #68).
+//
+// Every test here starts the host while the migration is still blocked, which is the condition
+// the issue is about. Move the migration back onto the pre-start path and all four fail.
+public class DatabaseMigrationStartupTests
+{
+    private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task StartAsync_MigrationHasNotFinished_HostStillReportsStarted()
+    {
+        var migrationGate = NewGate();
+        using var host = BuildHost((_, _) => migrationGate.Task);
+
+        try
+        {
+            // The assertion is inside the helper: reaching this line at all is the result.
+            await StartWithinTimeoutAsync(host);
+        }
+        finally
+        {
+            migrationGate.TrySetResult();
+            await StopQuietlyAsync(host);
+        }
+    }
+
+    [Fact]
+    public async Task Request_MigrationHasNotSucceeded_IsRefusedWith503()
+    {
+        var migrationGate = NewGate();
+        using var host = BuildHost((_, _) => migrationGate.Task);
+
+        try
+        {
+            await StartWithinTimeoutAsync(host);
+
+            var response = await host.GetTestClient().GetAsync("/api/wallet/balance");
+
+            // Serving here would answer against a schema that has not been migrated.
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        }
+        finally
+        {
+            migrationGate.TrySetResult();
+            await StopQuietlyAsync(host);
+        }
+    }
+
+    [Fact]
+    public async Task Request_DatabaseArrivesLate_IsServedOnceTheMigrationSucceeds()
+    {
+        var migrationGate = NewGate();
+        using var host = BuildHost((_, _) => migrationGate.Task);
+
+        try
+        {
+            await StartWithinTimeoutAsync(host);
+
+            var client = host.GetTestClient();
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, (await client.GetAsync("/api/wallet/balance")).StatusCode);
+
+            // The database turns up. No restart and no second process — this host recovers.
+            migrationGate.TrySetResult();
+            await WaitUntilReadyAsync(host);
+
+            var response = await client.GetAsync("/api/wallet/balance");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("served", await response.Content.ReadAsStringAsync());
+        }
+        finally
+        {
+            migrationGate.TrySetResult();
+            await StopQuietlyAsync(host);
+        }
+    }
+
+    [Fact]
+    public async Task VersionRequest_MigrationHasNotSucceeded_IsStillAnswered()
+    {
+        var migrationGate = NewGate();
+        using var host = BuildHost((_, _) => migrationGate.Task);
+
+        try
+        {
+            await StartWithinTimeoutAsync(host);
+
+            // "Which build is running?" is the question a degraded service exists to answer
+            // (issue #218), and it reads nothing from the database.
+            var response = await host.GetTestClient().GetAsync("/version");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        finally
+        {
+            migrationGate.TrySetResult();
+            await StopQuietlyAsync(host);
+        }
+    }
+
+    private static TaskCompletionSource NewGate() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static IHost BuildHost(DatabaseMigrationStep migrate) =>
+        new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services => services.AddDatabaseMigrationAtStartup(migrate))
+                    .Configure(app =>
+                    {
+                        app.UseDatabaseReadinessGate();
+                        app.Run(context => context.Response.WriteAsync("served"));
+                    });
+            })
+            .Build();
+
+    /// <summary>
+    /// Starts the host and fails if it does not report started while the migration is still
+    /// blocked — the regression this whole issue is about.
+    /// </summary>
+    private static async Task StartWithinTimeoutAsync(IHost host)
+    {
+        // Started on a pool thread on purpose. A migration back on the pre-start path can block
+        // its caller's thread outright rather than hand back a pending task — that is exactly
+        // what the old top-level `await MigrateAsync()` did — and this has to fail on that
+        // rather than hang with it.
+        var start = Task.Run(() => host.StartAsync());
+        var first = await Task.WhenAny(start, Task.Delay(StartTimeout));
+
+        Assert.True(
+            ReferenceEquals(first, start),
+            "The host did not report started while the migration was still blocked, so the migration is back on the pre-start path. " +
+            "Under UseWindowsService() that is the window the SCM counts against its start timeout (issue #230).");
+
+        await start;
+    }
+
+    private static async Task WaitUntilReadyAsync(IHost host)
+    {
+        var readiness = host.Services.GetRequiredService<DatabaseReadiness>();
+        var deadline = DateTime.UtcNow + ReadyTimeout;
+
+        while (!readiness.IsReady && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+
+        Assert.True(readiness.IsReady, "The migration completed but the readiness gate never opened.");
+    }
+
+    /// <summary>
+    /// Cleanup only. A host whose start never completed cannot be stopped cleanly, and the
+    /// failure that caused it is the one worth reporting.
+    /// </summary>
+    private static async Task StopQuietlyAsync(IHost host)
+    {
+        try
+        {
+            await host.StopAsync();
+        }
+        catch (Exception)
+        {
+            // Deliberately ignored; see above.
+        }
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/Fakes/MigratedDatabase.cs
+++ b/tests/TallaEgg.AllServices.Tests/Fakes/MigratedDatabase.cs
@@ -1,0 +1,23 @@
+using TallaEgg.Core.Startup;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// A <see cref="DatabaseReadiness"/> that is already open, for tests that construct a background
+/// loop directly.
+/// </summary>
+/// <remarks>
+/// Since issue #230 those loops wait on readiness before touching the database, because the
+/// migration now runs alongside the host rather than ahead of it. These tests drive their target
+/// method directly against an already-migrated in-memory database, so the honest stand-in is a
+/// readiness that has already opened — a closed one would hang the loop, which is the point of it.
+/// </remarks>
+internal static class MigratedDatabase
+{
+    public static DatabaseReadiness Readiness()
+    {
+        var readiness = new DatabaseReadiness();
+        readiness.MarkReady();
+        return readiness;
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/OutboxBatchResilienceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxBatchResilienceTests.cs
@@ -107,7 +107,8 @@ public class OutboxBatchResilienceTests : IDisposable
         var processor = new OutboxProcessorService(
             _provider.GetRequiredService<IServiceScopeFactory>(),
             new InstanceIdentity("batch-resilience-tests"),
-            NullLogger<OutboxProcessorService>.Instance);
+            NullLogger<OutboxProcessorService>.Instance,
+            MigratedDatabase.Readiness());
 
         // Must not throw — the loop absorbs the persistence failure.
         await processor.ProcessDueMessagesAsync(CancellationToken.None);

--- a/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxDueSelectionTests.cs
@@ -98,7 +98,8 @@ public class OutboxDueSelectionTests : IDisposable
         var processor = new OutboxProcessorService(
             _provider.GetRequiredService<IServiceScopeFactory>(),
             new InstanceIdentity("due-selection-tests"),
-            NullLogger<OutboxProcessorService>.Instance);
+            NullLogger<OutboxProcessorService>.Instance,
+            MigratedDatabase.Readiness());
 
         await processor.ProcessDueMessagesAsync(CancellationToken.None);
     }

--- a/tests/TallaEgg.AllServices.Tests/OutboxLeaseTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OutboxLeaseTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -90,7 +90,8 @@ public class OutboxLeaseTests : IDisposable
     private OutboxProcessorService ProcessorFor(string instance) => new(
         _provider.GetRequiredService<IServiceScopeFactory>(),
         new InstanceIdentity(instance),
-        NullLogger<OutboxProcessorService>.Instance);
+        NullLogger<OutboxProcessorService>.Instance,
+        MigratedDatabase.Readiness());
 
     private static string PayloadFor(Guid tradeId) =>
         System.Text.Json.JsonSerializer.Serialize(new TradeDto


### PR DESCRIPTION
**Branch Name**: `fix/migrate-after-host-start`
**Linked Issue**: closes #230

---

## Description

All three deployed APIs ran `Database.MigrateAsync()` in top-level statements between
`builder.Build()` and `app.Run()`. Under `UseWindowsService()` the process does not connect to the
SCM dispatcher until `app.Run()`, so every second spent migrating was a second the SCM counted
against its 45-second start timeout *with nothing connected yet* — and a database that was not
answering did not fail fast, it blocked, and the process was killed before it could report
anything.

This moves the migration onto a hosted service that runs after the host has started, with bounded
retry and backoff, and refuses requests with `503` until it succeeds.

#228 fixed the *ordering* — SQL Server is now an SCM dependency of these three. It cannot fix that
`Running` for SQL Server means the process started, not that the instance accepts connections.
This closes that remainder.

---

## Type of Change

- [x] Hotfix (urgent bug fix)
- [x] Documentation (the runbook half)

---

## Changes Made

New shared bootstrap in `TallaEgg.Core.Startup`:

- **`DatabaseMigrationHostedService`** — a `BackgroundService` that yields immediately, then
  applies the migration, retrying on failure. Ten attempts; backoff doubles from 5s to a 60s
  ceiling (~6 minutes of waiting, plus each attempt's own connection timeout). Every attempt is
  logged with its exception.
- **`DatabaseReadiness`** — a singleton flag, written once when the migration succeeds.
- **`UseDatabaseReadinessGate()`** — middleware answering `503 Service Unavailable` with an
  `ApiResponse.Fail` body and a `Retry-After` header until that flag opens.
- **`AddDatabaseMigrationAtStartup(migrate)`** — the registration, one line per service.

Call sites:

- `Wallet.Api`, `Users.Api`, `Orders.Api`: the old `using (var scope = app.Services.CreateScope())`
  block becomes the delegate passed to `AddDatabaseMigrationAtStartup`, registered *before*
  `Build()`; `UseDatabaseReadinessGate()` goes in directly after `UseTallaEggErrorHandling()`.
- `Orders.Api`: the instance-identity line reads a singleton and touches no database, so it moves
  **out** of the retrying step and is logged straight after `Build()` — earlier than before, which
  keeps the "before anything it writes carries that name" property (#160) that this change would
  otherwise have weakened.
- `Users.Api`: the `try`/`catch` that logged and rethrew is gone — the retry loop logs every failed
  attempt with its exception, which is all that block did.
- `Orders.Api`'s three background loops (`MatchingEngineService`, `OutboxProcessorService`,
  `AutoQuotePublisherService`) each `await _readiness.WaitUntilReadyAsync(stoppingToken)` before
  their first query. They used to be guaranteed to start after the migration; they no longer are.
  See the self-review below — this one was not optional.
- `AddMatchingEngine` and `AddDatabaseMigrationAtStartup` both register `DatabaseReadiness` with
  `TryAddSingleton`, so they compose in either order and the existing registration tests keep going
  through the production path unchanged.

Docs: `docs/operations/WINDOWS_DEPLOYMENT.md` (the "what neither ordering buys" section that #231
wrote and this falsifies — rewritten with the three log shapes an operator will actually see),
`AGENT.md`, and the comment in `install-services.ps1` that said the same thing.

---

## Two decisions the issue asked me to make and defend

### 1. What the service does before the migration succeeds: **it refuses every request with 503**

Confirmed with the owner before building it, because it changes an external contract.

There is no health or readiness endpoint in any of the three services today — `driver.ps1` probes
the Swagger page. So "fail readiness" had to be either a gate on the endpoints that exist or a new
endpoint. The gate won: adding `/ready` would have added a contract with no consumer (there is no
orchestrator and no probe), while the gate makes the failure legible everywhere it can actually be
observed.

Serving instead was the alternative, and it is worse: the caller gets whatever error the missing
schema raises, as a 500 with a stack trace in the log, rather than "still starting, try again".

**`GET /version` is exempt.** Answering "which build is this?" while a service is degraded is the
entire reason it exists (#218), and it reads nothing from the database.

One consequence worth naming: `/api-docs` is *not* exempt, so `driver.ps1 start` now waits for the
migration to actually succeed rather than for a port to open. That is a better probe than it had.

### 2. Shared code, not three copies

The three differ only in which `DbContext` they resolve and what they seed, so that part is a
delegate and the retry/backoff/logging/give-up is written once. #205 is the precedent the issue
points at — one mistake copied into five bootstraps because no shared one existed — and a retry
schedule is exactly the kind of thing that would be tuned in one place and left stale in two.

`TallaEgg.Core` already carries the other shared bootstrap concerns (`StartupLogging`,
`ConfigurationGuard`, `ApiKeyAuthenticationHandler`), and the delegate keeps EF Core out of it.

### Giving up loudly

After ten failed attempts the service logs the exception at `Fatal`, sets a non-zero process exit
code and calls `StopApplication()`. A database that never comes up therefore ends as a `Stopped`
service, not a `Running` one answering 503 forever.

**Do not read the exit code as a restart trigger.** `Environment.ExitCode` sets the *process* exit
code, which a console run or CI sees. The SCM reports `ServiceBase.ExitCode`, a different value,
not reachable from the shared kernel without a Windows-only dependency — so the `sc.exe failure`
restart actions `install-services.ps1` configures cannot be assumed to fire on it. The `Fatal` log
line and the service reaching `Stopped` are the signal that is guaranteed either way. The code
comment says exactly this; step 5 of the verification below is me asking you to settle it on the
server, since I have no elevation here to create a throwaway service and find out.

---

## Scope: what I deliberately did not do

**`Affiliate.Api` has the same shape and is excluded.** It calls `MigrateAsync()` at
`Program.cs:137` with `app.Run()` at 226 — but it does **not** call `UseWindowsService()`, is not
one of the four services `install-services.ps1` installs, and ships zero migration files, so it
fails every request regardless (`AGENT.md`). None of the failure mode described here can reach it.

**`TallaEgg.Api` does not have the shape.** No `MigrateAsync()`, no `UseWindowsService()`, and it
maps no endpoints.

The Persian comment `// اجرای مایگریشن‌ها` ("run the migrations") on the moved lines in `Users.Api`
and `Orders.Api` is dropped rather than translated: it is the "what, not why" comment that
`STANDARDS.md` §5 uses as its own bad example. The Persian *log messages* that moved with the
`Users.Api` seed are rewritten in English. The seeded administrator's Persian name is data and is
untouched.

---

## Testing Completed

### Build and unit tests

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)

dotnet test TallaEgg.sln --no-build
Passed! - Failed: 0, Passed: 880, Skipped: 0, Total: 880

bash scripts/check-doc-paths.sh
402 tracked text file(s) checked, every reference resolves.
```

867 → 880: thirteen new tests.

- `DatabaseMigrationStartupTests` — the host reports started while the migration is still blocked;
  requests are 503; a late database is served once it succeeds; `/version` is not gated.
- `DatabaseMigrationHostedServiceTests` — success on the first attempt; retry until success;
  give-up stops the host and leaves readiness closed; shutdown mid-retry is not give-up.
- `BackgroundLoopsWaitForMigrationTests` — none of the three Orders loops opens a scope before
  readiness; `WaitUntilReadyAsync` releases on success and returns false on shutdown.

**The startup tests are the regression guard, and I checked they bite.** With the migration put
back on the pre-start path — `_migrate(...).GetAwaiter().GetResult()` in place of the yield — all
four fail in 10s with the reason, rather than hanging:

```
Failed DatabaseMigrationStartupTests.StartAsync_MigrationHasNotFinished_HostStillReportsStarted [10 s]
  The host did not report started while the migration was still blocked, so the migration is back
  on the pre-start path. Under UseWindowsService() that is the window the SCM counts against its
  start timeout (issue #230).
Failed!  - Failed: 4, Passed: 0, Skipped: 0, Total: 4
```

(That mutation is not in the diff — it was applied, run, and reverted.)

### (a) The failure, reproduced before the change

`Wallet.Api` on `main`, connection string pointed at an unroutable address so the connect blocks
rather than being refused:

```
[18:18:39 INF] Starting Wallet.Api, version 1.2.0, built from commit 1563b7d...
[18:19:44 FTL] The service is terminating on an unhandled exception.
System.InvalidOperationException: An exception has been raised that is likely due to a transient failure...
   at Microsoft.EntityFrameworkCore.Migrations.Internal.Migrator.MigrateAsync(...)
   at Program.<Main>$(String[] args) in ...\src\Wallet\Wallet.Api\Program.cs:line 162
```

**Blocked for 65 seconds and died at `Program.cs:162`. `Application started` never appeared** —
`grep -c "Application started"` → `0`. Under the SCM that is a kill at 45s with the service never
having connected, which is exactly the #228 event-log wording.

### (b) Same condition, after the change

Connection string pointed at `127.0.0.1:14330`, where nothing is listening:

```
PASS (b): 'Application started' after 1.5s, with the database unreachable.
  3 failed attempt(s) logged after 60s; the service is still up.
```

Probes during that window:

```
  /api/wallet/balance?userId=1 -> 503  {"success":false,"message":"سرویس هنوز آماده نیست: مهاجرت پایگاه داده کامل نشده است. لطفاً چند لحظه دیگر دوباره تلاش کنید.","data":null}
  /api-docs/index.html         -> 503  (same body)
  /version                     -> 200
```

### (c) The database arrives late

A TCP forwarder onto the real SQL Server is started only after three attempts have already failed:

```
[18:53:20 INF] Now listening on: http://localhost:60933
[18:53:20 INF] Application started. Press Ctrl+C to shut down.
[18:53:35 WRN] Database migration attempt 1 of 10 failed. Retrying in 5s; requests are answered 503 until it succeeds.
[18:53:55 WRN] Database migration attempt 2 of 10 failed. Retrying in 10s; requests are answered 503 until it succeeds.
[18:54:20 WRN] Database migration attempt 3 of 10 failed. Retrying in 20s; requests are answered 503 until it succeeds.
[18:54:40 INF] Database migration succeeded on attempt 4 of 10. The service is now answering requests.
```

```
PASS (c): migration succeeded 20s after the database arrived, with no restart.
  /api-docs/index.html -> 200
  /version             -> 200
```

**No restart, no second process** — the same host recovered on its own.

### (c) again, against `Orders.Api` — the one with background loops

The same script against `Orders.Api`, because it is the service where the loops could have reached
the database ahead of the migration:

```
PASS (b): 'Application started' after 2.9s, with the database unreachable.
  3 failed attempt(s) logged after 60s; the service is still up.
  /api/symbols/active  -> 503
  /version             -> 200
PASS (c): migration succeeded 20s after the database arrived, with no restart.
  /api-docs/index.html -> 200
```

All three loops logged themselves started and then waited. Across the ~80-second window with no
database, the log contains **no exception from any of them** — only the migration's own retry
warnings and the 503s from the probes above:

```
[19:22:39 INF] Application started. Press Ctrl+C to shut down.
[19:22:39 INF] 🚀 Matching Engine Service is starting...
[19:22:39 INF] OutboxProcessorService started (poll every 5s).
[19:22:39 INF] AutoQuotePublisherService started (poll every 2m).
[19:22:55 WRN] Database migration attempt 1 of 10 failed. Retrying in 5s; requests are answered 503 until it succeeds.
[19:23:14 WRN] Database migration attempt 2 of 10 failed. Retrying in 10s; requests are answered 503 until it succeeds.
[19:23:39 WRN] Database migration attempt 3 of 10 failed. Retrying in 20s; requests are answered 503 until it succeeds.
[19:24:00 INF] Database migration succeeded on attempt 4 of 10. The service is now answering requests.
```

### End-to-end, healthy database — unchanged

```
driver.ps1 start
All services up after 4s.

driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
=== Done in 00:00:37.1. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled
  MAUA/IRT: 17 filled
  SEKE_BAHAR/IRT: 16 filled
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
```

Date/time run: 2026-09-07.

### Environment

- [x] Tested locally (Windows + SQL Server Express)
- [ ] **Not** tested under the SCM — see below. No elevation on this machine.

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys or tokens
- [x] No connection string appears in this PR, in any log quoted here, or in the diff — the
      reproduction rewrote only the `Server=` field of the real one, inside a script, and never
      printed it
- [x] No machine names, addresses, usernames or personal paths
- [x] `config/appsettings.global.json` untouched and uncommitted
- [x] Code compiles without warnings

---

## Code Quality

- [x] Naming per `STANDARDS.md`; new tests are `Method_Scenario_ExpectedResult`
- [x] Comments in English, explaining why
- [x] No large blocks of commented-out code

---

## Breaking Changes?

- [x] **Yes, one, and it was approved before it was built.** Between host start and a successful
      migration, every endpoint on the three APIs answers `503` instead of serving. `GET /version`
      is exempt. With a healthy database the window is about a second; the smoke run above did not
      notice it.

The bot's typed clients treat a non-2xx as a failed call, which it is. Nothing else consumes these
APIs.

---

## Deployment Notes

**Pre-deployment**: nothing. No migration, no configuration key, no environment variable. The
change is entirely in how the existing migration is scheduled.

**Rollback**: revert the commit and redeploy. No data or schema is involved — a rolled-back binary
migrates the same database the same way, just earlier.

**Read this first, though:** #228's fix — the `sc.exe` dependency on the SQL Server service — **is
in this repository but has not been applied to the VM.** So today nothing on that machine protects
a boot. This change does not need it and does not replace it: they cover different halves. #228
gets SQL Server started ahead of the APIs; this makes the APIs survive SQL Server not yet
answering. Applying #228's three `sc.exe config` lines (PR #231, "Verification I need to run",
step 2) is still worth doing, and can be done before or after this deploy — it needs no restart.

---

## Verification I need you to run

Everything above is a developer machine. The proof that matters is under the SCM, on the server,
and only you can run it.

### 1. Redeploy the three APIs

`publish-all.ps1` then `install-services.ps1`, per the runbook. Nothing new is needed on the
command line.

### 2. Confirm each service now starts without waiting for its database

This is the whole change, and it is visible without a reboot. From an **elevated PowerShell
session**:

```powershell
Stop-Service 'MSSQL$SQLEXPRESS' -Force
Restart-Service TallaEggWalletApi
Get-Service TallaEggWalletApi | Format-Table Status, Name -AutoSize
```

**Pass** is `Running`, reached in a few seconds. Before this change that command failed after 45
seconds with *"The service did not respond to the start or control request in a timely fashion."*

Then its own log, `C:\TallaEgg\publish\Wallet.Api\logs\wallet-api-<date>.log`:

```
[INF] Application started. Press Ctrl+C to shut down.
[WRN] Database migration attempt 1 of 10 failed. Retrying in 5s; requests are answered 503 until it succeeds.
```

Seeing `Application started` **before** the first migration warning is the fix. If the warnings are
absent and the service is `Running`, the database was reachable after all — stop SQL Server first
and try again, or the test proves nothing.

### 3. Confirm it recovers on its own

```powershell
Start-Service 'MSSQL$SQLEXPRESS'
```

Within a minute the same log should show, with no restart of the API:

```
[INF] Database migration succeeded on attempt N of 10. The service is now answering requests.
```

Then start the other three services and confirm the stack works normally.

**Do not leave SQL Server stopped for more than about eight minutes** during this test. Ten
attempts is roughly six minutes of backoff plus each attempt's connection timeout, after which the
service deliberately stops itself. That is the designed behavior, not a failure — but you would
then need to start it again by hand.

### 4. Reboot (this also verifies #228, if you have applied it)

```powershell
Restart-Computer -Force
```

Wait five minutes, then:

```powershell
Get-Service 'MSSQL$SQLEXPRESS','TallaEggWalletApi','TallaEggUsersApi','TallaEggOrdersApi','TallaEggBot' |
    Format-Table Status, Name, StartType -AutoSize
```

**Pass** is all five `Running` with nobody having started anything by hand.

### 5. The one thing I could not determine — please look

If step 3 is skipped and the migration is allowed to exhaust its ten attempts, the service stops
with a non-zero process exit code. I could not establish whether the SCM records that as a failure
and applies the configured restart actions. If you happen to see it, this tells you:

```powershell
Get-WinEvent -FilterHashtable @{ LogName='System'; ProviderName='Service Control Manager' } -MaxEvents 40 |
    Sort-Object TimeCreated | Format-List TimeCreated, Id, Message
```

An event 7031/7034 naming `TallaEggWalletApi` means the SCM saw it as a failure and the restart
actions apply. A plain 7036 "entered the stopped state" means it did not, and a stopped service
after a hopeless migration needs a person. Either is acceptable behavior; I would just like the
runbook to say which one is true.

### If something goes wrong

Collect the service's own log around the failure — the migration lines say precisely which attempt
failed and why — and reopen #230. Rollback is a redeploy of the previous binaries; nothing on disk
or in the database changes.

---

## Self-review (`/code-review high`)

Four findings, all from one blind spot: **the readiness gate covers inbound HTTP, and nothing was
done about the background loops that used to be guaranteed to start after the migration.** All four
are fixed in the second commit.

1. **`Orders.Api`'s three loops were not gated (the serious one).** I had decided against gating
   them, reasoning it was log noise the loops already tolerate. That was wrong, and the mechanism I
   missed is specific: `AutoQuotePublisherService.ExecuteAsync` calls `ActiveSymbolsAsync` outside
   any `try`/`catch`, and no host here overrides `BackgroundServiceExceptionBehavior`, so the .NET
   default of **`StopHost`** applies. On an upgrade carrying a pending migration the
   `ServiceLeases` table already exists, so the lease is acquirable, the query hits a schema
   mid-change, and the escaping `SqlException` takes the whole host down — #230's outage, re-entered
   through the back door by the fix for it. **Verified before fixing**: `LeaderGate.TryLeadAsync`
   does swallow database errors (so a *fully down* database is safe), and `grep` confirms no
   `BackgroundServiceExceptionBehavior` anywhere in the repo. All three loops now wait.
2. **The outbox loop could dispatch settlements against a pre-migration read.** Same fix.
3. **`Environment.ExitCode` is not what the SCM reads.** The comment claimed more than the code
   delivers; corrected, and reflected under "Giving up loudly" above.
4. **`MarketModeStartupValidator` inside the retried step.** A throw from a check documented as
   "logged only; it does not stop the service" (#73) would have held readiness closed and stopped
   the service after ten attempts. It has its own catch now.

The review also cleared, and I confirmed: `/version` path matching in all three services;
`WalletApiClient` failing closed on a 503, so the gate cannot turn a wallet outage into a false
"zero balance"; and `MatchingEngineService`/`LeaderGate` swallowing database errors.

**Both new guards were checked against a mutation rather than assumed.** Putting the migration back
on the pre-start path fails all four `DatabaseMigrationStartupTests` in 10s with the reason quoted
above; removing the readiness wait from `AutoQuotePublisherService` fails
`AutoQuotePublisher_MigrationHasNotSucceeded_DoesNotReachTheDatabase`. Neither mutation is in the
diff.

---

## Related Issues

- Closes #230
- Completes the pair with #228 / PR #231, which ordered SQL Server first but could not wait for it
- The shared-bootstrap reasoning is #205's
- `/version` staying answerable while degraded is #218's

🤖 Generated with [Claude Code](https://claude.com/claude-code)
