### PR TITLE
[Fix] release-artifacts never started: runner context in a job env block

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,19 +43,28 @@ jobs:
   publish:
     runs-on: windows-latest
 
-    env:
-      TAG: ${{ github.event.release.tag_name || inputs.tag }}
-      # Outside the workspace: publish-all.ps1 writes <InstallRoot>\publish\<Service>\, and
-      # anything under the checkout risks being swept into a later glob.
-      INSTALL_ROOT: ${{ runner.temp }}\TallaEgg
-
     steps:
+      # Both values are set in a step rather than in a job-level `env:` block. The first version
+      # of this workflow put INSTALL_ROOT there as ${{ runner.temp }}, and the `runner` context
+      # is not available in a job's `env` — that is a startup failure, which GitHub reports as a
+      # run with no jobs, no steps and no log to read. A step is the first place every context
+      # and every RUNNER_* variable is guaranteed to resolve, so both live here now.
+      #
+      # INSTALL_ROOT stays outside the workspace: publish-all.ps1 writes
+      # <InstallRoot>\publish\<Service>\, and anything under the checkout risks being swept into
+      # a later glob.
+      - name: Resolve the release tag and the publish root
+        shell: pwsh
+        run: |
+          "TAG=${{ github.event.release.tag_name || inputs.tag }}" >> $env:GITHUB_ENV
+          "INSTALL_ROOT=$env:RUNNER_TEMP\TallaEgg" >> $env:GITHUB_ENV
+
       # The tag, not the default branch. main is routinely ahead of the tag being released —
       # it was by one commit at v1.1.0 — so building whatever HEAD happens to be would attach
       # artifacts that are not the release.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ env.TAG }}
 
       - uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Description
The workflow added in #252 has failed on every push since it merged, and never ran at all for the
`v1.3.0` release it was written for. It set `INSTALL_ROOT: ${{ runner.temp }}\TallaEgg` in the
job's `env:` block, and the `runner` context is not available there.

## Linked Task / Finding
Follow-up to #252. No issue — found by watching for the run that should have fired on publish.

## Type
- [x] Hotfix

## Why it was invisible
GitHub reports an invalid context as a **startup failure**: a run appears with conclusion
`failure`, **zero jobs, zero steps, no log, and no annotation on any check**. `gh run view` returns
`"jobs": []`. Nothing is marked red on the PR, because the required check is `test` from a
different workflow and that passed. So the workflow looked merged and healthy, and the only symptom
was the absence of a run on `release: published` — which you have to be looking for to notice.

```
completed  failure  ...  release-artifacts.yml  main  push  34234389901  0s
```

Five of those accumulated — one per push since #252 — before anything pointed at the cause.

## Changes
- Both `TAG` and `INSTALL_ROOT` move into a first step that writes them to `$GITHUB_ENV`, where
  every context and every `RUNNER_*` variable is guaranteed to resolve.
- The job-level `env:` block is **removed entirely**, so this class of mistake has nowhere left to
  live in this file.
- `actions/checkout` takes its `ref` from `env.TAG` instead of repeating the expression.

## Testing
The file parses and its structure is asserted rather than eyeballed:
```
YAML parses
job-level env block present: False
any runner. context: True   <- comment only, line 48; expressions in YAML comments are not evaluated
steps: Resolve the release tag and the publish root, actions/checkout@v4, actions/setup-dotnet@v4,
       Publish the four deployed services, Verify the assemblies carry the tagged version,
       Refuse to package a configuration file, Package each service, Attach the artifacts
```
The real proof is a run that produces jobs. After this merges, `workflow_dispatch` against
`v1.3.0` — the input that exists for exactly this — should build and attach the four zips to the
already-published release. If that run is green, this is fixed; if it is another 0s failure, it is
not.

## Checklist
- [x] No secrets/tokens/credentials in the diff
- [x] Comments in English, explain the "why"
- [ ] Tests — not applicable; a workflow's behavior is its run
- [ ] Peer reviewed

## Deployment Notes
None. CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)