### PR TITLE
[Docs] Correct the artifact redeploy recipe: stop order, and no install script

### DIFF
--- a/docs/operations/WINDOWS_DEPLOYMENT.md
+++ b/docs/operations/WINDOWS_DEPLOYMENT.md
@@ -70,25 +70,52 @@ Windows runner and attaches one zip per service to it. The runner builds from a 
 so `/version` reports a commit hash rather than `null` — a source zip downloaded onto the server
 has no `.git` for the SDK to read.
 
-```powershell
-# Stop first: unzipping over a running service hits locked files.
-'TallaEggBot', 'TallaEggOrdersApi', 'TallaEggUsersApi', 'TallaEggWalletApi' |
-    ForEach-Object { sc.exe stop $_ }
+**Stop bot-first, start bot-last.** The bot is declared dependent on the three APIs, so the SCM
+refuses to stop an API while the bot is running: `sc.exe` returns error 1051 and, if you are not
+reading its output, the API simply stays up and the replacement silently overwrites nothing.
+Alphabetical order is not dependency order — getting that wrong is what left the bot stopped and
+the three APIs still running on the first attempt at the v1.3.0 deployment.
 
+```powershell
 $tag = 'v1.3.0'
-foreach ($service in 'Wallet.Api', 'Users.Api', 'Orders.Api', 'Bot') {
-    $zip = "$env:TEMP\$service-$tag.zip"
-    Invoke-WebRequest -OutFile $zip `
-        "https://github.com/MohKardan/TallaEgg/releases/download/$tag/$service-$tag.zip"
-    Expand-Archive $zip -DestinationPath "C:\TallaEgg\publish\$service" -Force
+$order = @(   # dependency order: starting reads down, stopping reads up
+    @{ Folder = 'Wallet.Api'; Service = 'TallaEggWalletApi' }
+    @{ Folder = 'Users.Api';  Service = 'TallaEggUsersApi' }
+    @{ Folder = 'Orders.Api'; Service = 'TallaEggOrdersApi' }
+    @{ Folder = 'Bot';        Service = 'TallaEggBot' }
+)
+
+# Download everything before stopping anything, so a network failure costs no downtime.
+foreach ($s in $order) {
+    Invoke-WebRequest -UseBasicParsing -OutFile "$env:TEMP\$($s.Folder)-$tag.zip" `
+        "https://github.com/MohKardan/TallaEgg/releases/download/$tag/$($s.Folder)-$tag.zip"
 }
 
-.\install-services.ps1 -InstallRoot C:\TallaEgg -TallaEggApiKey (Read-Host -AsSecureString "TallaEgg API key")
+foreach ($s in $order[3..0]) { sc.exe stop $s.Service }    # bot first
+# Wait for all four to report Stopped before continuing: a running process holds its own DLLs.
+
+foreach ($s in $order) {
+    $live = "C:\TallaEgg\publish\$($s.Folder)"
+    Remove-Item "$live.bak" -Recurse -Force -ErrorAction SilentlyContinue
+    Rename-Item $live "$live.bak"                          # the old build, kept to roll back to
+    Expand-Archive "$env:TEMP\$($s.Folder)-$tag.zip" -DestinationPath $live
+}
+
+foreach ($s in $order) { sc.exe start $s.Service }         # bot last
 ```
 
+Expanding into a fresh folder rather than over the old one is what stops a file deleted between
+releases from lingering; the renamed `.bak` beside it is the rollback — swap the two folders back
+and restart.
+
+**`install-services.ps1` does not need to run for this.** It exists to create or reconfigure the
+services, and a redeploy does neither: stopping a service, replacing its files and starting it
+again is what picks up new binaries. Run it when a service definition changes — a new dependency,
+a different `InstallRoot`, a rotated API key — which is also the only time the key is needed.
+
 The shared configuration lives at `C:\TallaEgg\config\appsettings.global.json`, one level above
-`publish\`, so unzipping over the service folders never touches it. That separation is the reason
-the layout is shaped this way.
+`publish\`, so replacing the service folders never touches it. That separation is the reason the
+layout is shaped this way.
 
 The workflow refuses to package an `appsettings.global.json`, so a release asset never carries
 credentials, and it fails rather than attaching anything if the built assemblies do not report


### PR DESCRIPTION
## Description
The redeploy recipe added alongside the `release-artifacts` workflow (#252) was written before
anything had been deployed with it. Doing the `v1.3.0` deployment showed two parts of it were
wrong. This corrects them from what actually ran.

## Linked Task / Finding
Follow-up to #252 and the v1.3.0 deployment. No issue.

## Type
- [x] Documentation

## What was wrong

**The stop order.** The recipe stopped services in the order they were listed, which was
alphabetical. `TallaEggBot` is declared dependent on the three APIs, so the SCM refuses to stop an
API while the bot is running — `sc.exe` returns error 1051. With its output discarded, the API
stays up and the deployment believes it stopped it. On the first attempt at v1.3.0 the bot
stopped, the three APIs did not, and the run ended before anything was replaced. Stopping now
reads bot-first and starting reads bot-last, with the dependency order written down as the reason.

**`install-services.ps1` does not need to run.** The recipe said it "still has to run … which is
what picks up the new binaries". It is not: that script creates and configures services, and a
redeploy changes neither definition. Stopping, replacing files and starting is what picks up new
binaries — which is what the successful deployment did, without the API key the script would
otherwise have demanded. It is now described as what it is: needed when a service definition
changes.

## Also added, from what the deployment actually did
- Download all four zips **before stopping anything**, so a network failure costs no downtime.
- Expand into a fresh folder with the previous build renamed to `.bak` beside it, rather than
  unzipping over the old one — that keeps a file deleted between releases from lingering, and
  leaves a rollback that is a folder swap.

## Testing
`scripts/check-doc-paths.sh` passes (412 files). The recipe itself is the deployment that ran:

```
--- stopping ---     TallaEggBot / OrdersApi / UsersApi / WalletApi -> Stopped
--- replacing ---    all four -> 1.3.0+7e698bfe48eb0b7e3432b6b2444cf76829508062
--- starting ---     all four -> Running
```
Confirmed afterwards from each service's own startup log line, not from the files on disk:
```
[INF] Starting Users.Api, version 1.3.0, built from commit 7e698bfe48eb0b7e3432b6b2444cf76829508062.
```

## Checklist
- [x] No secrets/tokens/credentials in the diff
- [x] Docs updated
- [ ] Peer reviewed

## Deployment Notes
None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)