### PR TITLE
[Docs] Record the Admin balance exemption as an intended rule — issue #242

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -120,6 +120,16 @@ is one. Confirmed with the product owner on 6 Shahrivar 1405.
   `A` lives in a separate wallet row keyed `CREDIT_A`, so a single-asset entity cannot evaluate
   the invariant. The check belongs where both rows are visible. The commented-out guard in that
   method is wrong code, correctly disabled.
+- **The `Admin` role skips the balance and credit check on `POST /api/orders`, deliberately.**
+  `OrderService.CreateOrderAsync` wraps both refusals — the check itself failing, and the balance
+  being insufficient — in `if (!isadmin)`, where `isadmin` is `user?.Role == UserRole.Admin`
+  (`OrderService.cs:118-131`). An administrator can therefore place an order of any size with no
+  funds and no credit, and that is intended. Confirmed with the product owner on 17 Shahrivar 1405
+  (2026-09-08). Two things to know before touching it: the role is `Admin` specifically, not
+  `SuperAdmin`, so this is not the shop ledger exemption it looks like; and it is **not** what lets
+  the market maker take the other side of a quote fill — that path runs through
+  `CreateLockedAndConfirmedOrderForQuoteAsync`, which never reaches this check at all. So removing
+  the bypass would not break dealer trading, and it is still not to be removed.
 
 ## Configuration
 

--- a/docs/design/API_REQUEST_VALIDATION.md
+++ b/docs/design/API_REQUEST_VALIDATION.md
@@ -243,7 +243,7 @@ Every refusal here is "this row does not exist". Nothing about the body itself i
 | | `asset` contains a `/` — **no check** ([`OrderService.cs:82`](../../src/Order/Orders.Application/OrderService.cs#L82)) | — | **400, opaque** — §3 |
 | | per-symbol `MinQuantity` / `MaxQuantity` ([`OrderService.cs:230,235`](../../src/Order/Orders.Application/OrderService.cs#L230)) | state | 400 |
 | | `quantity * price >= MinNotional` ([`OrderService.cs:242`](../../src/Order/Orders.Application/OrderService.cs#L242)) | cross-field | 400 |
-| | credit + balance across both assets ([`OrderService.cs:120,127`](../../src/Order/Orders.Application/OrderService.cs#L120)) — **skipped entirely when the user's role is `Admin`** ([`:118`](../../src/Order/Orders.Application/OrderService.cs#L118)) | state | 400, or no check at all |
+| | credit + balance across both assets ([`OrderService.cs:120,127`](../../src/Order/Orders.Application/OrderService.cs#L120)) — **skipped entirely when the user's role is `Admin`**, deliberately ([`:118`](../../src/Order/Orders.Application/OrderService.cs#L118)) | state | 400, or no check at all |
 | | the order factories re-check asset/amount/price/userId ([`Order.cs:38-47`](../../src/Order/Orders.Core/Order.cs#L38-L47), in `CreateMakerOrder`; `CreateLimitOrder` at [`:72-82`](../../src/Order/Orders.Core/Order.cs#L72-L82)) | shape | 500. The first three are pre-checked above; `userId` is not, so `Guid.Empty` reaches here unless the balance check refuses it first |
 | `POST /api/quotes` | `symbol` non-blank ([`Quote.cs:64`](../../src/Order/Orders.Core/Quote.cs#L64)) — a **null** symbol faults earlier, §3 | shape | 400 |
 | | `buyPrice > 0`, `sellPrice > 0` ([`Quote.cs:67,70`](../../src/Order/Orders.Core/Quote.cs#L67)) | shape | 400 |
@@ -279,6 +279,14 @@ Every refusal here is "this row does not exist". Nothing about the body itself i
 ¹ `Guid.Empty` on a non-nullable `Guid`. `[Required]` can never fail on one, so this is not in fact
 expressible as a stock DataAnnotation — the trap PR #236 named when it deleted `[Required]` from
 `OrderDto.Id` and `OrderDto.Side`.
+
+**The `Admin` bypass on `POST /api/orders` is intended, not a defect.** An administrator placing an
+order with no funds and no credit is a business rule, confirmed with the product owner on
+17 Shahrivar 1405 (2026-09-08), and it is listed among the rules that look like bugs in
+[`AGENT.md`](../../AGENT.md). It is recorded here because a client cannot see it from the schema —
+the same request refused for one account succeeds for another — not as something to fix. Note it is
+not the dealer mechanism: a quote fill creates the market maker's side through
+`CreateLockedAndConfirmedOrderForQuoteAsync`, which never reaches this check.
 
 ## 6. Endpoints that answer 404, not 400
 


### PR DESCRIPTION
**Branch Name**: `docs/record-admin-balance-exemption`
**Linked Issue**: follows #242 (closed); no issue of its own — this records an owner decision

---

## Description

`POST /api/orders` skips the balance and credit check entirely when the caller's role is `Admin`.
This was found while measuring #242, raised as a possible defect, and the product owner has
confirmed it is deliberate. This records that, so it is not raised a fourth time.

---

## Type of Change
- [ ] Hotfix (urgent bug fix)
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [x] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

---

## What the code does

```csharp
// src/Order/Orders.Application/OrderService.cs:117-131
var user = await _usersApiClient.GetUserByIdAsync(userId);
var isadmin = user?.Role == UserRole.Admin;

if (!isadmin)
if (!balanceCheckSuccess) { … throw new BusinessRuleException($"خطا در بررسی موجودی: …"); }

if (!isadmin)
if (!hasSufficientBalance) { … throw new BusinessRuleException($"موجودی ناکافی: …"); }
```

Both refusals are skipped, so an administrator places an order of any size with no funds and no
credit. Intended.

## Changes Made

- **`AGENT.md`** — a fifth entry in "Business rules that look like bugs". That section exists
  precisely because every rule in it has already been reported as a defect at least once, including
  by an audit, and this one now has been too.
- **`docs/design/API_REQUEST_VALIDATION.md`** — the inventory row said "skipped entirely when the
  user's role is `Admin`" with no indication that it was intended, which invites exactly the report
  the owner has now answered. It now says the rule is deliberate and links to `AGENT.md`.

The entry stays in the inventory rather than being deleted, because it is still something a client
cannot discover from the schema: the same request refused for one account succeeds for another.

## Two things recorded alongside it

Both matter for anyone who later thinks about removing the bypass, and neither is obvious:

1. **The role is `Admin`, not `SuperAdmin`.** So this is not the shop-ledger exemption it resembles
   — `SuperAdmin` is the account that holds the shop's accounting, and it is not what this line
   tests.
2. **It is not the dealer mechanism.** A quote fill creates the market maker's side through
   `QuoteFillService.CreateSideAsync` → `OrderService.CreateLockedAndConfirmedOrderForQuoteAsync`,
   a different method that never reaches this check. So removing the bypass would not break dealer
   trading — which is the argument someone would reach for first, and it does not hold. The rule
   stands on its own merits, not on that one.

## Testing Completed

Documentation only, no behavior change.

```
scripts/check-doc-paths.sh
409 tracked text file(s) checked, every reference resolves.
```

Build and tests were green on `main` at `9fb68d7` immediately before this branch was cut
(`0 Warning(s) 0 Error(s)`; `Failed: 0, Passed: 894`), and this change touches no code.

### End-to-end
- [x] Not applicable — two Markdown files.

## Security Checklist

- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `config/appsettings.global.json` untouched and untracked
- [x] No names, emails, identifiers, personal paths or server addresses in the diff

**Worth a reviewer's judgement**, since this is a public repository: the diff states that an
`Admin`-role account can place orders without funds. It is already visible in the source, all three
APIs are loopback-only with no HTTPS binding, and reaching the endpoint at all requires the
`X-API-Key` in Production — so writing it down adds no exposure. The alternative, leaving it
undocumented, is what caused it to be re-reported this week.

## Code Quality

- [x] English, matching the surrounding entries' style
- [x] Dated the way the section already dates its confirmations (Jalali, with the Gregorian date
      alongside since the rest of the repo uses ISO)
- [x] No dependencies added

## Breaking Changes?

- [x] No breaking changes

## Deployment Notes

None. Two Markdown files.

## Related Issues

- #242 — where the bypass was found and measured
- #246 — the validation work; unaffected, since a shape filter would not touch a role-conditional
  business check
- #36 — the credit model, which may reshape where the balance check lives; this rule is an input to
  that decision, not a blocker for it

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description explains why and what
- [x] All tests pass locally
- [ ] Code reviewed by at least one peer
- [x] No secrets or sensitive data
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
