### PR TITLE
[Feat] Build the four services on release publish and attach them to the release

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,135 @@
+# Builds the four deployed services from a published release and attaches them to it.
+#
+# Until this existed, a deployment built on the server: the runbook's path is to download the
+# tag's source zip onto the VM and run publish-all.ps1 there. That works, and it has two costs
+# this removes. A zip is not a checkout, so the build sees no `.git` and the commit hash the
+# .NET SDK would otherwise embed is absent — `/version` reports `commitHash: null` on the one
+# machine where the question is asked (#218). And the artifact the server runs is built by
+# whoever happened to run the script, from a toolchain nobody recorded.
+#
+# It also automates the one step of `docs/process/STANDARDS.md` §11 that was manual and easy to
+# skip: reading the built assemblies to confirm they carry the tagged version. That check is
+# `Verify` below, and it fails the run rather than reporting into a log nobody reads. Before
+# #217 every release tag from v1 to v1.0.3 shipped assemblies still saying 1.0.0, and the only
+# reason v1.1.0 and v1.2.0 did not is that someone remembered to look.
+#
+# Deployment is still not here. `build-and-test.yml` says a half-working deploy pipeline would
+# be a pure loss, and that has not changed: the VM is reachable only through an IAP tunnel, and
+# restarting it messages every registered user. This produces the artifact a deployment uses.
+# Installing it stays a decision someone makes.
+#
+# `release: published`, not `push: tags`. §11 makes publishing the deliberate act and tagging a
+# mechanical one — a tag can be pushed for a release that is still a draft. Building on publish
+# means the artifacts exist exactly when the release becomes something people can act on.
+
+name: release-artifacts
+
+on:
+  release:
+    types: [published]
+
+  # For re-running against a release whose build failed, or was published before this existed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v1.3.0)'
+        required: true
+
+permissions:
+  # Uploading assets onto the release is a write to the repository's contents.
+  contents: write
+
+jobs:
+  publish:
+    runs-on: windows-latest
+
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      # Outside the workspace: publish-all.ps1 writes <InstallRoot>\publish\<Service>\, and
+      # anything under the checkout risks being swept into a later glob.
+      INSTALL_ROOT: ${{ runner.temp }}\TallaEgg
+
+    steps:
+      # The tag, not the default branch. main is routinely ahead of the tag being released —
+      # it was by one commit at v1.1.0 — so building whatever HEAD happens to be would attach
+      # artifacts that are not the release.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      # The same script an operator runs by hand, with no copy of its project list here: a
+      # fifth deployed service must not be something this workflow can forget.
+      - name: Publish the four deployed services
+        run: ./scripts/windows-services/publish-all.ps1 -InstallRoot "$env:INSTALL_ROOT"
+
+      # §11 step 3, automated. Reads what was actually built rather than trusting that
+      # Directory.Build.props and the tag agree — the failure this catches is a release tagged
+      # vX.Y.Z whose assemblies say something else, which is invisible until someone asks a
+      # running service what it is.
+      - name: Verify the assemblies carry the tagged version
+        shell: pwsh
+        run: |
+          $expected = $env:TAG -replace '^v', ''
+          $assemblies = @{
+            'Wallet.Api'  = 'Wallet.Api.dll'
+            'Users.Api'   = 'Users.Api.dll'
+            'Orders.Api'  = 'Orders.Api.dll'
+            'Bot'         = 'TallaEgg.TelegramBot.Infrastructure.dll'
+          }
+
+          $failed = $false
+          foreach ($service in $assemblies.Keys) {
+            $path = Join-Path $env:INSTALL_ROOT "publish\$service\$($assemblies[$service])"
+            $info = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($path)
+
+            # ProductVersion is InformationalVersion: "1.3.0+<commit>" inside a checkout.
+            $actual = ($info.ProductVersion -split '\+')[0]
+
+            if ($actual -ne $expected) {
+              Write-Host "::error::$service reports $actual, but the release is tagged $env:TAG (expected $expected). Raise VersionPrefix in Directory.Build.props."
+              $failed = $true
+            } else {
+              Write-Host "$service $($info.ProductVersion)"
+            }
+          }
+
+          if ($failed) { exit 1 }
+
+      # config/appsettings.global.json holds live credentials and is untracked (#33), so a CI
+      # checkout has none and Directory.Build.props copies nothing. This asserts that rather
+      # than assuming it: these zips are attached to a public release, and the cost of being
+      # wrong once is every credential in the file.
+      - name: Refuse to package a configuration file
+        shell: pwsh
+        run: |
+          $found = Get-ChildItem -Path "$env:INSTALL_ROOT\publish" -Recurse -Filter 'appsettings.global.json' -ErrorAction SilentlyContinue
+
+          if ($found) {
+            Write-Host "::error::A shared configuration file reached the publish output: $($found.FullName)"
+            exit 1
+          }
+
+          Write-Host "No appsettings.global.json in the publish output."
+
+      - name: Package each service
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\artifacts" | Out-Null
+
+          foreach ($service in 'Wallet.Api', 'Users.Api', 'Orders.Api', 'Bot') {
+            $zip = "$env:RUNNER_TEMP\artifacts\$service-$env:TAG.zip"
+            Compress-Archive -Path "$env:INSTALL_ROOT\publish\$service\*" -DestinationPath $zip
+            Write-Host "$zip  $([math]::Round((Get-Item $zip).Length / 1MB, 1)) MB"
+          }
+
+      # --clobber so a re-run through workflow_dispatch replaces the assets instead of failing
+      # on a name that already exists.
+      - name: Attach the artifacts to the release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload $env:TAG "$env:RUNNER_TEMP\artifacts\*.zip" --clobber

--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -60,10 +60,50 @@ neither belongs in a deployment. Decision recorded on
 
 ## Redeploying a new version
 
+Two ways in. Prefer the first: it installs the same bytes for everyone and keeps `/version`
+able to name the commit.
+
+### From a published release
+
+Publishing a release runs the `release-artifacts` workflow, which builds the four services on a
+Windows runner and attaches one zip per service to it. The runner builds from a real checkout,
+so `/version` reports a commit hash rather than `null` — a source zip downloaded onto the server
+has no `.git` for the SDK to read.
+
+```powershell
+# Stop first: unzipping over a running service hits locked files.
+'TallaEggBot', 'TallaEggOrdersApi', 'TallaEggUsersApi', 'TallaEggWalletApi' |
+    ForEach-Object { sc.exe stop $_ }
+
+$tag = 'v1.3.0'
+foreach ($service in 'Wallet.Api', 'Users.Api', 'Orders.Api', 'Bot') {
+    $zip = "$env:TEMP\$service-$tag.zip"
+    Invoke-WebRequest -OutFile $zip `
+        "https://github.com/MohKardan/TallaEgg/releases/download/$tag/$service-$tag.zip"
+    Expand-Archive $zip -DestinationPath "C:\TallaEgg\publish\$service" -Force
+}
+
+.\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString "TallaEgg API key")
+```
+
+The shared configuration lives at `C:\TallaEgg\config\appsettings.global.json`, one level above
+`publish\`, so unzipping over the service folders never touches it. That separation is the reason
+the layout is shaped this way.
+
+The workflow refuses to package an `appsettings.global.json`, so a release asset never carries
+credentials, and it fails rather than attaching anything if the built assemblies do not report
+the tagged version.
+
+### Building on the server
+
+The only option for a commit that has no release, and the fallback if a release has no assets.
+
 ```powershell
 .\scripts\windows-services\publish-all.ps1 -InstallRoot C:\TallaEgg
 .\scripts\windows-services\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString "TallaEgg API key")
 ```
+
+### Either way
 
 `install-services.ps1` stops and recreates each service, so re-running it is the redeploy step —
 there's no separate update path to remember.


### PR DESCRIPTION
## Description
A deployment currently builds on the server. The runbook's path is to download the tag's source
zip onto the VM and run `publish-all.ps1` there, which works but has two costs: a zip is not a
checkout, so the build sees no `.git` and `/version` reports `commitHash: null` on the one machine
where the question is worth asking (#218); and the bytes a server runs were built by whoever ran
the script, from a toolchain nobody recorded. This builds them once, on publish, and attaches them
to the release.

## Linked Task / Finding
No issue — this came out of a conversation about what could be automated ahead of a CD pipeline.

## Type
- [x] Feature (CI)
- [x] Docs

## Changes
- **`.github/workflows/release-artifacts.yml`**, triggered by `release: published`. Not
  `push: tags` — §11 makes publishing the deliberate act and tagging a mechanical one, and a tag
  can be pushed for a release that is still a draft. `workflow_dispatch` is there to re-run
  against a release whose build failed.
- It runs **the same `publish-all.ps1`** an operator runs, with no second copy of the project list
  in the workflow, so a fifth deployed service cannot be forgotten in one place and not the other.
- **The runbook** now documents both redeploy paths, release artifact first, with the
  server-side build kept as the fallback for a commit that has no release.

## Two guards, both failing the run rather than logging
- **The assemblies must report the tagged version.** This is §11 step 3 — "verify the built
  assemblies actually carry the tagged version before publishing anything" — which until now was a
  manual instruction that only worked when someone remembered to follow it. Every tag from `v1` to
  `v1.0.3` shipped assemblies still saying `1.0.0`, and the only reason `v1.1.0` and `v1.2.0`
  didn't is that the step was done by hand. Now a mismatch fails the release build and says which
  service and what to fix.
- **No `appsettings.global.json` may reach the publish output.** It is untracked (#33), so a CI
  checkout has none and `Directory.Build.props` copies nothing — the guard asserts that rather
  than assuming it. These zips are attached to a public release and the cost of being wrong once
  is every credential in the file.

## What this deliberately does not do
Deploy. `build-and-test.yml`'s own header argues a half-working deploy pipeline would be a pure
loss, and nothing about that has changed: the VM is reachable only through an IAP tunnel, and
restarting it broadcasts a message to every registered user. This produces the artifact a
deployment consumes; installing it stays a decision a person makes.

## Testing
The YAML parses and `scripts/check-doc-paths.sh` passes (411 files, every reference resolves).
Beyond that **this is unproven until the first release is published** — there is no way to
exercise a `release: published` workflow without publishing a release, and pointing
`workflow_dispatch` at `v1.2.0` would attach assets to a historical release to test a workflow.
The intended first run is `v1.3.0`, immediately after this merges; if it fails, the fix is a
follow-up and `workflow_dispatch` re-runs it against the same tag.

Reviewer's attention is worth most on: the `${{ github.event.release.tag_name || inputs.tag }}`
fallback, and whether `windows-latest` is the right runner (chosen because the target is Windows
services, at the cost of a slower runner on a workflow that runs once per release).

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Docs updated (`docs/operations/WINDOWS_DEPLOYMENT.md`)
- [ ] Tests — not applicable; a workflow's behavior is its run
- [ ] Peer reviewed

## Deployment Notes
No migration, no config change. Adds one workflow that runs only when a release is published, and
`contents: write` scoped to that workflow so it can upload assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
