### PR TITLE
[Fix] Record how each order was placed, on both sides of a quote fill — issue #250

### DIFF
--- a/src/Order/Orders.Application/CreateOrderCommand.cs
+++ b/src/Order/Orders.Application/CreateOrderCommand.cs
@@ -21,21 +21,35 @@ public record CreateOrderCommand
     [Required]
     public Guid UserId { get; init; }
     
+    /// <summary>
+    /// The side — buy or sell. Named <c>Type</c> for historical reasons; the order <i>type</i> is
+    /// <see cref="OrderType"/> below. The same misnomer sits on <c>OrderHistoryDto.Type</c>, where
+    /// it reaches the wire and so costs more to correct; issue #250 records both and deliberately
+    /// renames neither here.
+    /// </summary>
     [Required]
     public OrderSide Type { get; init; }
-    
+
+    /// <summary>
+    /// How the price was arrived at — named, or taken. See <see cref="Order.Type"/> for why the two
+    /// sides of one quote fill hold different values.
+    /// </summary>
+    [Required]
+    public OrderType OrderType { get; init; }
+
     [Required]
     public TradingType TradingType { get; init; }
-    
+
     [StringLength(500)]
     public string? Notes { get; init; }
 
     public CreateOrderCommand(
-        string asset, 
-        decimal amount, 
-        decimal price, 
-        Guid userId, 
+        string asset,
+        decimal amount,
+        decimal price,
+        Guid userId,
         OrderSide type,
+        OrderType orderType,
         TradingType tradingType,
         string? notes = null)
     {
@@ -44,6 +58,7 @@ public record CreateOrderCommand
         Price = price;
         UserId = userId;
         Type = type;
+        OrderType = orderType;
         TradingType = tradingType;
         Notes = notes;
     }

--- a/src/Order/Orders.Application/OrderService.cs
+++ b/src/Order/Orders.Application/OrderService.cs
@@ -137,13 +137,22 @@ public class OrderService
             List<TradeDto> executedTrades = new();
 
 
-            // Limit orders start as Makers
+            // Every order from this endpoint starts as a Maker: it rests in the book until
+            // something matches it.
+            //
+            // request.Type is recorded rather than acted on. This endpoint builds the same resting
+            // order whatever it is sent, so a Market or StopLimit here is not honoured — but it was
+            // previously read into a log line and discarded, leaving the column a constant zero and
+            // nothing to measure a future refusal against (issue #250). Recording the caller's
+            // intent is not the same as promising to execute it, and refusing the types this
+            // endpoint cannot honour is a behaviour change filed separately.
             var limitCommand = new CreateOrderCommand(
                 request.Asset,
                 request.Amount,
                 request.Price,
                 userId,
                 orderSide,
+                request.Type,
                 tradingType,
                 request.Notes
             );
@@ -274,6 +283,7 @@ public class OrderService
             command.Price,
             command.UserId,
             command.Type,
+            command.OrderType,
             command.TradingType,
             command.Notes
         );

--- a/src/Order/Orders.Application/Services/QuoteFillService.cs
+++ b/src/Order/Orders.Application/Services/QuoteFillService.cs
@@ -154,15 +154,26 @@ public class QuoteFillService
 
         // Both orders are created at the same price and quantity, so the match is always complete
         // and nothing is left resting in the book.
+        //
+        // They differ in order type, and that is the model rather than an inconsistency. The
+        // customer took a price somebody else had already published, so their side is a market
+        // order; the dealer named that price when they published the quote, so theirs is a limit
+        // order. Recording both as Market — which is what happened until issue #250, since nothing
+        // assigned the column at all — loses the only thing the two sides disagree about.
+        //
+        // This is also the whole of "we have no peer-to-peer trading yet": the dealer is the only
+        // participant who can name a price, so a customer's order can only ever be a market order.
+        // When peer-to-peer opens, the customer's side stops being a constant and starts coming
+        // from the request.
         var customerOrder = await CreateSideAsync(customerUserId, symbol, customerSide, quantity, price,
-            $"پذیرش مظنه {quote.Id}");
+            OrderType.Market, $"پذیرش مظنه {quote.Id}");
 
         if (customerOrder is null)
             return (false, "ثبت سفارش شما انجام نشد.", null);
 
         var adminSide = customerSide == OrderSide.Buy ? OrderSide.Sell : OrderSide.Buy;
         var adminOrder = await CreateSideAsync(marketMakerUserId, symbol, adminSide, quantity, price,
-            $"طرف مقابل مظنه {quote.Id}");
+            OrderType.Limit, $"طرف مقابل مظنه {quote.Id}");
 
         if (adminOrder is null)
         {
@@ -204,12 +215,13 @@ public class QuoteFillService
     /// confirmed — but not matched. Matching happens once, for both orders together.
     /// </summary>
     private async Task<Order?> CreateSideAsync(
-        Guid userId, string symbol, OrderSide side, decimal quantity, decimal price, string notes)
+        Guid userId, string symbol, OrderSide side, decimal quantity, decimal price,
+        OrderType orderType, string notes)
     {
         try
         {
             var command = new CreateOrderCommand(
-                symbol, quantity, price, userId, side, TradingType.Spot, notes);
+                symbol, quantity, price, userId, side, orderType, TradingType.Spot, notes);
 
             return await _orderService.CreateLockedAndConfirmedOrderForQuoteAsync(command);
         }

--- a/src/Order/Orders.Core/Order.cs
+++ b/src/Order/Orders.Core/Order.cs
@@ -15,7 +15,25 @@ public class Order
     /// Order side: buy or sell.
     /// </summary>
     public OrderSide Side { get; private set; }
-    public OrderType Type { get; set; }
+
+    /// <summary>
+    /// How the order was placed: the price was named (<see cref="OrderType.Limit"/>) or taken
+    /// (<see cref="OrderType.Market"/>).
+    ///
+    /// <para>
+    /// The two sides of one quote fill disagree on this, and that is the model rather than a
+    /// rounding of it: the dealer published the price, so their side is a limit order, while the
+    /// customer took the price that was already there, so theirs is a market order. One trade, one
+    /// price, two order types.
+    /// </para>
+    ///
+    /// <para>
+    /// Assigned by the factory, like every other value here. It used to carry a public setter and
+    /// no caller, so every order ever written held the enum default — <c>Market</c> — including the
+    /// dealer's half of every fill (issue #250). Rows written before this fix still hold it.
+    /// </para>
+    /// </summary>
+    public OrderType Type { get; private set; }
     public OrderStatus Status { get; private set; }
     public TradingType TradingType { get; private set; }
     public OrderRole Role { get; private set; }
@@ -25,12 +43,19 @@ public class Order
     // Set on a taker order to point at the maker order it filled against.
     public Guid? ParentOrderId { get; private set; }
 
+    /// <param name="orderType">
+    /// How the price was arrived at — see <see cref="Type"/>. Required rather than defaulted: a
+    /// default is what let every order in the database claim to be a market order (issue #250), and
+    /// the answer differs between the two sides of a single fill, so no default can be right for
+    /// both.
+    /// </param>
     public static Order CreateMakerOrder(
-        string asset, 
-        decimal amount, 
-        decimal price, 
-        Guid userId, 
+        string asset,
+        decimal amount,
+        decimal price,
+        Guid userId,
         OrderSide type,
+        OrderType orderType,
         TradingType tradingType,
         string? notes = null)
     {
@@ -55,6 +80,7 @@ public class Order
             Price = price,
             UserId = userId,
             Side = type,
+            Type = orderType,
             Status = OrderStatus.Pending,
             TradingType = tradingType,
             Role = OrderRole.Maker,

--- a/src/Order/Orders.Core/Order.cs
+++ b/src/Order/Orders.Core/Order.cs
@@ -116,6 +116,11 @@ public class Order
             Price = price,
             UserId = userId,
             Side = OrderSide.Buy, // Default to Buy for now
+            // Set here rather than left at the enum default, which would have this factory produce
+            // an order recording Market despite its name. It has no callers — issue #250 files it
+            // with the other unreferenced declarations rather than deleting it here — but the
+            // setter is private now, so a future caller would have no way to correct it.
+            Type = OrderType.Limit,
             Status = OrderStatus.Pending,
             TradingType = TradingType.Spot, // Default to Spot for now
             Role = OrderRole.Maker,

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -82,6 +82,25 @@ namespace TallaEgg.Core.DTOs.Order
         public Guid UserId { get; set; }
 
         public OrderSide Side { get; set; }
+
+        /// <summary>
+        /// How the caller means the price to be arrived at. <b>Recorded, not honoured</b>: this
+        /// endpoint builds the same resting order whatever it is sent, so <c>Market</c>,
+        /// <c>StopLimit</c> and <c>Oco</c> are all stored as asked and then treated alike.
+        ///
+        /// <para>
+        /// It was previously read into a log line and discarded, so <c>Order.Type</c> held the enum
+        /// default on every row ever written (issue #250). It stays on the request rather than
+        /// being removed with #240's five: ordinary customers cannot name a price today — only the
+        /// dealer publishes quotes — and this becomes their choice when peer-to-peer trading opens.
+        /// </para>
+        ///
+        /// <para>
+        /// Refusing the types the endpoint cannot honour would be a behaviour change and is filed
+        /// separately. Note that the bot reaches this endpoint only on its fallback path, and sends
+        /// <c>Market</c> when it does.
+        /// </para>
+        /// </summary>
         public OrderType Type { get; set; }
         public TradingType TradingType { get; set; }
         public string? Notes { get; set; }

--- a/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
+++ b/src/TallaEgg/TallaEgg.Core/DTOs/Order/OrderDtos.cs
@@ -97,8 +97,12 @@ namespace TallaEgg.Core.DTOs.Order
         ///
         /// <para>
         /// Refusing the types the endpoint cannot honour would be a behaviour change and is filed
-        /// separately. Note that the bot reaches this endpoint only on its fallback path, and sends
-        /// <c>Market</c> when it does.
+        /// separately. Before writing that refusal, note what the bot actually sends: it reaches
+        /// this endpoint only when no quote is active, and the value it posts is whichever button
+        /// started the conversation. Today that is <c>Market</c> in practice, because the only
+        /// order-entry button on the customer's menu is the quote one — but the <c>Limit</c> button
+        /// is commented out of the keyboard rather than removed from the handler, so a replayed or
+        /// forwarded button label still posts <c>Limit</c>.
         /// </para>
         /// </summary>
         public OrderType Type { get; set; }

--- a/tests/TallaEgg.AllServices.Tests/AtomicMatchRoleTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/AtomicMatchRoleTests.cs
@@ -52,7 +52,7 @@ public class AtomicMatchRoleTests : IDisposable
 
     private Order AddOrder(Guid userId, OrderSide side, DateTime createdAt)
     {
-        var order = Order.CreateMakerOrder(Symbol, Quantity, Price, userId, side, TradingType.Spot);
+        var order = Order.CreateMakerOrder(Symbol, Quantity, Price, userId, side, OrderType.Limit, TradingType.Spot);
         // Force the timestamp so which side is the resting (maker) order is deterministic.
         typeof(Order).GetProperty(nameof(Order.CreatedAt))!
             .SetValue(order, createdAt);

--- a/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/BackgroundLeaderGateTests.cs
@@ -239,8 +239,8 @@ public class BackgroundLeaderGateTests : IDisposable
     {
         using var db = NewContext();
 
-        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Buy, TradingType.Spot);
-        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Sell, TradingType.Spot);
+        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Buy, OrderType.Limit, TradingType.Spot);
+        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, Guid.NewGuid(), OrderSide.Sell, OrderType.Limit, TradingType.Spot);
         buy.Confirm();
         sell.Confirm();
 

--- a/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DealerModeSkipsBackgroundMatchingTests.cs
@@ -95,8 +95,8 @@ public class DealerModeSkipsBackgroundMatchingTests : IDisposable
     {
         using var db = NewContext();
 
-        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, _buyerId, OrderSide.Buy, TradingType.Spot);
-        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, _sellerId, OrderSide.Sell, TradingType.Spot);
+        var buy = Order.CreateMakerOrder(Symbol, Quantity, Price, _buyerId, OrderSide.Buy, OrderType.Limit, TradingType.Spot);
+        var sell = Order.CreateMakerOrder(Symbol, Quantity, Price, _sellerId, OrderSide.Sell, OrderType.Limit, TradingType.Spot);
         buy.Confirm();
         sell.Confirm();
 

--- a/tests/TallaEgg.AllServices.Tests/DoubleMatchTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/DoubleMatchTests.cs
@@ -59,7 +59,7 @@ public class DoubleMatchTests : IDisposable
 
     private Order AddOrder(Guid userId, OrderSide side, decimal amount)
     {
-        var order = Order.CreateMakerOrder(Symbol, amount, Price, userId, side, TradingType.Spot);
+        var order = Order.CreateMakerOrder(Symbol, amount, Price, userId, side, OrderType.Limit, TradingType.Spot);
         order.Confirm();
         _context.Orders.Add(order);
         _context.SaveChanges();

--- a/tests/TallaEgg.AllServices.Tests/MatchFailureRecoveryTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/MatchFailureRecoveryTests.cs
@@ -48,7 +48,7 @@ public class MatchFailureRecoveryTests : IDisposable
 
     private Order AddOrder(OrdersDbContext context, Guid userId, OrderSide side, decimal amount)
     {
-        var order = Order.CreateMakerOrder(Symbol, amount, Price, userId, side, TradingType.Spot);
+        var order = Order.CreateMakerOrder(Symbol, amount, Price, userId, side, OrderType.Limit, TradingType.Spot);
         order.Confirm();
         context.Orders.Add(order);
         context.SaveChanges();

--- a/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OrderRequestContractTests.cs
@@ -23,10 +23,11 @@ public class OrderRequestContractTests
     /// formatting decision.
     /// </summary>
     /// <remarks>
-    /// <c>Type</c> is on the list on the weakest grounds of the eight: <c>CreateOrderAsync</c>
-    /// reads it into a log line and never branches on it, and no code under <c>src/Order/</c>
-    /// mentions <c>OrderType</c> at all. It is here because it is read, not because it decides
-    /// anything.
+    /// <c>Type</c> was on this list on the weakest grounds of the eight: it was read into a log
+    /// line and never branched on, and no code under <c>src/Order/</c> mentioned <c>OrderType</c>
+    /// at all. It now decides what the order records (issue #250) — which is still not the same as
+    /// deciding how the order executes, since this endpoint builds the same resting order whatever
+    /// it is sent. See <see cref="OrderDto.Type"/>.
     /// </remarks>
     private static readonly string[] MembersTheEndpointReads =
     [

--- a/tests/TallaEgg.AllServices.Tests/OrderTypeRecordedTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/OrderTypeRecordedTests.cs
@@ -1,0 +1,293 @@
+using System.Net;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orders.Application;
+using Orders.Application.Services;
+using Orders.Core;
+using Orders.Infrastructure;
+using TallaEgg.Core;
+using TallaEgg.Core.DTOs.Order;
+using TallaEgg.Core.DTOs.Wallet;
+using TallaEgg.Core.Enums.Order;
+using TallaEgg.Infrastructure.Clients;
+using TallaEgg.TelegramBot.Infrastructure.Clients;
+using TallaEgg.AllServices.Tests.Fakes;
+
+namespace TallaEgg.AllServices.Tests;
+
+/// <summary>
+/// That an order records how it was placed (issue #250).
+///
+/// <para>
+/// <b>The model these tests encode</b>, confirmed with the product owner on 2026-09-08. The shop
+/// publishes a quote; a customer fills it. Both sides of that fill are orders, and the two are not
+/// the same kind of order: the dealer <i>named</i> the price, so their side is a
+/// <see cref="OrderType.Limit"/> order, while the customer <i>took</i> the price that was there, so
+/// their side is a <see cref="OrderType.Market"/> order. One trade, one price, two order types.
+/// </para>
+///
+/// <para>
+/// Ordinary customers cannot place a limit order today — the dealer is the only participant who
+/// names a price — and that is what "we have no peer-to-peer trading yet" means in this codebase.
+/// It is why <see cref="OrderDto.Type"/> stays on the request rather than being removed: it becomes
+/// the customer's choice when peer-to-peer trading opens.
+/// </para>
+///
+/// <para>
+/// <b>What was wrong:</b> <c>Order.Type</c> was never assigned by any factory, so every order in
+/// the database carried the enum default — <see cref="OrderType.Market"/>, value <c>0</c> —
+/// whatever it actually was. That made the column accidentally right for the customer's side of
+/// every fill and wrong for the dealer's, which is why only half of these tests could go red.
+/// </para>
+/// </summary>
+public class OrderTypeRecordedTests : IDisposable
+{
+    private const string Symbol = CurrenciesConstant.MAUA_IRT;
+    private const decimal BuyPrice = 17_000_000m;
+    private const decimal SellPrice = 17_200_000m;
+    private const decimal Quantity = 1m;
+
+    private readonly SqliteConnection _connection;
+    private readonly Guid _customer = Guid.NewGuid();
+    private readonly Guid _dealer = Guid.NewGuid();
+
+    public OrderTypeRecordedTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using var setup = NewContext();
+        setup.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private OrdersDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<OrdersDbContext>().UseSqlite(_connection).Options);
+
+    // ── the entity records what it is told ──────────────────────────────────────
+
+    /// <summary>
+    /// The factory every order in production goes through. It took the side and the trading type
+    /// and silently left the order type at the enum default, which is the whole of issue #250.
+    /// </summary>
+    [Theory]
+    [InlineData(OrderType.Market)]
+    [InlineData(OrderType.Limit)]
+    [InlineData(OrderType.StopLimit)]
+    [InlineData(OrderType.Oco)]
+    public void CreateMakerOrder_GivenAnOrderType_RecordsThatType(OrderType orderType)
+    {
+        var order = Order.CreateMakerOrder(
+            Symbol, Quantity, BuyPrice, _customer, OrderSide.Buy, orderType, TradingType.Spot);
+
+        Assert.Equal(orderType, order.Type);
+    }
+
+    // ── the two sides of a quote fill ───────────────────────────────────────────
+
+    /// <summary>
+    /// The customer took a price somebody else published, so their order is a market order.
+    /// </summary>
+    /// <remarks>
+    /// This one cannot go red on the unfixed code — <see cref="OrderType.Market"/> is the enum
+    /// default, so the column already said this by accident. It is here to hold the value once it
+    /// is deliberate, and it is paired with
+    /// <see cref="TheDealersSideOfAQuoteFill_IsRecordedAsALimitOrder"/>, which can.
+    /// </remarks>
+    [Fact]
+    public async Task TheCustomersSideOfAQuoteFill_IsRecordedAsAMarketOrder()
+    {
+        await PublishQuoteAsync();
+
+        await BuildQuoteFillService().AcceptQuoteAsync(_customer, Symbol, OrderSide.Buy, Quantity);
+
+        var customerOrder = Assert.Single(await OrdersOfAsync(_customer));
+        Assert.Equal(OrderType.Market, customerOrder.Type);
+    }
+
+    /// <summary>
+    /// The dealer published the price, so their side is a limit order. Before the fix this said
+    /// <c>Market</c>, like every other row in the table.
+    /// </summary>
+    [Fact]
+    public async Task TheDealersSideOfAQuoteFill_IsRecordedAsALimitOrder()
+    {
+        await PublishQuoteAsync();
+
+        await BuildQuoteFillService().AcceptQuoteAsync(_customer, Symbol, OrderSide.Buy, Quantity);
+
+        var dealerOrder = Assert.Single(await OrdersOfAsync(_dealer));
+        Assert.Equal(OrderType.Limit, dealerOrder.Type);
+    }
+
+    /// <summary>
+    /// The sharpest statement of the model: one fill, one price, two different order types. Both
+    /// sides used to carry the same value, which is what made the column useless.
+    /// </summary>
+    [Theory]
+    [InlineData(OrderSide.Buy)]
+    [InlineData(OrderSide.Sell)]
+    public async Task TheTwoSidesOfOneFill_DoNotShareAnOrderType(OrderSide customerSide)
+    {
+        await PublishQuoteAsync();
+
+        await BuildQuoteFillService().AcceptQuoteAsync(_customer, Symbol, customerSide, Quantity);
+
+        var customerOrder = Assert.Single(await OrdersOfAsync(_customer));
+        var dealerOrder = Assert.Single(await OrdersOfAsync(_dealer));
+
+        Assert.Equal(OrderType.Market, customerOrder.Type);
+        Assert.Equal(OrderType.Limit, dealerOrder.Type);
+    }
+
+    // ── POST /api/orders keeps the type the caller sent ─────────────────────────
+
+    /// <summary>
+    /// The request's <c>type</c> was read into a log line and thrown away. It is now what the
+    /// order records, which is the only reading under which the field means anything.
+    /// </summary>
+    /// <remarks>
+    /// <c>StopLimit</c> and <c>Oco</c> are deliberately included. The endpoint cannot honour them —
+    /// it builds a resting order whatever it is sent — and refusing them would be a behaviour
+    /// change this issue does not make. Recording what was asked for is what lets that refusal be
+    /// written later against evidence rather than against a column of zeroes.
+    /// </remarks>
+    [Theory]
+    [InlineData(OrderType.Market)]
+    [InlineData(OrderType.Limit)]
+    [InlineData(OrderType.StopLimit)]
+    [InlineData(OrderType.Oco)]
+    public async Task PostOrders_RecordsTheTypeTheCallerSent(OrderType requested)
+    {
+        await BuildOrderService().CreateOrderAsync(new OrderDto
+        {
+            Asset = Symbol,
+            Amount = Quantity,
+            Price = BuyPrice,
+            UserId = _customer,
+            Side = OrderSide.Buy,
+            Type = requested,
+            TradingType = TradingType.Spot
+        });
+
+        var order = Assert.Single(await OrdersOfAsync(_customer));
+        Assert.Equal(requested, order.Type);
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────────
+
+    private async Task PublishQuoteAsync()
+    {
+        await using var db = NewContext();
+        db.Quotes.Add(Quote.Publish(Symbol, BuyPrice, SellPrice, _dealer));
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<List<Order>> OrdersOfAsync(Guid userId)
+    {
+        await using var db = NewContext();
+        return await db.Orders.Where(o => o.UserId == userId).ToListAsync();
+    }
+
+    /// <summary>Approves every check and records nothing; these tests are about one column.</summary>
+    private sealed class PermissiveWallet : StubWalletApiClient
+    {
+        public override Task<(bool Success, string Message, bool HasSufficientCreditAndBalanceBase, bool HasSufficientCreditAndBalanceQuote)>
+            ValidateCreditAndBalanceAsync(Guid userId, string symbol, decimal amount, decimal price) =>
+            Task.FromResult((true, "ok", true, true));
+
+        public override Task<(bool Success, string Message, WalletDTO? Wallet)> LockBalanceAsync(
+            Guid userId, string asset, decimal amount) =>
+            Task.FromResult((true, "locked", (WalletDTO?)new WalletDTO()));
+
+        public override Task<(bool Success, string Message)> UnlockBalanceAsync(Guid userId, string asset, decimal amount) =>
+            Task.FromResult((true, "unlocked"));
+    }
+
+    private readonly PermissiveWallet _wallet = new();
+
+    private OrderService BuildOrderService()
+    {
+        var context = NewContext();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Matching:MarketModes:" + Symbol] = "Dealer",
+                // The constructor requires this key (issue #205). The canned handler answers
+                // whatever is asked, so the host is only ever a label.
+                ["UsersApiUrl"] = "http://users.test/api"
+            })
+            .Build();
+
+        var marketMode = new MarketModeProvider(configuration, NullLogger<MarketModeProvider>.Instance);
+        var quoteRepository = new QuoteRepository(context, NullLogger<QuoteRepository>.Instance);
+        var orderRepository = new OrderRepository(context, NullLogger<OrderRepository>.Instance);
+        var tradeRepository = new TradeRepository(context);
+
+        // 404 rather than a user: GetUserByIdAsync returns null, so the caller is not an
+        // administrator and the ordinary balance path runs. Which path it takes does not matter
+        // here, but taking the customer's is the honest default.
+        var usersApiClient = new UsersApiClient(
+            new HttpClient(new NotFoundHandler()), configuration, NullLogger<UsersApiClient>.Instance);
+
+        return new OrderService(
+            orderRepository, _wallet, new NoOpMatchingEngine(),
+            NullLogger<OrderService>.Instance,
+            usersApiClient,
+            new OrderCollateralReconciler(orderRepository, tradeRepository, _wallet,
+                NullLogger<OrderCollateralReconciler>.Instance),
+            quoteRepository, marketMode);
+    }
+
+    private QuoteFillService BuildQuoteFillService()
+    {
+        var context = NewContext();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Matching:MarketModes:" + Symbol] = "Dealer"
+            })
+            .Build();
+
+        var marketMode = new MarketModeProvider(configuration, NullLogger<MarketModeProvider>.Instance);
+        var quoteRepository = new QuoteRepository(context, NullLogger<QuoteRepository>.Instance);
+        var orderRepository = new OrderRepository(context, NullLogger<OrderRepository>.Instance);
+        var tradeRepository = new TradeRepository(context);
+
+        var orderService = new OrderService(
+            orderRepository, _wallet, new NoOpMatchingEngine(),
+            NullLogger<OrderService>.Instance,
+            UsersApiClient: null!,
+            new OrderCollateralReconciler(orderRepository, tradeRepository, _wallet,
+                NullLogger<OrderCollateralReconciler>.Instance),
+            quoteRepository, marketMode);
+
+        return new QuoteFillService(
+            quoteRepository, orderService, marketMode,
+            new OrderMatchingRepository(context, NullLogger<OrderMatchingRepository>.Instance),
+            _wallet, NullLogger<QuoteFillService>.Instance);
+    }
+
+    private sealed class NotFoundHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{\"success\":false}", Encoding.UTF8, "application/json")
+            });
+    }
+
+    private sealed class NoOpMatchingEngine : IMatchingEngine
+    {
+        public Task ProcessOrderAsync(Order order, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ProcessOrderAsync(Guid orderId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ProcessAllPendingOrdersAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/PendingOrderNotMatchableTests.cs
@@ -46,7 +46,7 @@ public class PendingOrderNotMatchableTests : IDisposable
     /// <summary>Creates an order in the desired state. Without a confirm it stays Pending.</summary>
     private Order AddOrder(OrderSide side, bool confirm)
     {
-        var order = Order.CreateMakerOrder(Symbol, 10m, 20_000_000m, Guid.NewGuid(), side, TradingType.Spot);
+        var order = Order.CreateMakerOrder(Symbol, 10m, 20_000_000m, Guid.NewGuid(), side, OrderType.Limit, TradingType.Spot);
         if (confirm) order.Confirm();
         _context.Orders.Add(order);
         _context.SaveChanges();

--- a/tests/TallaEgg.AllServices.Tests/PositionServiceTests.cs
+++ b/tests/TallaEgg.AllServices.Tests/PositionServiceTests.cs
@@ -51,7 +51,7 @@ public class PositionServiceTests : IDisposable
 
     private Order SeedOrder(Guid userId, OrderSide side, decimal qty, decimal price, string symbol)
     {
-        var order = Order.CreateMakerOrder(symbol, qty, price, userId, side, TradingType.Spot);
+        var order = Order.CreateMakerOrder(symbol, qty, price, userId, side, OrderType.Limit, TradingType.Spot);
         order.Confirm();
         _context.Orders.Add(order);
         _context.SaveChanges();


### PR DESCRIPTION
## Description

`Order.Type` had a public setter and no caller, so every order ever written carried the enum
default — `Market` — whatever it actually was. This assigns it from the factory, and gives the two
sides of a quote fill the values the business model says they have.

**Linked issue**: part of #250

## The model this encodes

Confirmed with the product owner on 2026-09-08, and it is not what the issue assumed:

| order | before | after |
|---|---|---|
| customer's side of a quote fill | `Market` | `Market` — accidentally right |
| dealer's side (the quote publisher) | `Market` | **`Limit`** — was wrong |
| `POST /api/orders` | `Market` | whatever the caller sent |

The dealer published the price, so their side is a limit order; the customer took the price that
was already there, so theirs is a market order. One trade, one price, two order types. Ordinary
customers cannot name a price today — that is what "we have no peer-to-peer trading yet" means in
this codebase — which is why `OrderDto.Type` stays on the request rather than going the way of
#240's five: it becomes the customer's choice when P2P opens.

**The issue's arithmetic does not survive this.** It reasoned that all 4,523 rows are limit orders
and should be backfilled to `Limit`. Under the model above roughly half of them are market orders
and are already correct.

## Changes Made

- `Order.Type` is assigned by `CreateMakerOrder`, and its setter is now private like every other
  value on the entity
- `CreateMakerOrder` **requires** an `OrderType` rather than defaulting one — a default is what
  caused this, and no single default is right for both sides of one fill
- `CreateOrderCommand` carries it through (its existing `Type` is the *side*; both are now
  documented rather than renamed — see "Found and not fixed")
- `QuoteFillService` names `Market` for the customer's side and `Limit` for the dealer's
- `OrderService.CreateOrderAsync` records `request.Type` instead of reading it into a log line and
  discarding it
- `OrderTypeRecordedTests` — 12 new tests; the model is written down in the class comment
- The nine existing `CreateMakerOrder` call sites in tests pass `OrderType.Limit` (they build
  resting, price-named orders)

## Testing

### Before — the failure, on unmodified `main`

The behavioural tests run against the unfixed code. Six of eight fail; the two that pass are the
`Market` cases, which passed by accident because `Market` is the enum default:

```
Failed TheDealersSideOfAQuoteFill_IsRecordedAsALimitOrder
  Assert.Equal() Failure: Values differ
  Expected: Limit
  Actual:   Market

Failed TheTwoSidesOfOneFill_DoNotShareAnOrderType(customerSide: Buy)
Failed TheTwoSidesOfOneFill_DoNotShareAnOrderType(customerSide: Sell)
  Expected: Limit
  Actual:   Market

Failed PostOrders_RecordsTheTypeTheCallerSent(requested: Limit)
  Expected: Limit
  Actual:   Market
Failed PostOrders_RecordsTheTypeTheCallerSent(requested: StopLimit)
  Expected: StopLimit
  Actual:   Market
Failed PostOrders_RecordsTheTypeTheCallerSent(requested: Oco)

Failed!  - Failed: 6, Passed: 2, Skipped: 0, Total: 8
```

The two that could not go red are marked as such in the test file, rather than left to look like
guards they are not.

### After

```
dotnet build TallaEgg.sln --no-incremental
    0 Warning(s)  0 Error(s)

dotnet test TallaEgg.sln
Passed!  - Failed: 0, Passed: 911, Skipped: 0, Total: 911
```

### End-to-end, against the running stack — 2026-09-08

`driver.ps1 smoke --users 5 --quotes 5 --trades 6 --seed 3`, through the real bot handler:

```
Simulation completed with errors 0; 6 settlement(s) completed, no new failures.
Filled trades by symbol:  BTC/IRT: 2   MAUA/IRT: 2   SEKE_BAHAR/IRT: 2
```

The database, scoped to the rows that run created — before this change all twelve would read `0`:

```
orders created since 2026-09-08 17:52:12 UTC:
  customer side (took the price)    Type=0 (Market)   n=6
  dealer side   (named the price)   Type=1 (Limit)    n=6
```

Integrity of what the run left behind: 12 Completed orders, 6 trades, 6 Completed outbox messages,
**0 resting orders, 0 duplicate settlements**.

### On the wire

Casing and binding defects are invisible in the C#, and this endpoint is where the issue's author
was misled — they posted `type: 1`, read `type: 0` back, and reported it as the server ignoring the
value, when that `0` was the *side*. So, measured rather than read:

```
POST /api/orders
{"userId":"<admin-user-id>","tradingType":0,"side":0,"amount":0.1,
 "type":1,"price":23590962.42,"asset":"MAUA/IRT"}

GET /api/orders/d7d12b98-0a25-46ca-9a13-8b46eb3e8f9f
{"id":"d7d12b98-…","asset":"MAUA/IRT","amount":0.10000000,"price":23590962.42000000,
 "userId":"<admin-user-id>","side":0,"type":1,"status":1,"role":0, …}
```

Sent `Limit`, stored `Limit`, served `Limit` — and `side: 0` sitting next to `type: 1` now shows the
two apart. The order was cancelled afterwards, so no collateral was left locked.

- [x] Unit tests added
- [x] Exercised against the running stack
- [x] No secrets/tokens in diff

## What this deliberately does not do

- **No backfill.** Rows written before this still hold the default. What they should say is the
  owner's decision and was deliberately deferred.
- **The endpoint still does not refuse `Market`, `StopLimit` or `Oco`.** It builds the same resting
  order whatever it is sent. Refusing them is a behaviour change that would refuse a live path: the
  bot reaches this endpoint whenever no quote is active, and posts whichever button started the
  conversation — `Market` in practice, since the quote button is the only order-entry button on the
  customer's menu, but the `Limit` button is commented out of the keyboard rather than removed from
  the handler, so a replayed label still posts `Limit`. Recording the caller's intent is what lets
  that refusal be written later against evidence instead of a column of zeroes.
- **`OrderHistoryDto.Type` is still the side.** Renaming it to `side` is a response-contract change
  on three endpoints; #250 says to do it separately, and this does not ride on it.

## Review

`/code-review high` raised two findings, both fixed in `5ab1a48`:

- `CreateLimitOrder` was the one factory still left recording `Market` despite its name. It has no
  callers — #250 files it with the other unreferenced declarations rather than deleting it here —
  but the private setter removes the escape hatch a future caller would have had.
- The `OrderDto.Type` comment overclaimed: the bot posts whichever button started the conversation,
  and `Market` is only what happens in practice. Qualified, since that comment is the evidence base
  for the deferred refusal decision.

## Found and not fixed

Each of these deserves its own issue rather than a rider on this one:

1. **The simulator's `DataReset` deletes asymmetrically — and this is why the issue's row count is
   not what it looks like.** It deletes trades where either side is a simulated user, but orders
   only `WHERE UserId IN (simulated)`. The dealer is a real account, so **every simulated fill
   leaves one orphan dealer-side order behind, forever.** Measured on this machine: 4,451 of 4,503
   orders have no trade at all, 4,460 of them on one real admin account, growing 2 → 10 → 1,067 →
   3,381 per day across simulator runs. Dev machines only; production never runs the simulator.
   **The issue's "4,523 orders" is almost entirely this residue.**
2. **The bot cannot tell "no quote published" from "I could not reach Orders".**
   `OrderApiClient.GetActiveQuoteAsync` returns `null` for a non-2xx response and from a bare
   `catch`, so a momentary failure reads as "there is no quote" and the confirmation falls through
   to `POST /api/orders`. That order then rests forever — every symbol is in `Dealer` mode, so
   `ProcessOrderForMatchingAsync` returns before matching — while the customer is told the order was
   placed and their collateral stays locked. Never fired on this database: latent, not live.
3. **`CreateOrderCommand.Type` is an `OrderSide`** — the internal twin of the `OrderHistoryDto.Type`
   misnomer. Documented here, not renamed.
4. **`BestPricesDto.OrderType` is never assigned by anything** — a fourth `type`-shaped property
   with no writer.

## Deployment Notes

No migration, no configuration change, and no ordering constraint against any other change. The
column already exists and nothing reads it, so old and new instances can run side by side.

**Rollback**: revert the commit. Rows written while it was deployed keep their values, which remain
correct under the model above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
