### PR TITLE
[Fix] Publish the request POST /api/orders actually reads — issue #240

### DIFF
--- a/docs/design/API_REQUEST_VALIDATION.md
+++ b/docs/design/API_REQUEST_VALIDATION.md
@@ -38,19 +38,28 @@ marked required. **No request-body property is required in any service.**
 Scale: 51 paths, 39 object schemas, 195 properties. 24 writable endpoints — 4 in Users, 6 in
 Wallet, 14 in Orders — taking 14 distinct request-body schemas between them, with 65 properties.
 
-### The one place a schema does describe a validation error
+### No schema describes a validation error, and that is now true everywhere
 
-`POST /api/orders` carries
-[`.ProducesValidationProblem(400)`](../../src/Order/Orders.Api/Program.cs#L687) — the only one in
-the repository — so its published 400 response is `HttpValidationProblemDetails`. The endpoint
-actually returns `new { success, message }` from
+`POST /api/orders` used to carry `.ProducesValidationProblem(400)` — the only one in the repository
+— so its published 400 response was `HttpValidationProblemDetails`, while the endpoint returned
+`new { success, message }` from
 [`Program.cs:661`](../../src/Order/Orders.Api/Program.cs#L661), `:664` and `:667`. The document
-promises a shape the server never sends, on the platform's busiest writable endpoint. It is the
-mirror of the `additionalProperties` over-statement PR #239 removed, and it survived that pass.
+promised a shape the server never sends, on the platform's busiest writable endpoint: a client
+parsing it found no `errors` member and no `title`, and the member that actually carries the reason
+was not in the published shape at all. It was the mirror of the `additionalProperties`
+over-statement PR #239 removed, and it survived that pass.
 
-This matters twice: a client parsing the published 400 shape finds no `errors` member and no
-`title`, and §7's argument against a validation filter has to account for the fact that one
-endpoint already advertises the filter's output.
+Issue #240 replaced it with
+[`.Produces<ApiResponse<CreateOrderResponse>>(400)`](../../src/Order/Orders.Api/Program.cs#L690),
+matching the `200` on the line above and what the endpoint returns. `HttpValidationProblemDetails`
+is gone from the Orders document, and no schema in any service now describes a validation error at
+all — which is the honest state, since none of them produces one.
+
+Two of the three hand-written refusals send `{ success, message }` with no `data` member, so they
+are that envelope minus a property rather than that envelope exactly. Nothing in any schema is
+`required` (above), so the document permits it, and every reader of these bodies treats a missing
+`data` as null. The bare anonymous object is the same shape by coincidence rather than by
+construction, which is worth knowing but is a separate concern from what the schema claims.
 
 ## 2. What a schema-valid body actually gets
 
@@ -322,8 +331,9 @@ are cross-field, stateful, or catalog lookups, and no attribute can carry them. 
 attributes and running them would make the schema describe roughly a *third* of enforcement, not all
 of it — and would leave every endpoint answering two different error shapes,
 `HttpValidationProblemDetails` from the filter and `ApiResponse<T>` from everything the filter cannot
-replace. (`POST /api/orders` already advertises the former and returns the latter — §1 — so that
-inconsistency exists today on one endpoint, and the filter would spread it to all 24.)
+replace. (`POST /api/orders` used to advertise the former while returning the latter — §1 — and #240
+removed the claim rather than making it true, so the platform now says `ApiResponse<T>` everywhere
+and a filter would be the one thing contradicting it.)
 
 Second, the client side. The bot reads `message` out of the `ApiResponse<T>` envelope at 17 call
 sites — 9 in

--- a/docs/design/API_REQUEST_VALIDATION.md
+++ b/docs/design/API_REQUEST_VALIDATION.md
@@ -38,6 +38,12 @@ marked required. **No request-body property is required in any service.**
 Scale: 51 paths, 39 object schemas, 195 properties. 24 writable endpoints — 4 in Users, 6 in
 Wallet, 14 in Orders — taking 14 distinct request-body schemas between them, with 65 properties.
 
+Those counts are the header's snapshot and predate #240, which is the one thing in this document
+measured later: it took five properties off `OrderDto` and one object schema
+(`HttpValidationProblemDetails`) out of Orders, so a re-measure today finds five fewer request-body
+properties than the figures above. They are left as measured rather than adjusted by arithmetic,
+because §9's method is what produced them and re-running it is what should replace them.
+
 ### No schema describes a validation error, and that is now true everywhere
 
 `POST /api/orders` used to carry `.ProducesValidationProblem(400)` — the only one in the repository
@@ -55,11 +61,12 @@ matching the `200` on the line above and what the endpoint returns. `HttpValidat
 is gone from the Orders document, and no schema in any service now describes a validation error at
 all — which is the honest state, since none of them produces one.
 
-Two of the three hand-written refusals send `{ success, message }` with no `data` member, so they
-are that envelope minus a property rather than that envelope exactly. Nothing in any schema is
-`required` (above), so the document permits it, and every reader of these bodies treats a missing
-`data` as null. The bare anonymous object is the same shape by coincidence rather than by
-construction, which is worth knowing but is a separate concern from what the schema claims.
+All three hand-written refusals send `{ success, message }` with no `data` member, so they are that
+envelope minus a property rather than that envelope exactly; the endpoint's two `catch` blocks are
+the ones that build a real `ApiResponse<T>`. Nothing in any schema is `required` (above), so the
+document permits both, and every reader of these bodies treats a missing `data` as null. The bare
+anonymous object is the same shape by coincidence rather than by construction, which is worth
+knowing but is a separate concern from what the schema claims.
 
 ## 2. What a schema-valid body actually gets
 

--- a/src/Order/Orders.Api/Program.cs
+++ b/src/Order/Orders.Api/Program.cs
@@ -684,7 +684,10 @@ app.MapPost("/api/orders", async (TallaEgg.Core.DTOs.Order.OrderDto request, Ord
 .WithDescription("Creates a limit or market order, determining the maker/taker role automatically.")
 .WithTags("Orders")
 .Produces<ApiResponse<CreateOrderResponse>>(200)
-.ProducesValidationProblem(400);
+// Not ProducesValidationProblem: nothing here returns a ProblemDetails body. All three refusals
+// above and both catch blocks answer in the ApiResponse envelope, and the member carrying the
+// reason is `message` (issue #240).
+.Produces<ApiResponse<CreateOrderResponse>>(400);
 
 // Returns an order by id.
 // orderId: Order id.

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -52,6 +52,16 @@ namespace TallaEgg.Core.DTOs.Order
     /// following that comment could reasonably have sent the user's id as <c>id</c> and left the
     /// order's user empty. Removing it costs no caller anything: the bot never set it, and a body
     /// that still carries <c>id</c> is accepted with the member ignored.
+    ///
+    /// Five more went the same way (issue #240): <c>Status</c>, <c>Role</c>, <c>CreatedAt</c>,
+    /// <c>UpdatedAt</c> and <c>ParentOrderId</c>. All five were bound, published in the schema and
+    /// discarded — the status and timestamps belong to the entity, the role is computed from the
+    /// matching result, and the parent is set by the matching engine when a taker is linked to a
+    /// maker. <c>Status</c> and <c>Role</c> were the reason the set was worth removing rather than
+    /// documenting: they name real trading concepts, so a client reading the schema could
+    /// reasonably believe <c>role</c> chose whether to post as maker or taker. Measured against the
+    /// running service, <c>{"role": 1, "status": 3, "parentOrderId": "…"}</c> returned <c>200</c>
+    /// and a plain maker order at the entity's own status, with no error and no warning.
     /// </remarks>
     public class OrderDto
     {
@@ -65,20 +75,16 @@ namespace TallaEgg.Core.DTOs.Order
         public decimal Amount { get; set; }
 
         /// <summary>
-        /// Price. Required for limit orders, optional for market orders.
+        /// Price, required on every order. The endpoint refuses a body without one, whatever
+        /// <see cref="Type"/> says (issue #240).
         /// </summary>
         public decimal Price { get; set; }
         public Guid UserId { get; set; }
 
         public OrderSide Side { get; set; }
         public OrderType Type { get; set; }
-        public OrderStatus Status { get; set; }
         public TradingType TradingType { get; set; }
-        public OrderRole Role { get; set; }
-        public DateTime CreatedAt { get; set; }
-        public DateTime? UpdatedAt { get; set; }
         public string? Notes { get; set; }
-        public Guid? ParentOrderId { get; set; } // برای Taker orders که به Maker order متصل می‌شوند
     }
     public class BestPricesDto
     {

--- a/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
@@ -41,28 +41,40 @@ public class OrderRequestContractTests
     ];
 
     /// <summary>
-    /// Every way a deployed API can publish <c>HttpValidationProblemDetails</c> as a response
-    /// shape. <c>ProducesValidationProblem</c> is the metadata; <c>Results.ValidationProblem</c>
-    /// and <c>Results.Problem</c> are the two ways a handler could start genuinely returning one,
-    /// at which point the metadata would stop being a lie and this guard would need revisiting
-    /// rather than satisfying.
+    /// Publishing a <c>ProblemDetails</c> response shape, in every spelling. The two
+    /// <c>Produces…</c> tokens are the metadata — <c>ProducesProblem</c> is not a substring of
+    /// <c>ProducesValidationProblem</c>, so both are needed. The two <c>Results.</c> tokens are how
+    /// a handler could start genuinely returning one, and each matches its <c>TypedResults.</c>
+    /// spelling too, that being the longer string. A handler that does return one is the case where
+    /// this guard should be revisited rather than satisfied.
     /// </summary>
     private static readonly string[] ProblemDetailsResponses =
     [
         "ProducesValidationProblem",
+        "ProducesProblem",
         "Results.ValidationProblem",
         "Results.Problem",
     ];
 
     /// <summary>
-    /// The three APIs that are deployed and that the bot calls. <c>Affiliate.Api</c> and
-    /// <c>TallaEgg.Api</c> are absent because neither is run.
+    /// The three APIs that are deployed and that the bot calls, plus the shared kernel their error
+    /// handling lives in. <c>Affiliate.Api</c> and <c>TallaEgg.Api</c> are absent because neither
+    /// is run.
     /// </summary>
+    /// <remarks>
+    /// <c>TallaEgg.Core</c> is on the list for the reason <see cref="JsonNamingPolicyConsistencyTests"/>
+    /// gives for the same entry: cross-service concerns get hoisted there, and the error body this
+    /// guard is about is already one of them — <c>GlobalExceptionHandler</c> and the repository's
+    /// one <c>AddProblemDetails()</c> both live under <c>ErrorHandling/</c>. Scanning only the three
+    /// hosts would leave the guard passing vacuously the moment a refusal moves into a shared
+    /// helper.
+    /// </remarks>
     public static TheoryData<string> DeployedApiRoots =>
     [
         "src/User/Users.Api",
         "src/Wallet/Wallet.Api",
         "src/Order/Orders.Api",
+        "src/TallaEgg/TallaEgg.Core",
     ];
 
     /// <summary>

--- a/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
@@ -1,0 +1,164 @@
+using TallaEgg.Core.DTOs.Order;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That <c>POST /api/orders</c> publishes the request it reads and the error shape it returns
+/// (issue #240).
+/// </summary>
+/// <remarks>
+/// Both halves are things the C# cannot show on its own. A property nothing reads compiles, binds
+/// and serializes exactly like one that matters, and endpoint metadata has no effect a caller can
+/// observe outside the published document — which is why #235, #237 and this issue were all found
+/// by walking <c>swagger.json</c> rather than by reading the diff.
+///
+/// The second test source-scans, like <see cref="JsonNamingPolicyConsistencyTests"/> and for the
+/// same reason: the three APIs are top-level statements no test can build a container from.
+/// </remarks>
+public class OrderRequestContractTests
+{
+    /// <summary>
+    /// Every member of <see cref="OrderDto"/> that <c>POST /api/orders</c> reads. Adding to this
+    /// list is a change to the request contract of the platform's order-entry endpoint, not a
+    /// formatting decision.
+    /// </summary>
+    /// <remarks>
+    /// <c>Type</c> is on the list on the weakest grounds of the eight: <c>CreateOrderAsync</c>
+    /// reads it into a log line and never branches on it, and no code under <c>src/Order/</c>
+    /// mentions <c>OrderType</c> at all. It is here because it is read, not because it decides
+    /// anything.
+    /// </remarks>
+    private static readonly string[] MembersTheEndpointReads =
+    [
+        nameof(OrderDto.Asset),
+        nameof(OrderDto.Amount),
+        nameof(OrderDto.Price),
+        nameof(OrderDto.UserId),
+        nameof(OrderDto.Side),
+        nameof(OrderDto.Type),
+        nameof(OrderDto.TradingType),
+        nameof(OrderDto.Notes),
+    ];
+
+    /// <summary>
+    /// Every way a deployed API can publish <c>HttpValidationProblemDetails</c> as a response
+    /// shape. <c>ProducesValidationProblem</c> is the metadata; <c>Results.ValidationProblem</c>
+    /// and <c>Results.Problem</c> are the two ways a handler could start genuinely returning one,
+    /// at which point the metadata would stop being a lie and this guard would need revisiting
+    /// rather than satisfying.
+    /// </summary>
+    private static readonly string[] ProblemDetailsResponses =
+    [
+        "ProducesValidationProblem",
+        "Results.ValidationProblem",
+        "Results.Problem",
+    ];
+
+    /// <summary>
+    /// The three APIs that are deployed and that the bot calls. <c>Affiliate.Api</c> and
+    /// <c>TallaEgg.Api</c> are absent because neither is run.
+    /// </summary>
+    public static TheoryData<string> DeployedApiRoots =>
+    [
+        "src/User/Users.Api",
+        "src/Wallet/Wallet.Api",
+        "src/Order/Orders.Api",
+    ];
+
+    /// <summary>
+    /// A bound property nothing reads is worse on this endpoint than on most: <c>Status</c> and
+    /// <c>Role</c> name real trading concepts, so a client reading the schema can reasonably
+    /// believe it is choosing whether to post as maker or taker. It is not — both are decided
+    /// server-side — and the request is accepted with a 200 and no warning.
+    /// </summary>
+    [Fact]
+    public void OrderDto_DeclaredMembers_AreOnlyThoseTheEndpointReads()
+    {
+        var declared = typeof(OrderDto)
+            .GetProperties()
+            .Select(property => property.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var expected = MembersTheEndpointReads
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, declared);
+    }
+
+    /// <summary>
+    /// <c>POST /api/orders</c> carried the repository's only <c>.ProducesValidationProblem(400)</c>
+    /// while returning <c>{ success, message }</c> from all three of its refusals, so a client
+    /// generating its error type from the document found neither <c>title</c> nor <c>errors</c>,
+    /// and the member that actually carries the reason was not in the published shape at all.
+    /// </summary>
+    /// <remarks>
+    /// No service returns a <c>ProblemDetails</c> body. The one <c>AddProblemDetails()</c> in the
+    /// repository is the fallback <c>UseExceptionHandler()</c> refuses to start without, and
+    /// <c>GlobalExceptionHandler</c> handles every exception before it is reached.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(DeployedApiRoots))]
+    public void ErrorResponseMetadata_InAnyDeployedApi_DoesNotAdvertiseProblemDetails(string relativeRoot)
+    {
+        var offenders = ScanForTokens(relativeRoot, ProblemDetailsResponses);
+
+        Assert.True(
+            offenders.Count == 0,
+            "An endpoint publishes a ProblemDetails response shape. Every refusal these services "
+                + "send is an ApiResponse<T> envelope or a bare { success, message }, so this "
+                + "advertises a body no handler returns (issue #240):"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
+    }
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "TallaEgg.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory.FullName;
+    }
+
+    private static bool IsCode(string line) =>
+        !line.TrimStart().StartsWith("//", StringComparison.Ordinal);
+
+    private static List<string> ScanForTokens(string relativeRoot, params string[] tokens)
+    {
+        var root = Path.Combine(RepoRoot(), relativeRoot);
+        Assert.True(Directory.Exists(root), $"{relativeRoot} does not exist; update the root list.");
+
+        var hits = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            // Build output carries copies of source-generated and referenced code.
+            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (!IsCode(lines[index]))
+                {
+                    continue;
+                }
+
+                if (tokens.Any(token => lines[index].Contains(token, StringComparison.Ordinal)))
+                {
+                    hits.Add($"{Path.GetRelativePath(RepoRoot(), file)}:{index + 1}: {lines[index].Trim()}");
+                }
+            }
+        }
+
+        return hits;
+    }
+}


### PR DESCRIPTION
**Branch Name**: `fix/order-dto-request-contract`
**Linked Issue**: closes #240

---

## Description

`POST /api/orders` published a request contract that was wrong in three ways: five properties
advertised as inputs and silently discarded, one doc comment inviting a specific mistake, and a
400 response type the endpoint has never returned. All three are fixed. Nothing about the running
system changes — the schema now describes what the server already did.

Everything below was measured by walking `GET /swagger/v1/swagger.json` on the running Orders
service and by posting real bodies to it, before and after. Not read off the C#.

---

## Type of Change
- [x] Hotfix (urgent bug fix) — not urgent; the closest available box for a defect fix
- [ ] Feature (new capability)
- [ ] Refactor (code organization, no behavior change)
- [ ] Performance (optimization)
- [ ] Documentation (docs/comments only)
- [ ] Security (auth, encryption, secrets rotation)

Done in the order the issue's comment suggests: (0), then (1), then (2) and (3) together.

---

## Changes Made

- Removed `Status`, `Role`, `CreatedAt`, `UpdatedAt` and `ParentOrderId` from `OrderDto`, with the
  reason recorded in the class's existing `<remarks>` block beside #235's and #237's
- Corrected the `Price` doc comment to state price is required on every order
- Replaced `.ProducesValidationProblem(400)` with `.Produces<ApiResponse<CreateOrderResponse>>(400)`
  on `POST /api/orders`
- Updated `docs/design/API_REQUEST_VALIDATION.md` §1 and §7, whose "the one place a schema does
  describe a validation error" subsection this change makes false
- Added `OrderRequestContractTests` — two guards, both seen red before the fix

---

## Part 0 — `.ProducesValidationProblem(400)`

The repository's only one. It made the published 400 an `HttpValidationProblemDetails`, against
three refusals that all return `{ success, message }`.

**Before**, from the running service:

```json
"400": {
  "description": "Bad Request",
  "content": { "application/problem+json": {
    "schema": { "$ref": "#/components/schemas/HttpValidationProblemDetails" } } }
}
```

**After**:

```json
"400": {
  "description": "Bad Request",
  "content": { "application/json": {
    "schema": { "$ref": "#/components/schemas/CreateOrderResponseApiResponse" } } }
}
```

`HttpValidationProblemDetails` is now absent from the Orders document altogether — it was in
`components.schemas` only because of this line, exactly as the issue's comment says.

**One thing worth stating rather than hiding.** All three hand-written refusals send a bare
`{ success, message }` with no `data` member, so they are the `ApiResponse` envelope minus a
property rather than that envelope exactly; the endpoint's two `catch` blocks are the ones that
build a real envelope. Nothing in any schema is `required`, so the document
permits it, and every reader treats a missing `data` as null. Recorded in §1; the
anonymous-object-vs-envelope inconsistency on this endpoint is left alone, see "found and not
fixed".

---

## Part 1 — the `Price` comment

The comment claimed price was "optional for market orders". Measured, unchanged by this PR:

```
POST /api/orders  {"asset":"MAUA/IRT","amount":0.5,"userId":"…","side":0,"type":0,"tradingType":0}
                                                                        ^^^^^^^^ OrderType.Market
-> 400 {"success":false,"message":"قیمت برای سفارش محدود الزامی است"}
```

A developer following the comment submitted a market order without a price and got a 400 whose
message talks about limit orders. Both checks — `Program.cs:667` and `OrderService.cs:94` — refuse
unconditionally and neither looks at `Type`. The comment was the thing that was wrong, per the
owner's decision; the code is untouched.

Per #237's own measurement, `OrderDto` lives in `TallaEgg.Core`, which generates no XML
documentation file, so **no doc comment on this class ever reached `swagger.json`**. This half of
the fix is invisible on the wire by design — it corrects what a reader of the C# is told.

---

## Parts 2 and 3 — the five properties

### Before: the defect, over real HTTP

```
REQUEST
{"asset":"MAUA/IRT","amount":0.5,"price":23400000,"userId":"…","side":0,"type":1,"tradingType":0,
 "status":3,"role":1,"parentOrderId":"11111111-1111-1111-1111-111111111111",
 "createdAt":"2020-01-01T00:00:00Z","updatedAt":"2020-01-01T00:00:00Z"}

RESPONSE  200
{"success":true,"message":"سفارش شما با موفقیت ثبت شد","data":{"order":{
  "id":"35bd2a56-…","asset":"MAUA/IRT","amount":0.5,"price":23400000,
  "status":1,          <- sent 3
  "role":0,            <- sent 1
  "createdAt":"2026-09-08T11:23:05Z",   <- sent 2020-01-01
  "updatedAt":null,                     <- sent 2020-01-01
  "parentOrderId":null                  <- sent 11111111-…
}, …}}
```

Every one of the five was accepted, ignored and overwritten. No error, no warning.

### The published schema

```
OrderDto properties, BEFORE (13)          OrderDto properties, AFTER (8)
  asset amount price userId                 asset amount price userId
  side type status tradingType role         side type tradingType
  createdAt updatedAt notes parentOrderId   notes
```

`OrderStatus` and `OrderRole` remain in the Orders document — `OrderHistoryDto` is a response and
legitimately carries both.

### After: an un-updated client still works

The compatibility argument #237 part 2 measured, re-measured here. The same body, still carrying
all five removed names, against the fixed service:

```
RESPONSE  200
{"success":true,"message":"سفارش شما با موفقیت ثبت شد",
 "data":{"order":{"id":"ed730dcd-…","asset":"MAUA/IRT","amount":0.5,"price":23400000, …}}}
```

`System.Text.Json` ignores unknown members, so a client that has not been updated keeps getting
orders. The bot sets none of the five in the first place (`BotHandler.cs:1459`), and nothing else in
the repository, scripts or docs posts these names.

---

## Testing Completed

### The guards, seen red before the fix

```
$ dotnet test --filter "FullyQualifiedName~OrderRequestContractTests"     # on unchanged source

  Failed OrderDto_DeclaredMembers_AreOnlyThoseTheEndpointReads
    Assert.Equal() Failure: Collections differ
                               ↓ (pos 2)
    Expected: ["Amount", "Asset", "Notes", "Price", "Side", ···]
    Actual:   ["Amount", "Asset", "CreatedAt", "Notes", "ParentOrderId", ···]

  Failed ErrorResponseMetadata_InAnyDeployedApi_DoesNotAdvertiseProblemDetails(
             relativeRoot: "src/Order/Orders.Api")
    An endpoint publishes a ProblemDetails response shape. …
    src\Order\Orders.Api\Program.cs:687: .ProducesValidationProblem(400);

Failed!  - Failed: 2, Passed: 2, Skipped: 0, Total: 4
```

The two that passed are the Users and Wallet variants of the second guard, so it is not vacuous.

### Unit tests

```
$ dotnet build TallaEgg.sln --no-incremental
Build succeeded.  0 Warning(s)  0 Error(s)

$ dotnet test TallaEgg.sln
Passed!  - Failed: 0, Passed: 898, Skipped: 0, Total: 898, Duration: 10 s
```

- [x] New unit tests written
- [x] All unit tests pass

### End-to-end

```
$ driver.ps1 smoke --users 10 --quotes 10 --trades 20 --seed 3
=== Done in 00:00:07.75. Registered 10 (9 approved), trades attempted 20, errors 0 ===
Filled trades by symbol:  BTC/IRT: 7 filled   MAUA/IRT: 7 filled   SEKE_BAHAR/IRT: 6 filled
Simulation completed with errors 0; 20 settlement(s) completed, no new failures.
```

**What that run does and does not cover.** It hit `POST /api/orders` **zero** times — checked in
`run-logs/orders.out.log`; the simulator fills through `/api/quotes/accept`, 100 calls in this run,
which never touches `OrderDto`. So the smoke is a regression check on everything *around* the
change, not on the changed path. **The changed path is covered by the direct HTTP probes above**,
which are the real end-to-end evidence here.

Database checked afterwards: no orphan orders (both probe orders cancelled, the probe account ends
with 0 active), no new locked collateral. The 101 failed outbox messages the service reports are
pre-existing — every one created `2026-09-01`, none today — and the driver's delta check confirmed
no new failures.

- [x] Exercised against the running stack
- [x] Date/time run: 2026-09-08

### Environment
- [x] Tested locally (Windows + SQL Server Express)

---

## Security Checklist
- [x] No hardcoded secrets, passwords, API keys, or tokens
- [x] No sensitive data in logs or error messages
- [x] `.gitignore` blocks sensitive files
- [x] Code compiles without warnings

---

## Code Quality
- [x] Code follows naming conventions (`STANDARDS.md`)
- [x] Comments are in English and explain the "why", not the "what"
- [x] No large blocks of commented-out code
- [x] No unnecessary dependencies added

---

## Documentation
- [x] Updated relevant `.md` files in `docs/`
- [x] Swagger/OpenAPI docs updated — measured above
- [x] Code comments are clear and in English

---

## Breaking Changes?

- [x] No breaking changes

Five request properties leave the published schema. Measured above: a client still sending them is
accepted with the members ignored, so nothing that works today stops working.

---

## Found and not fixed

Reported here so they can become issues, per the repository's habit:

1. **`POST /api/orders` answers two different 400 shapes.** The three hand-written checks return a
   bare `{ success, message }`; the two catch blocks return the `ApiResponse<CreateOrderResponse>`
   envelope. They coincide only because nothing is `required` and `data` is nullable. This is a
   real inconsistency on one endpoint and squarely #246's territory — the honest fix is to make the
   three refusals use the envelope, which changes a live 400 body and is therefore not this PR.
2. **The endpoint accepts an `OrderType` it never branches on.** `Type` is read into one log line
   at `OrderService.cs:66` and nowhere else; `OrderType` is not mentioned anywhere under
   `src/Order/`, and `CreateOrderAsync` always builds a limit command. So `Market`, `StopLimit` and
   `Oco` are accepted and silently treated as `Limit`. This is the question the `Price` comment was
   really about, and deciding whether market orders are meant to exist is the owner's call, not a
   comment fix's.
3. **`type` means two different things on this endpoint.** In the request it is an `OrderType`; in
   the response, `Order.Type` and `OrderHistoryDto.Type` are an `OrderSide`. Posting `type: 1`
   (Limit) returns `type: 0` (Buy), which reads like the server ignored the value — it did, but not
   for that reason. A trap for anyone measuring this endpoint.
4. **One correction to the issue.** Its table attributes `Status` to
   `Order.CreateMakerOrder` / `CreateTakerOrder`. `CreateTakerOrder` was deleted — see the comment
   at `Orders.Core/Order.cs:101-112` — and `CreateMakerOrder` is the only factory. It does not
   change the conclusion.

---

## Deployment Notes

**Pre-Deployment**: none. No migration, no configuration key, no new required setting.

**Ordering**: no constraint against any other change. The five properties can leave the server
before or after any client is updated, in either order, because unknown members are ignored on the
way in and none of the five was ever read.

**Post-Deployment Verification**: `GET /swagger/v1/swagger.json` on Orders — `OrderDto` should carry
8 properties and `components.schemas` should have no `HttpValidationProblemDetails`.

**Rollback Plan**: revert the commit and redeploy Orders. Nothing persists, nothing migrates, and a
client sending the old field set works against both versions.

---

## Related Issues

- Closes #240
- #237 / PR #239 — same class, same file; removed `Id` and flagged these
- #235 / PR #236 — where this DTO was last worked, and why it has a `<remarks>` block
- #242 — where the `.ProducesValidationProblem` line was found, and `API_REQUEST_VALIDATION.md` §1
- #246 — the validation work this line would otherwise contradict
- #97 — the browser client that will read this schema instead of the C#

---

## Final Checklist

- [x] PR title is descriptive and follows format
- [x] Description clearly explains "why" and "what"
- [x] All tests pass locally
- [x] No secrets or sensitive data in code
- [x] Commit messages are clear
- [x] Documentation is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
