### PR TITLE
[Fix] Choose the request casing instead of inheriting it — issue #241

### DIFF
--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/AffiliateApiClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using TallaEgg.Core;
+using TallaEgg.Core.Json;
 
 namespace TallaEgg.TelegramBot.Infrastructure.Clients;
 
@@ -30,7 +31,7 @@ public class AffiliateApiClient : IAffiliateApiClient
     public async Task<(bool success, string message)> ValidateInvitationAsync(string invitationCode)
     {
         var request = new { InvitationCode = invitationCode };
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -83,7 +84,7 @@ public class AffiliateApiClient : IAffiliateApiClient
             UsedByUserId = usedByUserId
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -145,7 +146,7 @@ public class AffiliateApiClient : IAffiliateApiClient
             MaxUses = maxUses
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -179,7 +180,7 @@ public class AffiliateApiClient : IAffiliateApiClient
             PhoneNumber = phoneNumber
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/OrderApiClient.cs
@@ -10,6 +10,7 @@ using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.Enums.Order;
+using TallaEgg.Core.Json;
 using TallaEgg.Core.Requests.Order;
 
 namespace TallaEgg.TelegramBot.Infrastructure.Clients;
@@ -417,7 +418,7 @@ public class OrderApiClient : IOrderApiClient
 
     public async Task<(bool success, string message)> SubmitOrderAsync(OrderDto order)
     {
-        var json = System.Text.Json.JsonSerializer.Serialize(order);
+        var json = System.Text.Json.JsonSerializer.Serialize(order, ApiJson.RequestOptions);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         try
         {
@@ -445,7 +446,9 @@ public class OrderApiClient : IOrderApiClient
         {
             var payload = new { symbol, buyPrice, sellPrice, publishedByUserId };
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(payload, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/quotes", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -512,7 +515,9 @@ public class OrderApiClient : IOrderApiClient
         try
         {
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(new { adminUserId }), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(new { adminUserId }, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/quotes/pending/{pendingQuoteId}/{action}", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -557,7 +562,9 @@ public class OrderApiClient : IOrderApiClient
         {
             var payload = new { spreadPercent, updatedByUserId };
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(payload, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/autoquote-settings/{symbol}/spread", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -580,7 +587,9 @@ public class OrderApiClient : IOrderApiClient
         {
             var payload = new { isEnabled, updatedByUserId };
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(payload, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/autoquote-settings/{symbol}/enabled", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -623,7 +632,9 @@ public class OrderApiClient : IOrderApiClient
         {
             var payload = new { isActive, updatedByUserId };
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(payload, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/symbols/{symbol}/active", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -711,7 +722,9 @@ public class OrderApiClient : IOrderApiClient
         {
             var payload = new { userId, symbol, side, quantity };
             var content = new StringContent(
-                System.Text.Json.JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                System.Text.Json.JsonSerializer.Serialize(payload, ApiJson.RequestOptions),
+                Encoding.UTF8,
+                "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/quotes/accept", content);
             var body = await response.Content.ReadAsStringAsync();
@@ -805,7 +818,7 @@ public class OrderApiClient : IOrderApiClient
         try
         {
             var requestBody = new { reason };
-            var json = System.Text.Json.JsonSerializer.Serialize(requestBody);
+            var json = System.Text.Json.JsonSerializer.Serialize(requestBody, ApiJson.RequestOptions);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/orders/user/{userId}/cancel-active", content);
@@ -835,7 +848,7 @@ public class OrderApiClient : IOrderApiClient
     {
         try
         {
-            var json = System.Text.Json.JsonSerializer.Serialize(request);
+            var json = System.Text.Json.JsonSerializer.Serialize(request, ApiJson.RequestOptions);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync($"{_baseUrl}/orders/market/notify-matching", content);

--- a/docs/process/STANDARDS.md
+++ b/docs/process/STANDARDS.md
@@ -97,6 +97,21 @@ sentences and holds the allowlist for the third; the two behavioral guards in
 `RequestDtoWireContractTests.cs` enforce the last. Adding a name to that allowlist is a contract
 decision, not a formatting one.
 
+**Every client asks for that shape as well.** A request body is serialized with
+`ApiJson.RequestOptions` (System.Text.Json) or `ApiJson.NewtonsoftRequestSettings` (Newtonsoft),
+named at the call site — never with whatever a serializer does when it is handed no options, which
+is the member name as declared in C# in both libraries. Fifteen of the twenty-two outbound bodies
+were in exactly that state until #241, accepted only because the receiving side binds
+case-insensitively; the seven that were not were anonymous objects built from local variables,
+right by coincidence and one promotion to a named DTO away from joining the rest.
+`ClientRequestWireContractTests.cs` enforces both halves — that every call site names the options,
+and that a typed body goes out under the names its endpoint's schema declares.
+
+**Do not tighten `PropertyNameCaseInsensitive` on its own.** It is what lets a service read a body
+whose casing does not match its schema, and both the clients above and the mixed deployments of
+#235 rest on it. It becomes safe to remove only once every writer is known to send the published
+casing — never before, and never in the same change that makes them.
+
 #### Trading-pair vocabulary: two spellings, and which one a new endpoint takes
 
 A trading pair is spelled `asset` in some schemas and `symbol` in others, and its quantity is

--- a/src/TallaEgg/TallaEgg.Core/Json/ApiJson.cs
+++ b/src/TallaEgg/TallaEgg.Core/Json/ApiJson.cs
@@ -31,10 +31,13 @@ namespace TallaEgg.Core.Json;
 /// <b>Nothing here is a deserialization setting.</b> The read side is #233's, and the clients'
 /// existing <c>PropertyNameCaseInsensitive</c> reads are untouched.
 ///
-/// Both members are shared, process-wide instances and must be treated as read-only.
-/// <see cref="RequestOptions"/> enforces that for itself — <see cref="JsonSerializerOptions"/>
-/// throws once it is frozen — while <see cref="JsonSerializerSettings"/> has no equivalent, so
-/// mutating <see cref="NewtonsoftRequestSettings"/> would reach every caller in the process.
+/// <b>Neither member can be reshaped by one of its callers.</b> That matters more here than it
+/// looks: these objects are reached from every request path in the platform, so a single line
+/// setting some unrelated option on one of them would change what every other caller puts on the
+/// wire. <see cref="RequestOptions"/> is frozen, and <see cref="JsonSerializerOptions"/> throws on
+/// a write once it is. <see cref="JsonSerializerSettings"/> has no equivalent, so
+/// <see cref="NewtonsoftRequestSettings"/> hands out a fresh instance instead — see the note there
+/// for why that costs nothing.
 /// </remarks>
 public static class ApiJson
 {
@@ -63,10 +66,26 @@ public static class ApiJson
     /// body carries a dictionary today, and that is a reason the difference is cheap to get right
     /// now, not a reason to leave it wrong.
     ///
-    /// The resolver is held on this single instance because a contract resolver caches the
-    /// contracts it builds; a fresh one per call would throw that cache away.
+    /// A new <see cref="JsonSerializerSettings"/> every time, over one shared resolver. The
+    /// settings object is what a caller could mutate and there is no way to freeze it, so nobody
+    /// gets a reference anyone else is holding; the resolver is what caches the contracts it
+    /// builds, and keeping that one static is what makes the fresh settings object free. Newtonsoft
+    /// builds a serializer from the settings on every <c>SerializeObject</c> call regardless, so
+    /// this adds one small allocation to an operation that is about to make an HTTP request.
     /// </remarks>
-    public static JsonSerializerSettings NewtonsoftRequestSettings { get; } = BuildNewtonsoftRequestSettings();
+    public static JsonSerializerSettings NewtonsoftRequestSettings => new()
+    {
+        ContractResolver = CamelCaseResolver,
+    };
+
+    /// <summary>
+    /// Shared because a contract resolver caches the contracts it builds, and safe to share because
+    /// it is never handed to a caller — only read through <see cref="NewtonsoftRequestSettings"/>.
+    /// </summary>
+    private static readonly IContractResolver CamelCaseResolver = new DefaultContractResolver
+    {
+        NamingStrategy = new CamelCaseNamingStrategy(),
+    };
 
     private static JsonSerializerOptions BuildRequestOptions()
     {
@@ -77,12 +96,4 @@ public static class ApiJson
         options.MakeReadOnly(populateMissingResolver: true);
         return options;
     }
-
-    private static JsonSerializerSettings BuildNewtonsoftRequestSettings() => new()
-    {
-        ContractResolver = new DefaultContractResolver
-        {
-            NamingStrategy = new CamelCaseNamingStrategy(),
-        },
-    };
 }

--- a/src/TallaEgg/TallaEgg.Core/Json/ApiJson.cs
+++ b/src/TallaEgg/TallaEgg.Core/Json/ApiJson.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace TallaEgg.Core.Json;
+
+/// <summary>
+/// The JSON shape this platform writes its outbound request bodies in: camelCase, chosen rather
+/// than inherited (issue #241).
+/// </summary>
+/// <remarks>
+/// Every service publishes a camelCase schema — the rule in <c>STANDARDS.md</c> §2, guarded by
+/// <c>JsonNamingPolicyConsistencyTests</c>. The four typed clients that call those services used
+/// to pass no serializer options at all, and neither library defaults to the published shape:
+/// <c>System.Text.Json</c> writes the member name as declared when it is given no
+/// <see cref="JsonSerializerOptions"/>, and <c>Newtonsoft.Json</c> always does. Fifteen of the
+/// twenty-two outbound bodies therefore went out in PascalCase, and every one of them was accepted
+/// only because the receiving side binds case-insensitively.
+///
+/// The seven that already matched were the accident, not the rule: they serialize anonymous objects
+/// built from local variables, and a C# local is camelCase, so <c>new { symbol, buyPrice }</c>
+/// happened to produce the published names. Promoting one of those bodies to a named DTO — a change
+/// with no visible risk in it — would have flipped it to PascalCase silently. Naming the options at
+/// every call site is what removes that trapdoor.
+///
+/// <b>Two objects, because there are two libraries.</b> Which serializer the platform standardises
+/// on is issue #233's question and is deliberately left open here; this type settles only the
+/// casing, so each library keeps an entry written in its own vocabulary. Both describe the same
+/// wire shape.
+///
+/// <b>Nothing here is a deserialization setting.</b> The read side is #233's, and the clients'
+/// existing <c>PropertyNameCaseInsensitive</c> reads are untouched.
+///
+/// Both members are shared, process-wide instances and must be treated as read-only.
+/// <see cref="RequestOptions"/> enforces that for itself — <see cref="JsonSerializerOptions"/>
+/// throws once it is frozen — while <see cref="JsonSerializerSettings"/> has no equivalent, so
+/// mutating <see cref="NewtonsoftRequestSettings"/> would reach every caller in the process.
+/// </remarks>
+public static class ApiJson
+{
+    /// <summary>
+    /// What a <c>System.Text.Json</c> request body is written with.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="JsonSerializerDefaults.Web"/> is the same profile
+    /// <c>Microsoft.AspNetCore.Http.Json.JsonOptions</c> gives the three hosts, so a body written
+    /// with it carries exactly the names the endpoint's published schema declares. Naming the
+    /// framework's own profile rather than setting <c>PropertyNamingPolicy</c> by hand keeps the
+    /// two sides tied to one definition instead of two that happen to agree.
+    /// </remarks>
+    public static JsonSerializerOptions RequestOptions { get; } = BuildRequestOptions();
+
+    /// <summary>
+    /// What a <c>Newtonsoft.Json</c> request body is written with.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="DefaultContractResolver"/> carrying a <see cref="CamelCaseNamingStrategy"/>,
+    /// not the <c>CamelCasePropertyNamesContractResolver</c> the issue suggests. That subclass
+    /// turns on <c>ProcessDictionaryKeys</c> and <c>OverrideSpecifiedNames</c> as well, and
+    /// <see cref="JsonSerializerDefaults.Web"/> does neither: it leaves <c>DictionaryKeyPolicy</c>
+    /// unset and lets an explicit wire name win over the policy. Matching the web profile is the
+    /// whole purpose of this type, so the resolver that matches it is the one to use — no request
+    /// body carries a dictionary today, and that is a reason the difference is cheap to get right
+    /// now, not a reason to leave it wrong.
+    ///
+    /// The resolver is held on this single instance because a contract resolver caches the
+    /// contracts it builds; a fresh one per call would throw that cache away.
+    /// </remarks>
+    public static JsonSerializerSettings NewtonsoftRequestSettings { get; } = BuildNewtonsoftRequestSettings();
+
+    private static JsonSerializerOptions BuildRequestOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        // Frozen up front rather than on first use, so a later mutation fails here instead of
+        // depending on whether anything has serialized yet.
+        options.MakeReadOnly(populateMissingResolver: true);
+        return options;
+    }
+
+    private static JsonSerializerSettings BuildNewtonsoftRequestSettings() => new()
+    {
+        ContractResolver = new DefaultContractResolver
+        {
+            NamingStrategy = new CamelCaseNamingStrategy(),
+        },
+    };
+}

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/UsersApiClient.cs
@@ -9,6 +9,7 @@ using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.User;
+using TallaEgg.Core.Json;
 using TallaEgg.Core.Requests.User;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -121,7 +122,7 @@ public class UsersApiClient : IUsersApiClient
             LastName = lastName
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -268,7 +269,7 @@ public class UsersApiClient : IUsersApiClient
             PhoneNumber = phoneNumber
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -321,7 +322,7 @@ public class UsersApiClient : IUsersApiClient
             NewStatus = newStatus
         };
 
-        var json = JsonConvert.SerializeObject(request);
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try
@@ -383,7 +384,8 @@ public class UsersApiClient : IUsersApiClient
     /// </summary>
     public async Task<(bool success, string message)> UpdateRoleAsync(Guid userId, TallaEgg.Core.Enums.User.UserRole newRole)
     {
-        var json = JsonConvert.SerializeObject(new { UserId = userId, NewRole = newRole });
+        var request = new { UserId = userId, NewRole = newRole };
+        var json = JsonConvert.SerializeObject(request, ApiJson.NewtonsoftRequestSettings);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         try

--- a/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
+++ b/src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs
@@ -7,6 +7,7 @@ using TallaEgg.Core;
 using TallaEgg.Core.DTOs;
 using TallaEgg.Core.DTOs.Order;
 using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Json;
 using TallaEgg.Core.Requests.Wallet;
 using TallaEgg.Core.Responses.Order;
 
@@ -83,7 +84,7 @@ public class WalletApiClient : IWalletApiClient
                 Amount = amount
             };
 
-            var json = JsonSerializer.Serialize(request);
+            var json = JsonSerializer.Serialize(request, ApiJson.RequestOptions);
             var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync("api/wallet/lockBalance", stringContent);
@@ -149,7 +150,7 @@ public class WalletApiClient : IWalletApiClient
                 Amount = amount
             };
 
-            var json = JsonSerializer.Serialize(request);
+            var json = JsonSerializer.Serialize(request, ApiJson.RequestOptions);
             var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             // Assuming there's an unlock endpoint - if not, we might need to implement it
@@ -485,7 +486,7 @@ public class WalletApiClient : IWalletApiClient
         try
         {
 
-            var json = JsonSerializer.Serialize(request);
+            var json = JsonSerializer.Serialize(request, ApiJson.RequestOptions);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync($"api/wallet/deposit", content);
@@ -518,7 +519,7 @@ public class WalletApiClient : IWalletApiClient
         try
         {
 
-            var json = JsonSerializer.Serialize(request);
+            var json = JsonSerializer.Serialize(request, ApiJson.RequestOptions);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync($"api/wallet/withdrawal", content);
@@ -556,7 +557,7 @@ public class WalletApiClient : IWalletApiClient
     {
         try
         {
-            var json = JsonSerializer.Serialize(trade);
+            var json = JsonSerializer.Serialize(trade, ApiJson.RequestOptions);
             var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync("api/wallet/changeBalance", stringContent);

--- a/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
@@ -1,0 +1,242 @@
+using System.Reflection;
+using System.Text.Json;
+using Newtonsoft.Json;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.Json;
+using TallaEgg.Core.Requests.User;
+using TallaEgg.Core.Requests.Wallet;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That the typed clients write their request bodies in the casing the endpoint's schema declares
+/// (issue #241).
+/// </summary>
+/// <remarks>
+/// This is the half of the wire contract the two existing guards cannot see.
+/// <see cref="JsonNamingPolicyConsistencyTests"/> looks at what a service serves;
+/// <see cref="RequestDtoWireContractTests"/> looks at whether a DTO round-trips against itself.
+/// Nothing compared a client's outgoing body with the schema of the endpoint it posts to, which is
+/// why fifteen of the twenty-two outbound bodies could go out in PascalCase against camelCase
+/// schemas without a single test noticing.
+///
+/// The two tests below close that loop from opposite ends. The source scan says every call site
+/// chooses its casing rather than inheriting it; the name comparison says the casing it chooses is
+/// the one the framework binds and the schema is generated from. Together with the sibling guard's
+/// promise that no service moves off that default, "the client writes what the schema declares"
+/// holds for every typed body.
+/// </remarks>
+public class ClientRequestWireContractTests
+{
+    /// <summary>
+    /// The two directories holding hand-written HTTP clients — the pair issue #241 measured.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately these two and not every serialize call in the solution. What this guard is
+    /// about is a body crossing the wire to an endpoint with a published schema, and outside these
+    /// directories the same call means something else. <c>OrderMatchingRepository</c> serializes a
+    /// <see cref="TradeDto"/> into <c>OutboxMessages.Payload</c> with a bare serializer, and
+    /// <c>OutboxProcessorService</c> reads it back case-<em>sensitively</em>; that pair has no
+    /// schema and no tolerance, and moving one side of it to camelCase would turn every payload
+    /// written before the deployment and not yet settled into a settlement for an empty symbol and
+    /// zero quantity. It is left exactly as it is, which <c>STANDARDS.md</c> §2 already requires.
+    /// </remarks>
+    public static TheoryData<string> ClientRoots =>
+    [
+        "src/TallaEgg/TallaEgg.Infrastructure/Clients",
+        "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients",
+    ];
+
+    /// <summary>
+    /// Every named type a client serializes into a request body, paired with whether Newtonsoft is
+    /// the library that writes it. Both halves are needed: the wire names come from the library's
+    /// naming strategy, and the two libraries reach camelCase by separate implementations.
+    /// </summary>
+    /// <remarks>
+    /// The anonymous bodies — seven in <c>OrderApiClient</c>, one in <c>UsersApiClient</c>, four in
+    /// <c>AffiliateApiClient</c> — have no type to name here, and are covered by the source scan
+    /// instead. That is the more useful guarantee for them anyway: what was wrong with the
+    /// anonymous bodies was never their names but that nothing decided their casing, and seven of
+    /// them read as correct today only because a C# local is camelCase.
+    /// </remarks>
+    public static TheoryData<Type, bool> TypedRequestBodies => new()
+    {
+        // UsersApiClient — Newtonsoft.
+        { typeof(RegisterUserRequest), true },
+        { typeof(UpdatePhoneRequest), true },
+        { typeof(UpdateUserStatusRequest), true },
+
+        // WalletApiClient — System.Text.Json. TradeDto is the settlement body.
+        { typeof(WalletRequest), false },
+        { typeof(TradeDto), false },
+
+        // OrderApiClient — System.Text.Json.
+        { typeof(OrderDto), false },
+        { typeof(NotifyMatchingEngineRequest), false },
+    };
+
+    /// <summary>
+    /// How a serialize call can be spelled. <c>JsonSerializerOptions</c> and
+    /// <c>JsonSerializer.Deserialize</c> both contain the word, so each token carries the leading
+    /// dot and the opening bracket with it. The generic spellings are listed because a call written
+    /// <c>Serialize&lt;T&gt;(…)</c> would otherwise slip past unseen, which is the one way a guard
+    /// like this fails quietly instead of loudly.
+    /// </summary>
+    private static readonly string[] SerializeCalls =
+    [
+        ".Serialize(",
+        ".Serialize<",
+        ".SerializeObject(",
+        ".SerializeObject<",
+    ];
+
+    private static readonly string[] SharedRequestOptions =
+    [
+        "ApiJson.RequestOptions",
+        "ApiJson.NewtonsoftRequestSettings",
+    ];
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory.FullName;
+    }
+
+    private static bool IsCode(string line)
+    {
+        var trimmed = line.TrimStart();
+        return !trimmed.StartsWith("//", StringComparison.Ordinal)
+            && !trimmed.StartsWith('*');
+    }
+
+    /// <summary>
+    /// A request body whose casing nothing chose is the defect (issue #241). Handed no options,
+    /// both serializers write the member name as it is declared in C#, so a call that passes none
+    /// puts PascalCase on the wire against a camelCase schema — and is accepted anyway, because the
+    /// receiving side binds case-insensitively. Fifteen of the twenty-two call sites were in that
+    /// state; the seven that were not were anonymous objects built from locals, right by
+    /// coincidence and one ordinary refactor away from being wrong.
+    /// </summary>
+    /// <remarks>
+    /// The options have to be named on the same line as the call. That is a real constraint on how
+    /// these lines are written, and it is the price of a guard that cannot pass vacuously: reading
+    /// the argument across lines means parsing C#, and searching the enclosing method instead would
+    /// go quiet the moment two calls sat in one. A call split across lines fails loudly here and is
+    /// fixed by joining it.
+    ///
+    /// Scoped to explicit serialize calls, which is every outbound body these clients build today.
+    /// <c>PostAsJsonAsync</c> and its siblings are not covered and do not need to be — they
+    /// serialize with <c>JsonSerializerDefaults.Web</c> already, which is the shape this asks for.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ClientRoots))]
+    public void RequestSerialization_InEveryTypedClient_NamesTheSharedOptions(string relativeRoot)
+    {
+        var root = Path.Combine(RepoRoot(), relativeRoot);
+        Assert.True(Directory.Exists(root), $"{relativeRoot} does not exist; update the root list.");
+
+        var offenders = new List<string>();
+        var calls = 0;
+
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                var line = lines[index];
+                if (!IsCode(line) || !SerializeCalls.Any(call => line.Contains(call, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                calls++;
+                if (SharedRequestOptions.Any(options => line.Contains(options, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                offenders.Add($"{Path.GetRelativePath(RepoRoot(), file)}:{index + 1}: {line.Trim()}");
+            }
+        }
+
+        // Guards the guard: a renamed directory, or a serialize call spelled some new way, would
+        // otherwise leave this sweeping nothing and reporting success.
+        Assert.True(
+            calls > 0,
+            $"No serialize call found under {relativeRoot}; this guard has stopped looking at anything.");
+
+        Assert.True(
+            offenders.Count == 0,
+            "A client serializes a request body without saying what casing to write it in, which is "
+                + "#241. Pass ApiJson.RequestOptions (System.Text.Json) or "
+                + "ApiJson.NewtonsoftRequestSettings (Newtonsoft) on the same line as the call:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    /// The other end of the loop: the names a client writes are the names its endpoint publishes.
+    /// The server side is <c>Microsoft.AspNetCore.Http.Json.JsonOptions</c> exactly as the framework
+    /// hands it to a minimal API — read from the framework rather than restated here, so this
+    /// compares two independent answers rather than one constant against itself.
+    /// </summary>
+    /// <remarks>
+    /// It earns its keep on the Newtonsoft rows. The two libraries implement camelCase separately,
+    /// each with its own rule for a name opening on consecutive capitals, and nothing guarantees
+    /// they stay in step across a package upgrade. No DTO here carries a name that would show a
+    /// difference today; this is what notices the first one that does.
+    ///
+    /// It rests on <see cref="JsonNamingPolicyConsistencyTests"/> for the step it cannot take
+    /// itself — that no deployed service moves its own serializer off that default, and that no
+    /// attribute pins a name past it. With both, the published schema and the framework default are
+    /// the same thing, and comparing against one compares against the other.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(TypedRequestBodies))]
+    public void TypedRequestBody_AsWrittenByItsClient_CarriesTheNamesTheServerBinds(Type type, bool newtonsoft)
+    {
+        var probe = Activator.CreateInstance(type);
+        Assert.NotNull(probe);
+
+        var asTheServerBindsIt = new Microsoft.AspNetCore.Http.Json.JsonOptions().SerializerOptions;
+        var declared = TopLevelNames(
+            System.Text.Json.JsonSerializer.Serialize(probe, type, asTheServerBindsIt));
+
+        var written = TopLevelNames(newtonsoft
+            ? JsonConvert.SerializeObject(probe, ApiJson.NewtonsoftRequestSettings)
+            : System.Text.Json.JsonSerializer.Serialize(probe, type, ApiJson.RequestOptions));
+
+        // Every public readable property reaches the wire, so a name missing from one side is
+        // reported as a difference rather than passing because both sides happened to omit it.
+        Assert.Equal(
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Count(p => p.CanRead),
+            declared.Count);
+
+        var unpublished = written.Except(declared, StringComparer.Ordinal).ToList();
+        var unwritten = declared.Except(written, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            unpublished.Count == 0 && unwritten.Count == 0,
+            $"{type.Name} goes on the wire under names its endpoint's schema does not declare, which "
+                + "is #241. The server binds them case-insensitively today and would stop the moment "
+                + "that tolerance is tightened:" + Environment.NewLine
+                + $"  written, not declared: {Render(unpublished)}" + Environment.NewLine
+                + $"  declared, not written: {Render(unwritten)}");
+    }
+
+    private static List<string> TopLevelNames(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.EnumerateObject().Select(property => property.Name).ToList();
+    }
+
+    private static string Render(IReadOnlyCollection<string> names) =>
+        names.Count == 0 ? "(none)" : string.Join(", ", names);
+}

--- a/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
@@ -64,7 +64,7 @@ public class ClientRequestWireContractTests
         ("src/Order/Orders.Infrastructure/OrderMatchingRepository.cs",
             "writes OutboxMessages.Payload, which OutboxProcessorService reads back case-sensitively"),
         ("src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs",
-            "posts to Telegram, an external contract that does not take this platform's casing"),
+            "posts to a third-party notification relay, whose field names it does not get to choose"),
         ("src/Order/Orders.Api/Program.cs",
             "formats a response DTO into a log line"),
         ("src/Order/Orders.Application/OrderService.cs",

--- a/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/ClientRequestWireContractTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using Newtonsoft.Json;
 using TallaEgg.Core.DTOs.Order;
@@ -30,22 +29,46 @@ namespace TallaEgg.AllServices.Tests;
 public class ClientRequestWireContractTests
 {
     /// <summary>
-    /// The two directories holding hand-written HTTP clients — the pair issue #241 measured.
+    /// Every line of C# the product ships, not the two <c>Clients/</c> directories issue #241
+    /// measured.
     /// </summary>
     /// <remarks>
-    /// Deliberately these two and not every serialize call in the solution. What this guard is
-    /// about is a body crossing the wire to an endpoint with a published schema, and outside these
-    /// directories the same call means something else. <c>OrderMatchingRepository</c> serializes a
-    /// <see cref="TradeDto"/> into <c>OutboxMessages.Payload</c> with a bare serializer, and
-    /// <c>OutboxProcessorService</c> reads it back case-<em>sensitively</em>; that pair has no
-    /// schema and no tolerance, and moving one side of it to camelCase would turn every payload
-    /// written before the deployment and not yet settled into a settlement for an empty symbol and
-    /// zero quantity. It is left exactly as it is, which <c>STANDARDS.md</c> §2 already requires.
+    /// Sweeping the whole trees and gating the exceptions, the same way
+    /// <see cref="JsonNamingPolicyConsistencyTests"/> does and for the reason it gives: a list of
+    /// the places that hold one today goes quiet the first time somebody puts one somewhere new,
+    /// and passing vacuously after a refactor is the failure a guard like this is most prone to.
+    /// The four clients live in two directories now; nothing stops a fifth being written beside the
+    /// service it calls, and that one would reintroduce #241 with this test still green.
     /// </remarks>
-    public static TheoryData<string> ClientRoots =>
+    public static TheoryData<string> ScanRoots =>
     [
-        "src/TallaEgg/TallaEgg.Infrastructure/Clients",
-        "TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients",
+        "src",
+        "TelegramBot",
+    ];
+
+    /// <summary>
+    /// Files that serialize JSON for something other than a request body one of these APIs binds.
+    /// Adding one is a statement about what the file does, not a formatting decision.
+    /// </summary>
+    /// <remarks>
+    /// The first is the one that matters. <c>OrderMatchingRepository</c> writes a
+    /// <see cref="TradeDto"/> into <c>OutboxMessages.Payload</c> with a bare serializer, and
+    /// <c>OutboxProcessorService</c> reads it back case-<em>sensitively</em> — that pair has no
+    /// schema between it and no tolerance either, so moving one side to camelCase would turn every
+    /// payload written before the deployment and not yet settled into a settlement for an empty
+    /// symbol and zero quantity. <c>STANDARDS.md</c> §2 already says so; this keeps the guard from
+    /// being the thing that argues otherwise.
+    /// </remarks>
+    private static readonly (string Path, string Why)[] NotRequestBodies =
+    [
+        ("src/Order/Orders.Infrastructure/OrderMatchingRepository.cs",
+            "writes OutboxMessages.Payload, which OutboxProcessorService reads back case-sensitively"),
+        ("src/TallaEgg/TallaEgg.Core/Services/TelegramLoggerService.cs",
+            "posts to Telegram, an external contract that does not take this platform's casing"),
+        ("src/Order/Orders.Api/Program.cs",
+            "formats a response DTO into a log line"),
+        ("src/Order/Orders.Application/OrderService.cs",
+            "formats a list of orders into a log line"),
     ];
 
     /// <summary>
@@ -136,8 +159,8 @@ public class ClientRequestWireContractTests
     /// serialize with <c>JsonSerializerDefaults.Web</c> already, which is the shape this asks for.
     /// </remarks>
     [Theory]
-    [MemberData(nameof(ClientRoots))]
-    public void RequestSerialization_InEveryTypedClient_NamesTheSharedOptions(string relativeRoot)
+    [MemberData(nameof(ScanRoots))]
+    public void RequestSerialization_AnywhereInTheProduct_NamesTheSharedOptions(string relativeRoot)
     {
         var root = Path.Combine(RepoRoot(), relativeRoot);
         Assert.True(Directory.Exists(root), $"{relativeRoot} does not exist; update the root list.");
@@ -147,6 +170,19 @@ public class ClientRequestWireContractTests
 
         foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
         {
+            // Build output carries copies of source-generated and referenced code.
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var relative = Path.GetRelativePath(RepoRoot(), file).Replace(Path.DirectorySeparatorChar, '/');
+            if (NotRequestBodies.Any(exempt => exempt.Path.Equals(relative, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
             var lines = File.ReadAllLines(file);
             for (var index = 0; index < lines.Length; index++)
             {
@@ -162,23 +198,43 @@ public class ClientRequestWireContractTests
                     continue;
                 }
 
-                offenders.Add($"{Path.GetRelativePath(RepoRoot(), file)}:{index + 1}: {line.Trim()}");
+                offenders.Add($"{relative}:{index + 1}: {line.Trim()}");
             }
         }
 
-        // Guards the guard: a renamed directory, or a serialize call spelled some new way, would
-        // otherwise leave this sweeping nothing and reporting success.
+        // Guards the guard: a serialize call spelled some new way, or an exemption widened until it
+        // covers everything, would otherwise leave this sweeping nothing and reporting success.
         Assert.True(
             calls > 0,
             $"No serialize call found under {relativeRoot}; this guard has stopped looking at anything.");
 
         Assert.True(
             offenders.Count == 0,
-            "A client serializes a request body without saying what casing to write it in, which is "
-                + "#241. Pass ApiJson.RequestOptions (System.Text.Json) or "
-                + "ApiJson.NewtonsoftRequestSettings (Newtonsoft) on the same line as the call:"
+            "JSON is serialized without saying what casing to write it in, which is #241. If this is "
+                + "a request body one of our APIs binds, pass ApiJson.RequestOptions "
+                + "(System.Text.Json) or ApiJson.NewtonsoftRequestSettings (Newtonsoft) on the same "
+                + "line as the call. If it is not — a log line, a stored payload, an external "
+                + "contract — add the file to NotRequestBodies with the reason:"
                 + Environment.NewLine
                 + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    /// An exemption that no longer names a real file is an exemption nobody is reading, and it
+    /// would silently widen the moment that path came back for some other reason.
+    /// </summary>
+    [Fact]
+    public void NotRequestBodies_EveryExemptFile_StillExists()
+    {
+        var missing = NotRequestBodies
+            .Where(exempt => !File.Exists(Path.Combine(RepoRoot(), exempt.Path)))
+            .Select(exempt => $"  {exempt.Path} — exempt because it {exempt.Why}")
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "NotRequestBodies exempts a file that is not there any more; drop the entry:"
+                + Environment.NewLine + string.Join(Environment.NewLine, missing));
     }
 
     /// <summary>
@@ -213,11 +269,11 @@ public class ClientRequestWireContractTests
             ? JsonConvert.SerializeObject(probe, ApiJson.NewtonsoftRequestSettings)
             : System.Text.Json.JsonSerializer.Serialize(probe, type, ApiJson.RequestOptions));
 
-        // Every public readable property reaches the wire, so a name missing from one side is
-        // reported as a difference rather than passing because both sides happened to omit it.
-        Assert.Equal(
-            type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Count(p => p.CanRead),
-            declared.Count);
+        // Only that the schema side has something to compare against, so a type that serialized to
+        // "{}" could not pass by writing nothing. Not an exact property count: a member both sides
+        // agree to leave off the wire — a [JsonIgnore], an indexer — is a consistent contract, and
+        // failing on it would report a wire mismatch that is not one.
+        Assert.NotEmpty(declared);
 
         var unpublished = written.Except(declared, StringComparer.Ordinal).ToList();
         var unwritten = declared.Except(written, StringComparer.Ordinal).ToList();


### PR DESCRIPTION
**Branch Name**: `fix/typed-clients-send-camelcase`
**Linked Issue**: closes #241

---

## Description

The four typed clients passed no serializer options at all, and neither library defaults to the
camelCase schema every service publishes. Fifteen of the twenty-two outbound request bodies went on
the wire in PascalCase, accepted only because the receiving side binds case-insensitively. This
gives the clients one shared, explicit `JsonSerializerOptions` (and one `JsonSerializerSettings` for
the Newtonsoft half) and names it at every `Serialize` call, so the request casing is **chosen
rather than inherited**.

Everything below was measured on the wire, not read off the diff. This whole family of issues
(#229, #235, #237) stayed hidden because nobody looked at the bytes.

---

## Type of Change
- [x] Hotfix (urgent bug fix) — not urgent; the closest box for a latent defect fix
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## The measurement, taken again rather than trusted

```
$ grep -rn "JsonSerializer.Serialize\|JsonConvert.SerializeObject" \
    src/TallaEgg/TallaEgg.Infrastructure/Clients/ \
    TelegramBot/TallaEgg.TelegramBot.Infrastructure/Clients/
```

22 sites, and the issue's table is exact:

| client | sites | PascalCase before | matched the schema |
|---|---|---|---|
| `UsersApiClient` | 4 | 4 | 0 |
| `WalletApiClient` | 5 | 5 | 0 |
| `AffiliateApiClient` | 4 | 4 | 0 |
| `OrderApiClient` | 9 | 2 | 7 |

**The seven that matched are the accident, not the rule.** All seven serialize anonymous objects
built from local variables (`new { symbol, buyPrice, sellPrice, publishedByUserId }`), and a C#
local is camelCase. Promoting any one of them to a named DTO would have flipped it to PascalCase
with nothing to notice. They are included in this change for that reason — and the proof that
including them was the right call is that **their bodies are byte-identical before and after**
(see the table below). The fix is a no-op for the seven that were right and moves exactly the
fifteen that were not.

---

## Both columns, over real HTTP

A loopback listener was stood in front of the four clients and every one of the 22 outbound bodies
recorded before and after the change. Full bodies for a representative row of each client:

| | before | after |
|---|---|---|
| `UsersApiClient.RegisterUserAsync` | `{"TelegramId":555001,"Username":"sample_user","FirstName":"First","LastName":"Last","InvitationCode":"admin"}` | `{"telegramId":555001,"username":"sample_user","firstName":"First","lastName":"Last","invitationCode":"admin"}` |
| `WalletApiClient.LockBalanceAsync` | `{"UserId":"1111…","Asset":"MAUA","Amount":0.5,"ReferenceId":null}` | `{"userId":"1111…","asset":"MAUA","amount":0.5,"referenceId":null}` |
| `AffiliateApiClient.UseInvitationAsync` | `{"InvitationCode":"admin","UsedByUserId":"1111…"}` | `{"invitationCode":"admin","usedByUserId":"1111…"}` |
| `OrderApiClient.SubmitOrderAsync` | `{"Asset":"MAUA/IRT","Amount":0.5,"Price":23483462.99,"UserId":"1111…","Side":0,…}` | `{"asset":"MAUA/IRT","amount":0.5,"price":23483462.99,"userId":"1111…","side":0,…}` |
| `WalletApiClient.TradeTransactionAndBalanceChangeAsync` | `{"Id":"2222…","Symbol":"MAUA/IRT","Price":23483462.99,"Quantity":0.5,"QuoteQuantity":11741731.50,…}` | `{"id":"2222…","symbol":"MAUA/IRT","price":23483462.99,"quantity":0.5,"quoteQuantity":11741731.50,…}` |

All 22, classified mechanically by first character of each top-level key:

```
                                                       BEFORE   AFTER
UsersApiClient.RegisterUserAsync                       PASCAL   camel
UsersApiClient.UpdatePhoneAsync                        PASCAL   camel
UsersApiClient.UpdateUserStatusAsync                   PASCAL   camel
UsersApiClient.UpdateRoleAsync                         PASCAL   camel
WalletApiClient.LockBalanceAsync                       PASCAL   camel
WalletApiClient.UnlockBalanceAsync                     PASCAL   camel
WalletApiClient.DepositeAsync                          PASCAL   camel
WalletApiClient.WithdrawalAsync                        PASCAL   camel
WalletApiClient.TradeTransactionAndBalanceChangeAsync  PASCAL   camel
AffiliateApiClient.ValidateInvitationAsync             PASCAL   camel
AffiliateApiClient.UseInvitationAsync                  PASCAL   camel
AffiliateApiClient.CreateInvitationAsync               PASCAL   camel
AffiliateApiClient.UpdateUserPhoneAsync                PASCAL   camel
OrderApiClient.SubmitOrderAsync                        PASCAL   camel
OrderApiClient.NotifyMatchingEngineAsync               PASCAL   camel
OrderApiClient.PublishQuoteAsync                       camel    camel   <- unchanged, byte for byte
OrderApiClient.ApprovePendingQuoteAsync                camel    camel   <- unchanged
OrderApiClient.UpdateAutoQuoteSpreadAsync              camel    camel   <- unchanged
OrderApiClient.SetAutoQuoteEnabledAsync                camel    camel   <- unchanged
OrderApiClient.SetSymbolActiveAsync                    camel    camel   <- unchanged
OrderApiClient.AcceptQuoteAsync                        camel    camel   <- unchanged
OrderApiClient.CancelAllUserActiveOrdersAsync          camel    camel   <- unchanged
```

15 PascalCase → 0. **A full diff of the 22 bodies shows differences on exactly those fifteen lines
and nothing else** — same values, same key order, same number formatting, same date formatting.
Only the casing moved.

---

## Changes Made

- **New `TallaEgg.Core.Json.ApiJson`** — `RequestOptions` (`JsonSerializerDefaults.Web`, frozen with
  `MakeReadOnly`) and `NewtonsoftRequestSettings` (a fresh `JsonSerializerSettings` per access over
  one static contract resolver: the settings object is the mutable part and there is no way to
  freeze it, so nobody holds a reference anyone else can see, while the resolver keeps the contract
  cache). It lives in `TallaEgg.Core` because that is the one assembly both client-hosting projects
  already reference, and it is where Newtonsoft's `PackageReference` already sits.
- **All 22 call sites** name one of the two.
- `docs/process/STANDARDS.md` §2 gains the write side of the rule it already states for responses,
  plus the deployment constraint below.
- `tests/…/ClientRequestWireContractTests.cs` — the guard, discussed at the end.

---

## The serialiser decision the issue asks for

The issue offers a choice for the Newtonsoft call sites: a camelCase contract resolver, or move
them to `System.Text.Json` as part of #233. **They keep Newtonsoft.**

- #233 is the question of which serialiser is the house one, and it is explicit that the migration
  is *not* a mechanical find-and-replace: the two libraries differ on null handling, date formats,
  enum conversion and missing-member behaviour, so a sweep is a behaviour change. Doing it here
  would smuggle that decision into a casing fix and make the wire diff impossible to read as
  "only the casing moved" — which is the one claim this PR needs to be able to make.
- Nothing is simplified by half-migrating. `UsersApiClient` and `OrderApiClient` would still use
  both libraries afterwards, because the *reads* stay on `JsonConvert.DeserializeObject` — that is
  #233's other half, untouched here.
- The resolver is precise and reversible: when #233 decides, these three call sites move with the
  rest.

**One deliberate departure from the issue's wording.** It suggests
`CamelCasePropertyNamesContractResolver`. This uses `DefaultContractResolver` with a
`CamelCaseNamingStrategy` instead. That subclass also turns on `ProcessDictionaryKeys` and
`OverrideSpecifiedNames`, and `JsonSerializerDefaults.Web` does neither — it leaves
`DictionaryKeyPolicy` unset and lets an explicit wire name beat the policy. Matching the web profile
is the entire purpose of the type, so the resolver that actually matches it is the one to use. No
request body carries a dictionary today, which makes the difference cheap to get right now rather
than a reason to leave it wrong.

---

## What is deliberately **not** touched

- **`PropertyNameCaseInsensitive`.** Not read, not moved, not removed. See Deployment.
- **The outbox payload.** `OrderMatchingRepository.cs:207` serialises a `TradeDto` into
  `OutboxMessages.Payload` with a bare serialiser, and `OutboxProcessorService.cs:262,283` reads it
  back **case-sensitively**. That pair has no schema and no tolerance between the two sides. Giving
  the writer camelCase would turn every payload written before the deployment and not yet settled
  into a settlement for an empty symbol and zero quantity — `STANDARDS.md` §2 already says so, and
  the guard's roots are the two `Clients/` directories precisely so it cannot creep there. The
  test file records this.
- **The read side**, which is #233.
- **The anonymous objects' member names.** `new { UserId = userId, NewRole = newRole }` is left
  spelled that way; the options decide the wire name now, and renaming the locals would be churn
  that suggests the member name still matters.

---

## Testing Completed

### Build

```
dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)
```

(`TreatWarningsAsErrors` is on, so the zero is enforced.)

### Unit tests

```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 894, Skipped: 0, Total: 894
```

884 on `main` plus 10 new: 2 scan roots × the source scan, 7 typed bodies × the name comparison, and
one that fails if the scan's exemption list stops naming a real file.

`scripts/check-doc-paths.sh` — `408 tracked text file(s) checked, every reference resolves.`

### End-to-end — `driver.ps1 smoke`

- [x] Exercised against the running stack — `driver.ps1 start`, then `driver.ps1 smoke`
- [x] Date/time run: 2026-09-07

```
driver.ps1 smoke --users 20 --quotes 20 --trades 50 --seed 7
Simulation completed with errors 0; 50 settlement(s) completed, no new failures.
=== Done in 00:00:26.43. Registered 20 (18 approved), trades attempted 50, errors 0 ===
Filled trades by symbol:
  BTC/IRT: 17 filled     MAUA/IRT: 17 filled     SEKE_BAHAR/IRT: 16 filled
Restored auto-quote for BTC/IRT to IsEnabled=True.
Restored auto-quote for MAUA/IRT to IsEnabled=True.
```

Settlement counts are the delta the driver asserts, not absolutes.

**Which write paths that actually drove**, counted from the services' own request logs — every one
of these carried a body this PR changed:

```
 129  POST /api/wallet/deposit                     <- WalletRequest        (admin/user funding)
 100  POST /api/wallet/lockBalance                 <- WalletRequest
  50  POST /api/quotes/accept                      <- anonymous            (quote fill)
  50  POST /api/wallet/unlockBalance               <- WalletRequest
  50  POST /api/wallet/changeBalance               <- TradeDto             (settlement)
  20  PUT  /api/user/status                        <- UpdateUserStatusRequest
  20  POST /api/user/update-phone                  <- UpdatePhoneRequest
  20  POST /api/quotes                             <- anonymous            (quote publish)
  20  POST /api/orders/user/{id}/cancel-active     <- anonymous
  20  POST /api/user/register                      <- RegisterUserRequest  (registration)
   3  POST /api/wallet/withdrawal                  <- WalletRequest
   5  POST /api/autoquote-settings/{sym}/enabled   <- anonymous
   1  POST /api/user/update-role                   <- anonymous
```

That is registration, admin funding, quote publishing, quote acceptance and settlement — five of
the six paths the issue flags — all green with camelCase bodies.

### End-to-end — the paths `smoke` does not take

`driver.ps1 smoke` fills by quote acceptance, so it never reaches `POST /api/orders`. Those were
driven separately through the same real clients against the running services:

```
== 1. POST /api/orders — SubmitOrderAsync (OrderDto) ==
   live market: bid 23645509.95, ask 23692848.47
   SubmitOrderAsync -> success=True, message=سفارش شما ثبت شد.
   read back: asset=MAUA/IRT amount=0.10000000 price=21990324.25000000 status=Confirmed
   cancel -> success=True, cancelledCount=1
   active orders left: 0

== 2. POST /api/autoquote-settings/{sym}/spread — UpdateAutoQuoteSpreadAsync ==
   spread before: 0.5000
   set to 0.7500 -> success=True; server now reports 0.7500
   restored: 0.5000 (was 0.5000)

== 3. POST /api/symbols/{sym}/active — SetSymbolActiveAsync ==
   SetSymbolActiveAsync(true) -> success=True, message=نماد فعال شد.
   active symbols: MAUA/IRT, SEKE_BAHAR/IRT, BTC/IRT

== 4. POST /api/quotes + /api/quotes/pending/{id}/reject ==
   active quote: buy 23645509.95, sell 23692848.47
   PublishQuoteAsync(26010060.94, 26062133.32) -> success=True, pendingId=a41c6193-…
   RejectPendingQuoteAsync -> success=True, message=مظنه رد شد و مظنهٔ قبلی برقرار ماند.
   active quote after: buy 23645509.95, sell 23692848.47
   unchanged: True
```

Each of these is a real assertion rather than a "200 means fine":

- The order is **read back** and carries the asset, amount and price that were sent, then cancelled
  so nothing rests in the book.
- The spread is set to a *different* value and read back at that value, then restored — the field
  cannot have defaulted.
- `isActive: true` produces `نماد فعال شد.` A body that failed to bind would arrive as `false` and
  the server would have answered `نماد غیرفعال شد.` and deactivated the symbol.
- The out-of-band quote is **rejected**, not approved, so nothing is published and the plausibility
  band's baseline — the last published mid — is left where it was. Prices are the live MAUA/IRT
  quote and 10% above it, not invented figures.

**17 of the 22 call sites were driven against a live service.** The remaining five, and why:

- The four `AffiliateApiClient` bodies. `Affiliate.Api` is not deployed — it calls `MigrateAsync()`
  with zero migration files and fails every request. Covered by the wire capture and by the source
  scan.
- `NotifyMatchingEngineAsync`. **`POST /api/orders/market/notify-matching` does not exist** —
  Orders.Api maps no such route, and nothing in the bot calls the method; the only other reference
  is a test double that throws. Flagged, not fixed: dead client code is not this issue's scope.

### Database afterwards, scoped to this run

```
Trades                 50      OrdersThisRun          101
SettlementMessages     50      OrdersStillOpen          0
Completed              50      DuplicateSettlements     0
PendingOrFailed         0      TradesNeverQueued        0
OrphanSettlements       0
```

One settlement per trade, no duplicates, nothing pending, no order left resting (the 101st is the
probe order above, cancelled). Locked balances across all 20 simulator wallets: **all zero** — no
stranded collateral.

The 101 `Failed` messages the outbox still holds are all dated `2026-09-01` — a week before this
branch — and none is from this run. Compared as a delta, as the runbook requires.

### Environment
- [x] Tested locally (Windows + SQL Server Express)

---

## The guard — built, and here is what it can and cannot do

The issue asks for a guard that, for each `MapPost`/`MapPut`, checks that the body its typed client
sends carries the names its schema declares, and says not to build a brittle one.

**Built, in the shape that is actually sound.** `ClientRequestWireContractTests` closes the loop
from both ends rather than trying to pair routes with client methods:

1. `RequestSerialization_AnywhereInTheProduct_NamesTheSharedOptions` — a source scan over `src/`
   and `TelegramBot/` entire. Every `Serialize`/`SerializeObject` call must name one of the two
   shared options objects, or its file must appear in a four-entry `NotRequestBodies` list with the
   reason it serialises something else — the outbox payload, the Telegram logger, two log lines.
   This is what covers the twelve **anonymous** bodies, which have no type to reflect on, and it is
   the stronger guarantee for them: what was wrong with them was never their names but that nothing
   decided their casing. It sweeps the whole trees rather than the two `Clients/` directories
   because a fifth client written beside the service it calls would otherwise reintroduce #241 with
   the test still green — the same argument `JsonNamingPolicyConsistencyTests` already makes for its
   own roots. A companion `[Fact]` fails if an exemption stops naming a real file.

2. `TypedRequestBody_AsWrittenByItsClient_CarriesTheNamesTheServerBinds` — for each of the seven
   named request types, the names the client writes must equal the names
   `Microsoft.AspNetCore.Http.Json.JsonOptions` produces. That is read **from the framework**, not
   restated as a constant, so it compares two independent answers.

Together with `JsonNamingPolicyConsistencyTests` — which already promises no service moves off that
default and no attribute pins a name past it — the published schema *is* the framework default, so
"the client writes what the schema declares" follows for every typed body without any route
matching at all.

**Three findings from `/code-review high` are fixed in `b742214`** — the scan's roots, an
over-tight property-count assertion, and the mutable-settings hazard above. See the review response
comment; the wire capture was retaken afterwards and all 22 bodies are byte-identical to the table
in this description.

**Why not the literal route-to-client pairing.** That is where the brittleness lives. Routes are
`$"{_baseUrl}/orders"` on one side and `"/api/orders"` on the other; pairing them means parsing
interpolated strings, and a guard that silently stops matching is worse than none. The reduction
above gets the same guarantee from two facts that are each independently checkable.

**Two honest limits, stated rather than hidden:**

- The options must be named on the same line as the call. Reading the argument across lines means
  parsing C#. A wrapped call fails loudly and is fixed by joining it — this caught one of my own
  lines during development.
- It covers explicit serialize calls, which is every outbound body these clients build today.
  `PostAsJsonAsync` is not covered and does not need to be: it serialises with
  `JsonSerializerDefaults.Web` already.

**Verified not vacuous**, by putting the defect back and re-running:

```
# one call site reverted to no options in each tree
RequestSerialization_AnywhereInTheProduct_NamesTheSharedOptions("src")          [FAIL]
  src/TallaEgg/TallaEgg.Infrastructure/Clients/WalletApiClient.cs:560: JsonSerializer.Serialize(trade);
RequestSerialization_AnywhereInTheProduct_NamesTheSharedOptions("TelegramBot")  [FAIL]
  TelegramBot/…/Clients/AffiliateApiClient.cs:34: JsonConvert.SerializeObject(request);

# ApiJson reverted to the pre-fix (no-options) behaviour — all seven typed bodies
TypedRequestBody_… (TradeDto)                 [FAIL]  written, not declared: Id, BuyOrderId, Symbol, …
TypedRequestBody_… (OrderDto)                 [FAIL]  written, not declared: Asset, Amount, Price, …
TypedRequestBody_… (WalletRequest)            [FAIL]  written, not declared: UserId, Asset, Amount, ReferenceId
TypedRequestBody_… (RegisterUserRequest)      [FAIL]  written, not declared: TelegramId, Username, …
TypedRequestBody_… (UpdatePhoneRequest)       [FAIL]  written, not declared: PhoneNumber, TelegramId
TypedRequestBody_… (UpdateUserStatusRequest)  [FAIL]  written, not declared: TelegramId, NewStatus
TypedRequestBody_… (NotifyMatchingEngineRequest) [FAIL] written, not declared: OrderId, Asset, Type
```

It also earns its keep going forward, on a case nothing else can see: the two libraries implement
camelCase separately, each with its own rule for a name that opens on consecutive capitals. No DTO
carries such a name today. This is what notices the first one that does.

---

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files — `config/appsettings.global.json` untouched and untracked
- [x] Code compiles without warnings
- [x] Input validation unchanged — no validation path is touched

---

## Code Quality

- [x] Follows `STANDARDS.md` naming, including the §2 rule this PR extends
- [x] Comments in English, explaining why
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added — `ApiJson` uses packages both projects already resolve

---

## Documentation

- [x] `docs/process/STANDARDS.md` §2 gains the write side of the JSON wire format rule and the
      deployment constraint
- [x] Swagger/OpenAPI: unchanged — no schema moves, only what clients send
- [x] `ApiJson` carries a `<remarks>` block recording why the casing is named rather than inherited,
      why there are two objects, and why the Newtonsoft resolver is the one it is

---

## Breaking Changes?

- [x] No breaking changes
- [ ] Breaking changes

No server contract changes. The bodies these clients send move from a spelling the servers accept to
the spelling their schemas declare, which the servers also accept. Both an old and a new client work
against both an old and a new service, in either deployment order — that is precisely the tolerance
this PR relies on and does not spend.

---

## Deployment Notes

**⚠️ Order matters, and it is one-directional.**

> **This change must be deployed *before* any tightening of `PropertyNameCaseInsensitive`, never
> after.**

The fix is safe in isolation because the servers accept both casings today. It stops being safe the
other way round: with strict binding in place first, every PascalCase body these clients still send
becomes a DTO of default values — an order with an empty asset and zero amount, not an exception —
and the failure lands on the settlement path among others. Nothing in this PR touches that setting,
and the new §2 paragraph says why the next person should not touch it alone either.

**Pre-deployment**: no migrations, no new configuration, no feature flags.

**Order among the services**: the bot and the three APIs may go in any order, or together. Nothing
here changes what a server accepts.

**Post-deployment verification**
- [ ] All three services start
- [ ] A registration completes from the bot (`POST /api/user/register` returns 200)
- [ ] One quote publishes and one quote-fill trade settles — the settlement body is `TradeDto`, the
      one on the critical path
- [ ] `run-logs`/service logs show no 400s on any `POST`/`PUT`

**Rollback**: revert the commit and redeploy. The old bodies are still accepted by every current
service, so a rollback of any single component is safe on its own.

---

## Related Issues

- Closes #241
- #233 — the read side and the serialiser question, deliberately left open; this PR explains why the
  Newtonsoft call sites stay on Newtonsoft
- #229, #235, #237 — the same family. #236's whole backward-compatibility story rested on the
  case-insensitive binding this PR stops depending on
- #97 — the browser client, which will send camelCase to the same endpoints; after this, so does the
  bot

**Found, not fixed** (scope): `OrderApiClient.NotifyMatchingEngineAsync` posts to
`/api/orders/market/notify-matching`, a route Orders.Api does not map, and nothing calls the method.
Happy to open an issue for it.

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description explains why and what
- [x] All tests pass locally
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data in code
- [x] Commit message is clear
- [x] Documentation is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
