### PR TITLE
[Chore] Raise the product version to 1.3.0 and cut the release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          AssemblyVersion, FileVersion and InformationalVersion from this — none of them should
          set AssemblyVersion itself. Bump the third number for a bug fix, the second for a new
          capability that does not break an existing contract, the first for one that does. -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
+++ b/TelegramBot/TallaEgg.TelegramBot.Infrastructure/Constants.cs
@@ -916,6 +916,11 @@ namespace TallaEgg.TelegramBot.Infrastructure
     {
         private static readonly Dictionary<string, string[]> Notes = new()
         {
+            ["1.3.0"] = new[]
+            {
+                "بازگشت خودکار سرویس‌ها پس از ری‌استارت یا قطعی سرور",
+                "جلوگیری از خاموش ماندن ربات وقتی دیتابیس دیرتر بالا می‌آید",
+            },
             ["1.2.0"] = new[]
             {
                 "ساخت مطمئن‌تر کیف‌پول‌ها هنگام ثبت‌نام",


### PR DESCRIPTION
## Description
Ten changes have merged since `v1.2.0` and none raised `VersionPrefix`, so `main` still builds
assemblies reporting `1.2.0`. This bumps it to `1.3.0` and adds the bot release-note entry the
bump requires. The tag and the release are cut from `main` after merge, per §11.

## Linked Task / Finding
No issue — this is the release step itself (`docs/process/STANDARDS.md` §11, "Cutting a release").

## Type
- [x] Chore (release)

## Why MINOR and not PATCH
Five of the ten change what goes on the wire: Orders.Api's response casing (#229), `OrderDto`'s
wire names (#235), the published schema (#237), the request `POST /api/orders` actually reads
(#240), and the casing the typed clients send (#241). §11 reserves PATCH for a fix no caller
would notice, and a caller notices those.

| PR | Issue | |
|---|---|---|
| #231 | #228 | **Critical** — services depend on the SQL Server service, so a reboot stops taking the stack down |
| #238 | #230 | **Critical** — migrate after the host starts, so a slow database is waited for rather than fatal |
| #234 | #229 | Orders.Api answers in camelCase like the other two services |
| #236 | #235 | `OrderDto` gets one wire name per value |
| #239 | #237 | The published schema describes what the servers do |
| #249 | #240 | `POST /api/orders` publishes the request it actually reads |
| — | #241 | The typed clients choose their request casing instead of inheriting it |
| #245, #247 | #242 | The request-validation contract and the Admin balance exemption, written down |
| #248 | — | `work-an-issue` skill |

**#228 and #230 are the reason to cut this now.** Neither is in the deployed `v1.2.0`, so the
server currently runs a build that is known not to survive a restart.

## Changes
- `<VersionPrefix>` 1.2.0 → 1.3.0 in `Directory.Build.props`.
- `ReleaseNotes["1.3.0"]` — required, or `NotifyUpdateToAllUsers` sends every registered user an
  update push with an empty changelog. `ReleaseNoteCoverageTests` now fails the build without it,
  which is the guard added with the 1.2.0 bump doing its job for the first time.

  ```
  🔹 مهم‌ترین تغییرات:
  • بازگشت خودکار سرویس‌ها پس از ری‌استارت یا قطعی سرور
  • جلوگیری از خاموش ماندن ربات وقتی دیتابیس دیرتر بالا می‌آید
  ```

  Only two lines, and both are #228/#230. The five wire-contract changes are deliberately not
  mentioned: each was verified against the running service to move only casing or a discarded
  field, with no consumer affected — there is nothing there a customer would notice, and saying
  otherwise would be padding.

## Testing

### Build and DLL metadata (§11 step 3)
```
dotnet build TallaEgg.sln --no-incremental
Build succeeded. 0 Warning(s) 0 Error(s)
```
Read back through the running services rather than only off disk — `/version`, from #218:
```
port 5136 (Users)   -> version=1.3.0 commit=f4dbf4a528723040a064d8a6f453b8bbce8c705a
port 60933 (Wallet) -> version=1.3.0 commit=f4dbf4a528723040a064d8a6f453b8bbce8c705a
port 5140 (Orders)  -> version=1.3.0 commit=f4dbf4a528723040a064d8a6f453b8bbce8c705a
```
From here on the release workflow (#252) checks this too, and fails the release build on a
mismatch.

### Unit tests
```
dotnet test TallaEgg.sln
Passed! - Failed: 0, Passed: 899, Skipped: 0, Total: 899
```

### End-to-end (`driver.ps1`, 2026-09-08)
```
driver.ps1 start   -> All services up after 4s.
driver.ps1 smoke   -> === Done in 00:00:20.18. Registered 5 (4 approved), trades attempted 10, errors 0 ===
                      Filled trades by symbol: BTC/IRT 4, MAUA/IRT 3, SEKE_BAHAR/IRT 3
                      Simulation completed with errors 0; 10 settlement(s) completed, no new failures.
```
The bot was not started: doing so broadcasts the announcement above to every registered user, and
that is a deployment decision rather than a test.

## Checklist (Definition of Done — see docs/process/STANDARDS.md)
- [x] Builds without warnings; tests pass (`dotnet test`)
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [x] Tests — covered by the existing `ReleaseNoteCoverageTests`; no new behavior to test
- [x] Docs — none needed; §11 already documents this procedure
- [ ] Peer reviewed

## Deployment Notes
No migration, no config change. **The first startup on 1.3.0 sends every registered user the
message quoted above.** To deploy without it, set `BOT_SUPPRESS_STARTUP_ANNOUNCEMENT=1` on the bot
service; the announced version is recorded only after a broadcast, so a later restart without the
variable still sends it.

Deploying this is also what proves #228 — the SCM dependency is only written when
`install-services.ps1` *creates* a service, so the fix has changed nothing on the VM so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
