### PR TITLE
[Fix] Make the published schema describe what the servers do — issue #237

### DIFF
--- a/docs/process/STANDARDS.md
+++ b/docs/process/STANDARDS.md
@@ -103,9 +103,13 @@ A trading pair is spelled `asset` in some schemas and `symbol` in others, and it
 `amount` or `quantity` along exactly the same line. This is real and pre-existing, not a mistake
 waiting to be tidied:
 
-| `asset` / `amount` | `symbol` / `quantity` |
-|---|---|
-| `OrderDto`, `OrderHistoryDto`, `WalletRequest` | `AcceptQuoteRequest`, `BestPricesDto`, `PublishQuoteRequest`, `TradeDto`, `TradeHistoryDto`, `PositionDto` |
+| | `asset` / `amount` | `symbol` / `quantity` |
+|---|---|---|
+| **request bodies** | `OrderDto`, `WalletRequest` | `AcceptQuoteRequest`, `PublishQuoteRequest`, `TradeDto` |
+| **responses** | `OrderHistoryDto` | `BestPricesDto`, `TradeDto`, `TradeHistoryDto`, `PositionDto` |
+
+`TradeDto` is on both rows: it is the body Orders posts to `/api/wallet/changeBalance` and part of
+what `POST /api/orders` returns.
 
 The two order-entry paths sit on opposite sides of it: `POST /api/orders` takes `asset`/`amount`,
 `POST /api/quotes/accept` takes `symbol`/`quantity`. A client that places orders has to know both

--- a/docs/process/STANDARDS.md
+++ b/docs/process/STANDARDS.md
@@ -97,6 +97,38 @@ sentences and holds the allowlist for the third; the two behavioral guards in
 `RequestDtoWireContractTests.cs` enforce the last. Adding a name to that allowlist is a contract
 decision, not a formatting one.
 
+#### Trading-pair vocabulary: two spellings, and which one a new endpoint takes
+
+A trading pair is spelled `asset` in some schemas and `symbol` in others, and its quantity is
+`amount` or `quantity` along exactly the same line. This is real and pre-existing, not a mistake
+waiting to be tidied:
+
+| `asset` / `amount` | `symbol` / `quantity` |
+|---|---|
+| `OrderDto`, `OrderHistoryDto`, `WalletRequest` | `AcceptQuoteRequest`, `BestPricesDto`, `PublishQuoteRequest`, `TradeDto`, `TradeHistoryDto`, `PositionDto` |
+
+The two order-entry paths sit on opposite sides of it: `POST /api/orders` takes `asset`/`amount`,
+`POST /api/quotes/accept` takes `symbol`/`quantity`. A client that places orders has to know both
+and pick per endpoint.
+
+**A new endpoint takes the spelling its own response already uses.** Where nothing constrains it —
+a genuinely new pair of request and response — use `symbol`/`quantity`, the larger group. That
+order matters and is not the same as "follow the majority": #235 kept `OrderDto` on `asset`/`amount`
+precisely because `OrderHistoryDto` is the response of that very endpoint, and a client works one
+endpoint at a time, so a request and response that disagree cost it more than a platform-wide
+majority it can look up once. Applying the majority rule first would reintroduce the mismatch that
+issue refused to create.
+
+**Unifying the two is not a rename**, which is why the split is written down rather than removed
+(issue #237). `TradeDto` is also the outbox payload: it is serialized into `OutboxMessages.Payload`
+with a bare `JsonSerializer` and read back case-sensitively, so renaming its properties silently
+turns every payload not yet settled into a settlement for an empty symbol and zero quantity.
+Changing it means a data migration over the stored payloads, plus a lockstep deployment of Orders
+and Wallet — `asset` versus `symbol` is a different name, not a different case, so the
+case-insensitive binding that makes ordinary DTO renames survive a mixed deployment does not bridge
+it. Worth doing only before a browser client (#97) ships against the current shape, and only as its
+own piece of work.
+
 #### Branch Names (Git)
 - **Feature**: `feat/{description}` (e.g., `feat/add-wallet-transaction`)
 - **Bugfix**: `fix/{description}` (e.g., `fix/null-reference-wallet`)

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -323,7 +323,25 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
+    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
+    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
+    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
+    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
+    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
+    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Issue #237.
+    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
+    {
+        foreach (var schema in document.Components.Schemas.Values)
+        {
+            // A schema that names a type for its extra members is describing a dictionary, which
+            // is a real statement about the payload. Only the blanket flag is cleared.
+            if (schema.AdditionalProperties is null)
+            {
+                schema.AdditionalPropertiesAllowed = true;
+            }
+        }
+    }));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Orders API V1");

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -23,6 +23,7 @@ using TallaEgg.Core.Startup;
 using TallaEgg.Infrastructure.Clients;
 using TallaEgg.TelegramBot.Infrastructure.Clients;
 using CancelActiveOrdersResponseDto = TallaEgg.Core.DTOs.Order.CancelActiveOrdersResponseDto;
+using TallaEgg.Core.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -323,25 +324,11 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
-    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
-    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
-    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
-    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
-    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
-    // these services actually do. Issue #237.
-    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
-    {
-        foreach (var schema in document.Components.Schemas.Values)
-        {
-            // A schema that names a type for its extra members is describing a dictionary, which
-            // is a real statement about the payload. Only the blanket flag is cleared.
-            if (schema.AdditionalProperties is null)
-            {
-                schema.AdditionalPropertiesAllowed = true;
-            }
-        }
-    }));
+    // Swashbuckle stamps `additionalProperties: false` on every object schema and no service
+    // enforces it; an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Why, at length, on the helper (issue #237).
+    app.UseSwagger(options =>
+        options.PreSerializeFilters.Add((document, _) => document.AllowUndeclaredMembers()));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Orders API V1");

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -47,10 +47,11 @@ namespace TallaEgg.Core.DTOs.Order
     /// Orders.Api validates this request by hand instead.
     ///
     /// An <c>Id</c> property went the same way (issue #237). It was a request field nothing read —
-    /// an order's id is assigned by the server — documented as "User id." four lines above the
-    /// separate <see cref="UserId"/>, so a client following it could reasonably have sent the user's
-    /// id as <c>id</c> and left the order's user empty. Removing it costs no caller anything: the
-    /// bot never set it, and a body that still carries <c>id</c> is accepted with the member ignored.
+    /// an order's id is assigned by the server — and it was documented as "User id." while a
+    /// separate <see cref="UserId"/> sat a few properties further down the same class, so a client
+    /// following that comment could reasonably have sent the user's id as <c>id</c> and left the
+    /// order's user empty. Removing it costs no caller anything: the bot never set it, and a body
+    /// that still carries <c>id</c> is accepted with the member ignored.
     /// </remarks>
     public class OrderDto
     {

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -45,14 +45,15 @@ namespace TallaEgg.Core.DTOs.Order
     /// calls <c>Validator.TryValidateObject</c> or registers a validation filter — so they enforced
     /// nothing while making the generated schema advertise constraints the server does not apply.
     /// Orders.Api validates this request by hand instead.
+    ///
+    /// An <c>Id</c> property went the same way (issue #237). It was a request field nothing read —
+    /// an order's id is assigned by the server — documented as "User id." four lines above the
+    /// separate <see cref="UserId"/>, so a client following it could reasonably have sent the user's
+    /// id as <c>id</c> and left the order's user empty. Removing it costs no caller anything: the
+    /// bot never set it, and a body that still carries <c>id</c> is accepted with the member ignored.
     /// </remarks>
     public class OrderDto
     {
-        /// <summary>
-        /// User id.
-        /// </summary>
-        public Guid Id { get; set; }
-
         /// <summary>
         /// Asset symbol, as a trading pair — for example <c>MAUA/IRT</c>.
         /// </summary>

--- a/src/TallaEgg/TallaEgg.Core/Swagger/SwaggerSchemaConventions.cs
+++ b/src/TallaEgg/TallaEgg.Core/Swagger/SwaggerSchemaConventions.cs
@@ -1,0 +1,52 @@
+using Microsoft.OpenApi.Models;
+
+namespace TallaEgg.Core.Swagger;
+
+/// <summary>
+/// Makes a generated OpenAPI document describe what these services actually do.
+/// </summary>
+public static class SwaggerSchemaConventions
+{
+    /// <summary>
+    /// Removes the blanket <c>additionalProperties: false</c> Swashbuckle stamps on every object
+    /// schema it generates.
+    /// </summary>
+    /// <remarks>
+    /// No service enforces that keyword and none is meant to (issue #237). <c>System.Text.Json</c>
+    /// ignores unknown members and nothing sets <c>JsonUnmappedMemberHandling.Disallow</c>, so a
+    /// request body carrying undeclared fields is accepted — deliberately: that tolerance is what
+    /// lets an un-updated bot keep talking to a post-#235 API. A client generated from the closed
+    /// schema, or one running the body through a validator, would reject a request the server
+    /// would have taken, and the failure lands before the request is ever sent.
+    ///
+    /// Responses are opened too, and for a reason of their own rather than as collateral: adding a
+    /// field to a response is a MINOR change under <c>STANDARDS.md</c> §11, so a closed response
+    /// schema promises something the platform does not — it would turn every such addition into a
+    /// break for any client that validates what it receives.
+    ///
+    /// It is cleared here rather than at generation time because an <c>ISchemaFilter</c> — the
+    /// hook Swashbuckle offers for this, since <c>SchemaGeneratorOptions</c> carries no switch for
+    /// it — is a Swashbuckle type, and this assembly cannot reference Swashbuckle: Users.Api pins
+    /// 7.0.0 while Orders and Wallet are on 9.0.3, and a 9.0.3 reference here reaches Users.Api as
+    /// a package downgrade (NU1605), which <c>TreatWarningsAsErrors</c> makes a build failure.
+    /// <c>Microsoft.OpenApi</c>, which this needs instead, is already resolved by all three.
+    ///
+    /// A schema that names a type for its extra members is describing a dictionary, which is a
+    /// real statement about the payload; only the blanket flag is cleared.
+    /// </remarks>
+    public static void AllowUndeclaredMembers(this OpenApiDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var schemas = document.Components?.Schemas;
+        if (schemas is null) return;
+
+        foreach (var schema in schemas.Values)
+        {
+            if (schema.AdditionalProperties is null)
+            {
+                schema.AdditionalPropertiesAllowed = true;
+            }
+        }
+    }
+}

--- a/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
+++ b/src/TallaEgg/TallaEgg.Core/TallaEgg.Core.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The OpenAPI object model only, not Swashbuckle: Users.Api pins Swashbuckle 7.0.0
+         while Orders and Wallet are on 9.0.3, so a Swashbuckle reference here would reach
+         Users.Api as a downgrade (NU1605). 1.6.22 is the version its 7.0.0 already
+         resolves. See Swagger/SwaggerSchemaConventions.cs (issue #237). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -257,7 +257,25 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
+    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
+    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
+    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
+    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
+    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
+    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Issue #237.
+    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
+    {
+        foreach (var schema in document.Components.Schemas.Values)
+        {
+            // A schema that names a type for its extra members is describing a dictionary, which
+            // is a real statement about the payload. Only the blanket flag is cleared.
+            if (schema.AdditionalProperties is null)
+            {
+                schema.AdditionalPropertiesAllowed = true;
+            }
+        }
+    }));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Users API v1");

--- a/src/User/Users.Api/Program.cs
+++ b/src/User/Users.Api/Program.cs
@@ -22,6 +22,7 @@ using Users.Application;
 using Users.Application.Mappers;
 using Users.Core;
 using Users.Infrastructure;
+using TallaEgg.Core.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -257,25 +258,11 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
-    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
-    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
-    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
-    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
-    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
-    // these services actually do. Issue #237.
-    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
-    {
-        foreach (var schema in document.Components.Schemas.Values)
-        {
-            // A schema that names a type for its extra members is describing a dictionary, which
-            // is a real statement about the payload. Only the blanket flag is cleared.
-            if (schema.AdditionalProperties is null)
-            {
-                schema.AdditionalPropertiesAllowed = true;
-            }
-        }
-    }));
+    // Swashbuckle stamps `additionalProperties: false` on every object schema and no service
+    // enforces it; an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Why, at length, on the helper (issue #237).
+    app.UseSwagger(options =>
+        options.PreSerializeFilters.Add((document, _) => document.AllowUndeclaredMembers()));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Users API v1");

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -186,7 +186,25 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
+    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
+    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
+    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
+    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
+    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
+    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Issue #237.
+    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
+    {
+        foreach (var schema in document.Components.Schemas.Values)
+        {
+            // A schema that names a type for its extra members is describing a dictionary, which
+            // is a real statement about the payload. Only the blanket flag is cleared.
+            if (schema.AdditionalProperties is null)
+            {
+                schema.AdditionalPropertiesAllowed = true;
+            }
+        }
+    }));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Wallet API v1");

--- a/src/Wallet/Wallet.Api/Program.cs
+++ b/src/Wallet/Wallet.Api/Program.cs
@@ -18,6 +18,7 @@ using Wallet.Application;
 using Wallet.Application.Mappers;
 using Wallet.Core;
 using Wallet.Infrastructure;
+using TallaEgg.Core.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -186,25 +187,11 @@ app.UseTallaEggCors();
 // bought for nothing.
 if (app.Environment.IsDevelopment())
 {
-    // Swashbuckle stamps `additionalProperties: false` on every object schema it generates and
-    // offers no option to turn that off, but no service enforces it: System.Text.Json ignores
-    // unknown members and nothing sets JsonUnmappedMemberHandling.Disallow. That leniency is
-    // deliberate and load-bearing — it is what lets an un-updated bot keep talking to a post-#235
-    // API — so the schema is what is wrong here, not the server. Clearing the flag omits the
-    // keyword, and an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
-    // these services actually do. Issue #237.
-    app.UseSwagger(options => options.PreSerializeFilters.Add((document, _) =>
-    {
-        foreach (var schema in document.Components.Schemas.Values)
-        {
-            // A schema that names a type for its extra members is describing a dictionary, which
-            // is a real statement about the payload. Only the blanket flag is cleared.
-            if (schema.AdditionalProperties is null)
-            {
-                schema.AdditionalPropertiesAllowed = true;
-            }
-        }
-    }));
+    // Swashbuckle stamps `additionalProperties: false` on every object schema and no service
+    // enforces it; an absent `additionalProperties` means "allowed" in OpenAPI 3, which is what
+    // these services actually do. Why, at length, on the helper (issue #237).
+    app.UseSwagger(options =>
+        options.PreSerializeFilters.Add((document, _) => document.AllowUndeclaredMembers()));
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "TallaEgg Wallet API v1");

--- a/tests/TallaEgg.AllServices.Tests/SwaggerSchemaConventionsTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/SwaggerSchemaConventionsTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using TallaEgg.Core.Swagger;
+
+namespace TallaEgg.AllServices.Tests;
+
+// Guards TallaEgg.Core.Swagger.SwaggerSchemaConventions, which every API service applies to its
+// generated document (issue #237). Swashbuckle closes every object schema it generates and no
+// service enforces that, so the published document has to be reopened before it is served. The
+// generator itself is not exercised here — none of the three services can boot in this
+// environment without a live SQL Server (issue #68) — so these work on the document model
+// Swashbuckle hands the filter.
+public class SwaggerSchemaConventionsTests
+{
+    [Fact]
+    public void AllowUndeclaredMembers_ClosedObjectSchema_StopsDeclaringTheKeyword()
+    {
+        var document = DocumentWith("OrderDto", new OpenApiSchema
+        {
+            Type = "object",
+            AdditionalPropertiesAllowed = false
+        });
+
+        document.AllowUndeclaredMembers();
+
+        // True with no AdditionalProperties is what makes the serializer omit the keyword, and an
+        // absent additionalProperties means "allowed" in OpenAPI 3 — matching the server.
+        Assert.True(document.Components.Schemas["OrderDto"].AdditionalPropertiesAllowed);
+        Assert.Null(document.Components.Schemas["OrderDto"].AdditionalProperties);
+    }
+
+    [Fact]
+    public void AllowUndeclaredMembers_DictionarySchema_LeavesItsValueTypeAlone()
+    {
+        // A schema naming a type for its extra members is describing a dictionary. That is a real
+        // statement about the payload, not the blanket flag, so it must survive untouched.
+        var valueType = new OpenApiSchema { Type = "string" };
+        var document = DocumentWith("StringMap", new OpenApiSchema
+        {
+            Type = "object",
+            AdditionalProperties = valueType
+        });
+
+        document.AllowUndeclaredMembers();
+
+        Assert.Same(valueType, document.Components.Schemas["StringMap"].AdditionalProperties);
+    }
+
+    [Fact]
+    public void AllowUndeclaredMembers_ExtensibleFrameworkSchema_IsNotRewritten()
+    {
+        // HttpValidationProblemDetails arrives already open, carrying an empty value schema. It is
+        // the framework's own and the one schema in the platform that was never closed.
+        var open = new OpenApiSchema { Type = "object", AdditionalProperties = new OpenApiSchema() };
+        var document = DocumentWith("HttpValidationProblemDetails", open);
+
+        document.AllowUndeclaredMembers();
+
+        Assert.True(document.Components.Schemas["HttpValidationProblemDetails"].AdditionalPropertiesAllowed);
+        Assert.NotNull(document.Components.Schemas["HttpValidationProblemDetails"].AdditionalProperties);
+    }
+
+    [Fact]
+    public void AllowUndeclaredMembers_DocumentWithoutComponents_DoesNotThrow()
+    {
+        // The filter runs inside the swagger middleware, so anything it throws is a 500 on the
+        // schema endpoint rather than a startup failure.
+        var document = new OpenApiDocument { Components = null };
+
+        document.AllowUndeclaredMembers();
+    }
+
+    private static OpenApiDocument DocumentWith(string name, OpenApiSchema schema) => new()
+    {
+        Components = new OpenApiComponents
+        {
+            Schemas = new Dictionary<string, OpenApiSchema> { [name] = schema }
+        }
+    };
+}


### PR DESCRIPTION
**Branch Name**: `fix/swagger-schema-tells-the-truth`
**Linked Issue**: closes #237

---

## Description

Three ways the published Swagger schema misleads whoever builds a client from it, found together
in the #235 schema review. None of them is a defect in the running system — each is the schema
saying something the servers do not do. All three are addressed here.

Everything below was measured against the three running services, before and after, by walking
`GET /swagger/v1/swagger.json` — not read off the C#.

---

## Type of Change
- [x] Hotfix (urgent bug fix) — not urgent; the closest available box for a defect fix
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

Done in the order the issue suggests: (3), then (2), then (1).

---

## Part 3 — `OrderDto.Id`

Confirmed nothing reads it, exactly as the issue asks:

```
$ grep -rn "request\.Id" --include="*.cs" .        # whole repo
(no matches)
```

`OrderService.CreateOrderAsync` builds its `CreateOrderCommand` from `Asset`, `Amount`, `Price`,
`UserId`, `Side`, `TradingType` and `Notes`; the order's id is generated server-side.
`BotHandler.cs:1459` never set the property — the value the old bot puts on the wire is
`Guid.Empty`, emitted only because the property existed.

The comment was corrected first (the safe half), then the property was deleted on the owner's
decision. The reason is recorded in the class's existing `<remarks>` block, next to #235's.

**One correction to the issue.** It says "the schema still advertises it … with nothing marking it
optional or server-assigned", and lists the wrong doc comment among the reasons. The comment never
reached the schema at all: `IncludeXmlComments` loads only the executing assembly's XML file, and
`OrderDto` lives in `TallaEgg.Core`, which sets no `GenerateDocumentationFile`. Measured — `id`
carried no `description` in the published schema either before or after:

```
OrderDto.id, BEFORE:  {"type": "string", "format": "uuid"}
OrderDto.id, AFTER:   absent
```

So the wrong comment misled a reader of the C#, and the schema misled a reader of the schema; they
were two problems, not one, and both are gone.

### Nothing breaks

`Id` becomes an unknown member, which `System.Text.Json` ignores — the same leniency part 2 is
about. An un-updated bot still posts it, and still gets an order. Measured over real HTTP against
the running service, below.

---

## Part 2 — `additionalProperties: false`

### The question the issue asks: default or configuration?

**Swashbuckle's default.** Not configuration — checked, not assumed:

```
$ grep -rn "SchemaFilter\|DocumentFilter\|OperationFilter\|AdditionalProperties\|UnmappedMember" --include="*.cs" .
(no matches)
```

All three `AddSwaggerGen` blocks set a title and `IncludeXmlComments`, and nothing else.
`SchemaGeneratorOptions` also offers no switch for it — in the shipped assembly's metadata,
`AdditionalPropertiesAllowed` exists only on `OpenApiSchema`, never as a generator option. So
overriding the default needs a filter; there is no line to delete.

### The decision: correct the schema, not the server

The issue already establishes that the leniency is load-bearing — it is what let an un-updated bot
keep talking to a post-#235 Orders.Api (PR #236's deployment section). Reproduced here on the
unmodified build, with the issue's own body:

```
POST /api/orders
{"Id":"00000000-…","symbol":"MAUA/IRT","asset":"MAUA/IRT","Amount":0.25,"quantity":0.25,"Price":23429694.35,…}

-> 200  success=True  asset=MAUA/IRT  amount=0.25
```

`symbol` and `quantity` do not exist in `OrderDto`, and `Id`/`Amount`/`Price` are PascalCase
spellings the schema does not declare either. The schema said that body was invalid. So the schema
was what was wrong.

### How

A `PreSerializeFilter` on each service's `UseSwagger` clears the flag. Clearing it omits the
keyword entirely, and an absent `additionalProperties` means "allowed" in OpenAPI 3 — which is what
these services actually do.

Only the blanket flag is cleared. A schema that names a type for its extra members is describing a
dictionary, which is a real statement about the payload; `HttpValidationProblemDetails` — the
framework's own, deliberately extensible — is untouched at `additionalProperties: {}`.

**Where it lives.** Once, in `TallaEgg.Core.Swagger.SwaggerSchemaConventions`; each service calls it
in one line. That follows `TallaEgg.Core.Cors.CorsExtensions`, which is the same thing for CORS —
cross-service startup wiring in the shared kernel, called from all five hosts, with
`CorsExtensionsTests` testing the helper directly.

It is a function over `OpenApiDocument` rather than the `ISchemaFilter` Swashbuckle offers for
mutating schemas, and that is forced: `ISchemaFilter` is a Swashbuckle type, and `Users.Api` pins
`Swashbuckle.AspNetCore` **7.0.0** while Orders and Wallet are on **9.0.3**, so a 9.0.3 reference in
`TallaEgg.Core` reaches Users.Api as a package downgrade (NU1605), which `TreatWarningsAsErrors`
makes a build failure. `Microsoft.OpenApi` carries no such problem — Users.Api's own Swashbuckle
already resolves 1.6.22, and Orders/Wallet resolve 1.6.23, so the 1.6.22 reference added to
`TallaEgg.Core` is satisfied everywhere and upgrades nothing:

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

The cost of that choice is one gap, recorded on the helper: a schema Swashbuckle inlines rather than
referencing would keep the flag. All 31 closed schemas were components, so it is hypothetical today.

The Swashbuckle version skew is real and pre-existing; flagged below, not fixed here.

---

## Part 1 — the two vocabularies

The owner chose option (1) plus (2): write the split down, and make `symbol`/`quantity` the
spelling for new endpoints. `docs/process/STANDARDS.md` §2 gains a subsection next to the JSON wire
format rule #235 added, carrying the issue's table, the rule, and why unifying is not a rename.

**One refinement to the issue's option (2).** "Pick `symbol`/`quantity`, the majority" can collide
with #235's own deciding principle — that a request agrees with its own response. A new endpoint
returning an `OrderHistoryDto` (`asset`/`amount`) but told to accept `symbol`/`quantity` would
reproduce exactly the mismatch #235 refused to create. The written rule is therefore ordered: match
the endpoint's own response first; where nothing constrains it, `symbol`/`quantity`.

The table was verified against the three live documents rather than copied:

```
wallet  TradeDto            symbol, quantity     orders  OrderDto             asset, amount
wallet  WalletRequest       asset,  amount       orders  OrderHistoryDto      asset, amount
orders  AcceptQuoteRequest  symbol, quantity     orders  PositionDto          symbol, quantity
orders  BestPricesDto       symbol               orders  PublishQuoteRequest  symbol
orders  TradeDto            symbol, quantity     orders  TradeHistoryDto      symbol, quantity
```

### How big option (3) would be, if it is ever wanted

Asked during review; measured, since the answer decides whether (3) stays on the table.

`TradeDto` is one class in `TallaEgg.Core` serving four roles: the outbox payload, the Orders→Wallet
request body for `/api/wallet/changeBalance`, part of the `POST /api/orders` response, and a
published schema in two services. Both the write (`OrderMatchingRepository.cs:207`) and the reads
(`OutboxProcessorService.cs:262,283`) use **default** `JsonSerializer` options — PascalCase in the
database, and **case-sensitive** on the way back.

```
OutboxMessages, local Orders database: 9,361 rows, every one carrying "Symbol" and "Quantity"
  Completed 8,651 · Failed 101 · Abandoned 609
```

The rows that must stay readable are Pending plus Failed — `/api/outbox/redrive-all-failed` and
`/api/outbox/{id}/redrive` re-drive Failed ones, while Abandoned "can never be re-driven again" by
design. The failure mode of getting this wrong is silent: a renamed property reading an old payload
yields `Symbol = ""` and `Quantity = 0`, a settlement for nothing, and no code on that path rejects
it.

So the code side is small and the risk is entirely in deployment. It needs (a) a data migration
rewriting the JSON keys in `OutboxMessages.Payload` — `scripts/migrate-irr-to-irt.sql` is the
precedent for a data-migrating `.sql` — or a drained and frozen queue across the deploy; (b) Orders
and Wallet shipped in lockstep, because `asset` versus `symbol` is a different name, not a different
case, so the case-insensitive binding that carried #235 through a mixed deployment does not bridge
it; and (c) six schemas across two services plus the `POST /api/orders` response. Worth doing only
before #97 ships against the current shape, and only as its own piece of work.

---

## Found, not fixed

Flagged per `STANDARDS.md` §3 rather than fixed inline.

1. **Two hand-written clients post PascalCase to a camelCase schema.** `WalletApiClient`'s
   `TradeTransactionAndBalanceChangeAsync` and `OrderApiClient`'s `SubmitOrderAsync` both serialize
   with default `JsonSerializer` options, so `/api/wallet/changeBalance` receives
   `{"Symbol":…,"Quantity":…}` and `/api/orders` receives `{"Asset":…,"Amount":…}` — the body printed
   in this PR's own testing section — while both published schemas say camelCase. It works only
   because minimal-API binding is case-insensitive, and tightening that (the natural follow-up to
   #229/#235) would break every bot order. Same family as #229 and #235, and invisible to their
   guards for the same reason: consistent-but-wrong rather than inconsistent.
2. **Five more server-assigned properties on `OrderDto`.** `Status`, `Role`, `CreatedAt`,
   `UpdatedAt` and `ParentOrderId` are never read by `CreateOrderAsync` — the same defect as the
   `Id` this PR removes, and `Role` and `Status` are worse, because a client can plausibly believe
   it is choosing the maker/taker role. Five more request-contract changes, so the owner's call and
   not folded in here. (`Type` looks like a sixth and is not: it is read, at `OrderService.cs:66`,
   in a log line.)
3. **`OrderDto.Price`'s doc comment is untrue.** It says price is "optional for market orders";
   `Orders.Api/Program.cs:679` rejects `Price <= 0` unconditionally and `CreateOrderAsync` never
   branches on `Type`. Exactly the defect this PR fixed on `Id`, one property away — left alone
   because the owner approved that one specific correction, not a licence to keep going.
4. **`OrderDto` declares no `required` while the endpoint 400s on three fields.** Deliberate, and
   one PR old: #236 deleted this DTO's DataAnnotations because they were unexecuted decoration
   reaching the schema, and took the `required` count to zero across all three services. Making the
   schema state real constraints means running validation for real, which is a platform-wide
   decision #236 already weighed and declined.
5. **Swashbuckle version skew.** `Users.Api` 7.0.0 versus 9.0.3 in the other two — what rules out a
   shared `ISchemaFilter`.
6. Untouched as the issue requires: #233 (two serialization libraries in one file) and #230
   (migration timing).

Items 1–4 are worth issues; say the word and I will open them.

---

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

(`TreatWarningsAsErrors` is on, so the zero is enforced.)

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 884, Skipped: 0, Total: 884
```

880 on `main` plus 4 new, all in `SwaggerSchemaConventionsTests`: a closed object schema opens, a
dictionary schema keeps its value type, the already-open framework schema is not rewritten, and a
document with no components does not throw.

No existing test needed changing. `RequestDtoWireContractTests` drives itself off `JsonTypeInfo`, so
`OrderDto` losing a property is simply one fewer field to check.

```
scripts/check-doc-paths.sh
404 tracked text file(s) checked, every reference resolves.
```

### The published schema, before and after

The whole point of this issue is something only visible on the wire, so all three documents were
captured from the running services before any change and again at the end, and compared
programmatically rather than by eye:

| service | `additionalProperties: false` before | after | rest of the document |
|---|---|---|---|
| Users (5136) | 6 | 0 | identical |
| Wallet (60933) | 2 | 0 | identical |
| Orders (5140) | 23 | 0 | identical but for `OrderDto.id`, removed |

31 of 32 object schemas before, matching the issue's count exactly; `HttpValidationProblemDetails`
was the one exception and still is, still at `additionalProperties: {}`.

Asserted, not eyeballed: stripping every `additionalProperties: false` from the before-documents
makes Users and Wallet compare equal to the after-documents, and leaves Orders differing in exactly
one property.

### End-to-end

- [x] Exercised against the running stack — `driver.ps1 start`, then `driver.ps1 smoke`
- [x] Date/time run: 2026-09-07

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
=== Done in 00:00:15.79. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled     MAUA/IRT: 17 filled     SEKE_BAHAR/IRT: 16 filled
Restored auto-quote for BTC/IRT to IsEnabled=True.
Restored auto-quote for MAUA/IRT to IsEnabled=True.
```

Settlement counts are the delta the driver asserts, not absolutes. A baseline run on the unmodified
build beforehand was green on the same seed.

### The server is still lenient — proved over real HTTP, not argued

The issue's own extra-field body, sent to the running Orders.Api before the change and again after,
with the same user and the live MAUA/IRT quote:

```
{"Id":"00000000-…","symbol":"MAUA/IRT","asset":"MAUA/IRT","Amount":0.25,"quantity":0.25,"Price":…,…}

BEFORE  -> 200  success=True  asset=MAUA/IRT  amount=0.25
AFTER   -> 200  success=True  asset=MAUA/IRT  amount=0.25
```

Identical. After the change that body carries **three** kinds of undeclared field — `symbol` and
`quantity`, which never existed; `Id`, which this PR removes; and the PascalCase spellings — and it
is still accepted. That is the un-updated bot's payload, and it still places an order. The schema
simply no longer claims otherwise.

### The bot's own client, through the changed path

`driver.ps1 smoke` takes the quote-fill path (`AcceptQuoteAsync`), which never touches
`POST /api/orders`, so the changed DTO was driven separately through the bot's real
`OrderApiClient.SubmitOrderAsync`, with `OrderDto` built from exactly the seven properties
`BotHandler.cs:1459` sets, against the running Orders.Api and the real database:

```
Body the bot now puts on the wire:
  {"Asset":"MAUA/IRT","Amount":0.50,"Price":23483462.99,"UserId":"…","Side":0,"Type":1,…}
    - no "Id" at all any more

SubmitOrderAsync -> success=True, message=سفارش شما ثبت شد.
```

Read straight out of `TallaEggOrders.dbo.Orders`:

```
Asset='MAUA/IRT'  Amount=0.50000000  Price=23483462.99000000  Status=Confirmed
```

Prices are the live MAUA/IRT quote at the time (buy 23,483,462.99 / sell 23,530,476.94), not
invented figures. Every probe order was cancelled afterwards, so nothing rests in the book.

### Environment
- [x] Tested locally (Windows + SQL Server Express)

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files — `config/appsettings.global.json` untouched and untracked
- [x] Code compiles without warnings
- [x] Input validation unchanged — the hand-written checks in `Program.cs` are untouched, and the
      server's tolerance of unknown members is deliberately preserved, not widened

Swagger remains Development-only in all three services; this changes what the document says, not
who can reach it.

---

## Code Quality

- [x] Follows `STANDARDS.md` naming, including the section this PR adds
- [x] Comments in English, explaining why
- [x] No large blocks of commented-out code
- [x] One dependency added, and only the one needed: `Microsoft.OpenApi` 1.6.22 in `TallaEgg.Core`,
      the version all three services already resolve. No Swashbuckle reference in the shared kernel,
      and no version moves anywhere.

---

## Documentation

- [x] `docs/process/STANDARDS.md` §2 gains the trading-pair vocabulary subsection
- [x] Swagger/OpenAPI: the schema is the subject of this PR; diffed above
- [x] `OrderDto`'s `<remarks>` records why `Id` went, alongside #235's reasoning

---

## Breaking Changes?

- [ ] No breaking changes
- [x] Breaking changes (see details below)

**Formally breaking**: the request contract of `POST /api/orders` loses the `id` field.

**In practice**: nothing breaks. The only caller is the bot, which never set it, and a body that
still sends `id` is accepted with the member ignored — measured above. The schema change in part 2
is strictly a relaxation: every body valid against the old schema is valid against the new one.

Per `STANDARDS.md` §11 this is MINOR-shaped, not MAJOR: no external integration exists to break. No
version bump is included — not this PR's call.

---

## Deployment Notes

**Pre-deployment**: no migrations, no new configuration, no feature flags.

Swagger is Development-only in all three services, so the two schema checks below belong here,
against a Development-configured run of the build being shipped — not after deployment, where the
endpoint is not mapped and would answer 404 whether the fix is present or missing.

- [x] `GET /swagger/v1/swagger.json` on each service contains no `"additionalProperties": false`
- [x] `OrderDto` in the Orders schema has no `id`

**Order**: the bot and `Orders.Api` may deploy in either order or together. The compatibility rests
on the same thing #236 measured — `PropertyNameCaseInsensitive` in `Orders.Api`, plus
`System.Text.Json` ignoring unknown members — and this PR deliberately preserves both.

**Post-deployment verification** — what production can actually answer:
- [ ] All three services start
- [ ] One order placed from the bot appears in `Orders` with the right `Asset` and `Amount`

**Rollback**: revert the commit and redeploy. An older `Orders.Api` reads the new bot's payload
correctly (it simply finds no `id`, which nothing read), so rolling back the API alone is safe too.

---

## Related Issues

- Closes #237
- Follows #235 / PR #236, whose Swagger review found all three of these
- Relevant to #97 (browser client) — the reason this was worth doing before it starts
- Untouched as the issue requires: #233, #230

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description explains why and what
- [x] All tests pass locally
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data in code
- [x] Commit message is clear
- [x] Documentation is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
